### PR TITLE
Delete errmsg if isn't NULL

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,8 +567,8 @@ public:
   virtual void WorkComplete ();
 
   // You must implement this to do some async work. If there is an
-  // error then set `errmsg` to to a message and the callback will
-  //be passed that string in an Error object
+  // error then allocate `errmsg` to to a message and the callback will
+  // be passed that string in an Error object
   virtual void Execute ();
 
 protected:

--- a/nan.h
+++ b/nan.h
@@ -441,6 +441,8 @@ public:
       NanDispose(persistentHandle);
     if (callback)
       delete callback;
+    if (errmsg)
+      delete errmsg;
   }
 
   virtual void WorkComplete () {


### PR DESCRIPTION
A fix ported from https://github.com/rvagg/node-leveldown/commit/4112961978fedb18043808b404cfa498398faa61 where the problem was that errmsg wasn't allocated correctly and could change value before being returned as an Error. This commit forces that errmsg has been allocated to the heap.
