### PR TITLE
0.4.1-wip

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -80,6 +80,7 @@
 #ifndef NAN_H
 #define NAN_H
 
+#include <uv.h>
 #include <node.h>
 #include <node_buffer.h>
 #include <string.h>


### PR DESCRIPTION
Node master removes uv.h from node.h, so including it explicitly here, seems to be OK with older versions of Node, mainly because deps/uv/ is included from addon.gypi in the dist and _I'm pretty sure that the node-gyp that's bundled with older versions of node will also include this_, but I probably need to confirm that before publishing this.
