### PR TITLE
GetFromPersistent and other NanAsyncWorker scope issues

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1293,6 +1293,10 @@ class NanCallback {
   explicit NanAsyncWorker(NanCallback *callback) : callback(callback) {
     request.data = this;
     errmsg = NULL;
+
+    NanScope();
+    v8::Local<v8::Object> obj = NanNew<v8::Object>();
+    NanAssignPersistent(persistentHandle, obj);
   }
 
   virtual ~NanAsyncWorker() {
@@ -1317,9 +1321,7 @@ class NanCallback {
     callback = NULL;
   }
 
-  NAN_INLINE void SavePersistent(const char *key, v8::Local<v8::Object> obj) {
-    NanScope();
-
+  NAN_INLINE void SavePersistent(const char *key, v8::Local<v8::Object> &obj) {
     v8::Local<v8::Object> handle = NanNew(persistentHandle);
     handle->Set(NanSymbol(key), obj);
   }

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -103,4 +103,11 @@
             "<!(node -e \"require('..')\")"
         ]
     }
+  , {
+        "target_name" : "bufferworkerpersistent"
+      , "sources"     : [ "cpp/bufferworkerpersistent.cpp" ]
+      , "include_dirs": [
+            "<!(node -e \"require('..')\")"
+        ]
+    }
 ]}

--- a/test/cpp/bufferworkerpersistent.cpp
+++ b/test/cpp/bufferworkerpersistent.cpp
@@ -1,0 +1,59 @@
+/**********************************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2014 NAN contributors
+ *
+ * MIT +no-false-attribs License <https://github.com/rvagg/nan/blob/master/LICENSE>
+ **********************************************************************************/
+
+#include <unistd.h>
+#include <node.h>
+#include <nan.h>
+
+class BufferWorker : public NanAsyncWorker {
+ public:
+  BufferWorker(
+          NanCallback *callback
+        , int milliseconds
+        , v8::Local<v8::Object> &bufferHandle
+      )
+    : NanAsyncWorker(callback), milliseconds(milliseconds) {
+
+      NanScope();
+
+      SavePersistent("buffer", bufferHandle);
+    }
+
+  ~BufferWorker() {}
+
+  void Execute () {
+    usleep(milliseconds * 1000);
+  }
+
+  void HandleOKCallback () {
+    NanScope();
+
+    v8::Local<v8::Object> handle = GetFromPersistent("buffer");
+    v8::Local<v8::Value> argv[] = { handle };
+    callback->Call(1, argv);
+  }
+
+ private:
+  int milliseconds;
+};
+
+NAN_METHOD(Sleep) {
+  NanScope();
+  v8::Local<v8::Object> bufferHandle = args[1].As<v8::Object>();
+  NanCallback *callback = new NanCallback(args[2].As<v8::Function>());
+  NanAsyncQueueWorker(new BufferWorker(callback, args[0]->Uint32Value(), bufferHandle));
+  NanReturnUndefined();
+}
+
+void Init(v8::Handle<v8::Object> exports) {
+  exports->Set(
+      NanSymbol("a")
+    , NanNew<v8::FunctionTemplate>(Sleep)->GetFunction());
+}
+
+NODE_MODULE(bufferworkerpersistent, Init)

--- a/test/js/bufferworkerpersistent.js
+++ b/test/js/bufferworkerpersistent.js
@@ -1,0 +1,25 @@
+const test     = require('tap').test
+    , bindings = require('bindings')
+    , crypto   = require('crypto')
+
+test('bufferworkerpersistent', function (t) {
+  var worker = bindings('bufferworkerpersistent').a
+    , called = false
+    , buf    = crypto.randomBytes(256)
+    , bufHex = buf.toString('hex')
+
+  t.type(worker, 'function')
+
+  setTimeout(function () {
+    t.ok(called)
+    t.end()
+  }, 300)
+
+  worker(200, buf, function (_buf) {
+    called = true
+    t.ok(Buffer.isBuffer(_buf), 'is buffer arg')
+    t.equal(_buf.toString('hex'), bufHex)
+  })
+
+  buf = null // unref
+})


### PR DESCRIPTION
Found my `Buffer`-related bug, although I don't fully understand it because it relates to `HandleScope` (which I don't confess to actually understand).

Having a `NanScope()` on `GetFromPersistent()` meant that when the object in question is a `Buffer`, we get back a handle that returns false for `Buffer::HasInstance(handle)`! This is only new behaviour in master so I don't know what's going on. Removing the `NanScope()` fixed it for me. I went ahead and added `NAN_INLINE` to these methods too and also make sure the `persistentHandle` is actually instantiated.

Interestingly, there were no real problems as far as I could tell, when the object in question isn't a `Buffer` so it's to do with `v8::Object#HasIndexedPropertiesInExternalArrayData()`. *shrug*

Also I think I might do a change from `SavePersistent()` to `SaveToPersistent()` to match `GetFromPersistent()` for the next release since we're going with breaking changes anyway and there aren't many people other than me actually using `NanAsyncWorker` out there!
