### PR TITLE
Make `errmsg` private, only access it through accessors

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -776,7 +776,7 @@ class NanCallback {
 public:
   NanAsyncWorker (NanCallback *callback) : callback(callback) {
     request.data = this;
-    errmsg = NULL;
+    errmsg_ = NULL;
   }
 
   virtual ~NanAsyncWorker () {
@@ -786,14 +786,14 @@ public:
       NanDisposePersistent(persistentHandle);
     if (callback)
       delete callback;
-    if (errmsg)
-      delete errmsg;
+    if (errmsg_)
+      delete errmsg_;
   }
 
   virtual void WorkComplete () {
     NanScope();
 
-    if (errmsg == NULL)
+    if (errmsg_ == NULL)
       HandleOKCallback();
     else
       HandleErrorCallback();
@@ -822,7 +822,6 @@ public:
 protected:
   v8::Persistent<v8::Object> persistentHandle;
   NanCallback *callback;
-  const char *errmsg;
 
   virtual void HandleOKCallback () {
     NanScope();
@@ -834,10 +833,24 @@ protected:
     NanScope();
 
     v8::Local<v8::Value> argv[] = {
-        v8::Exception::Error(v8::String::New(errmsg))
+        v8::Exception::Error(v8::String::New(errmsg_))
     };
     callback->Call(1, argv);
   }
+
+  void SetErrmsg(const char *msg) {
+    size_t size = strlen(msg);
+    errmsg_ = new char[size + 1];
+    strncpy(errmsg_, msg, size);
+    errmsg_[size] = '\0';
+  }
+
+  char *Errmsg() {
+    return errmsg_;
+  }
+
+private:
+  char *errmsg_;
 };
 
 NAN_INLINE(void NanAsyncExecute (uv_work_t* req)) {

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -87,4 +87,12 @@
             "<!(node -e \"require('..')\")"
         ]
     }
+  , {
+        "target_name" : "asyncworkererror"
+      , "sources"     : [ "cpp/asyncworkererror.cpp" ]
+      , "cflags"      : [ "-Wno-unused-local-typedefs" ]
+      , "include_dirs": [
+            "<!(node -e \"require('..')\")"
+        ]
+    }
 ]}

--- a/test/cpp/asyncworkererror.cpp
+++ b/test/cpp/asyncworkererror.cpp
@@ -1,0 +1,26 @@
+#include <unistd.h>
+#include <node.h>
+#include "nan.h"
+
+class ErrorWorker : public NanAsyncWorker {
+ public:
+  ErrorWorker(NanCallback *callback) : NanAsyncWorker(callback) {}
+  ~ErrorWorker() {}
+
+  void Execute () {
+    SetErrmsg("Error");
+  }
+};
+
+NAN_METHOD(Work) {
+  NanScope();
+  NanCallback *callback = new NanCallback(args[0].As<v8::Function>());
+  NanAsyncQueueWorker(new ErrorWorker(callback));
+  NanReturnUndefined();
+}
+
+void Init (v8::Handle<v8::Object> exports) {
+  exports->Set(NanSymbol("a"), v8::FunctionTemplate::New(Work)->GetFunction());
+}
+
+NODE_MODULE(asyncworkererror, Init)

--- a/test/js/asyncworkererror-test.js
+++ b/test/js/asyncworkererror-test.js
@@ -1,0 +1,12 @@
+const test     = require('tap').test
+    , bindings = require('bindings')
+
+test('asyncworkererror', function (t) {
+  var worker = bindings('asyncworkererror').a
+  t.type(worker, 'function')
+  worker(function (err) {
+    t.ok(err)
+    t.equal(err.message, 'Error')
+    t.end()
+  })
+})


### PR DESCRIPTION
Allocate a copy of error message on the heap, preventing trying to
deallocate non-allocated memory.

Fixes #79.

cc @bnoordhuis
