### PR TITLE
Set number of build threads and parallel tests to the number of CPU cores

### DIFF
--- a/test/docker/run-docker.sh
+++ b/test/docker/run-docker.sh
@@ -8,7 +8,7 @@ __dirname="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # How many tests can we run at once without making the computer grind to a halt
 # or causing other unwanted resource problems:
-SIMULTANEOUS=4
+SIMULTANEOUS=`grep '^processor\s*\:\s*[0-9][0-9]*$' /proc/cpuinfo | wc -l`
 
 # The versions of Node to test, this assumes that we have a Docker image
 # set up with the name "node_dev-<version>"

--- a/test/docker/setup-docker.sh
+++ b/test/docker/setup-docker.sh
@@ -7,7 +7,7 @@
 __dirname="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # For `make -j X`
-BUILD_THREADS=6
+BUILD_THREADS=`grep '^processor\s*\:\s*[0-9][0-9]*$' /proc/cpuinfo | wc -l`
 
 # The versions of Node to test, edit the node_versions.list file to change
 # NOTE: to re-make "master" just `sudo docker rmi node_dev-master` and run


### PR DESCRIPTION
This should work better as a dynamic base, but it might need tweaking for hyperthreading or personal preference.
