### PR TITLE
0.5.2-wip: make NanAsyncWorker.*Persistent() public

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -11,6 +11,9 @@
  * Version 0.5.1 (current Node unstable: 0.11.8, Node stable: 0.10.21)
  *
  * ChangeLog:
+ *  * 0.5.2 (WIP)
+ *    - Convert SavePersistent and GetFromPersistent in NanAsyncWorker from protected and public
+ *
  *  * 0.5.1 Nov 12 2013
  *    - Use node::MakeCallback() instead of direct v8::Function::Call()
  *
@@ -708,15 +711,6 @@ public:
     callback = NULL;
   }
 
-  virtual void Execute () =0;
-
-  uv_work_t request;
-
-protected:
-  v8::Persistent<v8::Object> persistentHandle;
-  NanCallback *callback;
-  const char *errmsg;
-
   void SavePersistent(const char *key, v8::Local<v8::Object> &obj) {
     NanScope();
 
@@ -730,6 +724,15 @@ protected:
     v8::Local<v8::Object> handle = NanPersistentToLocal(persistentHandle);
     return handle->Get(NanSymbol(key)).As<v8::Object>();
   }
+
+  virtual void Execute () =0;
+
+  uv_work_t request;
+
+protected:
+  v8::Persistent<v8::Object> persistentHandle;
+  NanCallback *callback;
+  const char *errmsg;
 
   virtual void HandleOKCallback () {
     NanScope();


### PR DESCRIPTION
A small change to `NanAsyncWorker`, I'd like to make `SavePersistent()` and `GetFromPersistent()` public so I can use them from the outside. I'm finding that best practice might be to save a persistent of the parent object on each async call so GC doesn't get a chance to clean up the parent if there is no reference left in JS-land. For instance:

``` js
function () {
  var batch = db.batch()
  batch.put('foo', 'bar')
  batch.write(function () {
    // no JS reference here, `batch` is free to be cleaned up prior to this
    // if the `write()` call takes a significantly long time
  })
}
```

so instead of resorting to referencing hacks in JS-land, if you put the reference to the parent object, in this case `batch` into the `NanAsyncWorker`, in this case for the `write()` work, then it is kept around until the worker is cleaned up.

This is much cleaner if you can do this from outside `NanAsyncWorker`.

Having said all that, I think my projects might be the only ones actually using `NanAsyncWorker` so this is mainly FYI but I'd appreciate any feedback, comments or objections before merging.
