### PR TITLE
WIP support Buffer::Use

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ NAN_METHOD(CalculateAsync) {
  * <a href="#api_nan_uint32_option_value"><b><code>NanUInt32OptionValue</code></b></a>
  * <a href="#api_nan_throw_error"><b><code>NanThrowError</code></b>, <b><code>NanThrowTypeError</code></b>, <b><code>NanThrowRangeError</code></b>, <b><code>NanThrowError(Local<Value>)</code></b></a>
  * <a href="#api_nan_new_buffer_handle"><b><code>NanNewBufferHandle(char *, uint32_t)</code></b>, <b><code>NanNewBufferHandle(uint32_t)</code></b></a>
+ * <a href="#api_nan_buffer_use"><b><code>NanBufferUse(char *, uint32_t)</code></b></a>
  * <a href="#api_nan_has_instance"><b><code>NanHasInstance</code></b></a>
  * <a href="#api_nan_persistent_to_local"><b><code>NanPersistentToLocal</code></b></a>
  * <a href="#api_nan_dispose"><b><code>NanDispose</code></b></a>
@@ -321,6 +322,18 @@ NanNewBufferHandle((char*)value.data(), value.size());
 ```
 
 Can also be used to initialize a `Buffer` with just a `size` argument.
+
+<a name="api_nan_buffer_use"></a>
+### v8::Local<v8::Object> NanBufferUse(char*, uint32_t)
+
+`Buffer::New(char*, uint32_t)` previous to 0.11 would make a copy of the data.
+While it was possible to get around this, it required a shim by passing a
+callback. So the new API `Buffer::Use(char*, uint32_t)` was introduced to remove
+needing to use this shim.
+
+`NanBufferUse` uses the `char*` passed as the backing data, and will free the
+memory automatically when the weak callback is called. Keep this in mind, as
+careless use can lead to "double free or corruption" and other cryptic failures.
 
 <a name="api_nan_has_instance"></a>
 ### bool NanHasInstance(Persistent<FunctionTemplate>&, Handle<Value>)

--- a/nan.h
+++ b/nan.h
@@ -127,6 +127,10 @@ static v8::Isolate* nan_isolate = v8::Isolate::GetCurrent();
     return node::Buffer::New(data, size);
   }
 
+  static inline v8::Local<v8::Object> NanBufferUse(char* data, uint32_t size) {
+    return node::Buffer::Use(data, size);
+  }
+
   static inline v8::Local<v8::Object> NanNewBufferHandle (uint32_t size) {
     return node::Buffer::New(size);
   }
@@ -201,6 +205,15 @@ static v8::Isolate* nan_isolate = v8::Isolate::GetCurrent();
   static inline v8::Local<v8::Object> NanNewBufferHandle (
      char *data, uint32_t size) {
     return v8::Local<v8::Object>::New(node::Buffer::New(data, size)->handle_);
+  }
+
+  void FreeData(char *data, void *hint) {
+    delete[] data;
+  }
+
+  static inline v8::Local<v8::Object> NanBufferUse(char* data, uint32_t size) {
+    return v8::Local<v8::Object>::New(
+        node::Buffer::New(data, size, FreeData, NULL)->handle_);
   }
 
   template <class TypeName>


### PR DESCRIPTION
There may be cases where a user wants to use the original char\* instead
of making a copy of the data. This adds support for the new Buffer::Use
method, while creating a shim for pre-v0.11.

Once a name has been approved I'll also add entries into the README.

I'm not sure what an appropriate name for this method should be, hence the ridiculous name. :)
