### PR TITLE
Suppress compiler warning for NanFromv8String.

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -867,6 +867,7 @@ static inline char* NanFromV8String(
     default:
       assert(0 && "unknown encoding");
   }
+  return to;
 }
 
 #endif


### PR DESCRIPTION
Removes `not all control paths return a value` warning.
