### PR TITLE
corrected NanCallback::Call for v0.8+.

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -760,9 +760,8 @@ class NanCallback {
 #if NODE_VERSION_AT_LEAST(0, 8, 0)
     v8::Local<v8::Function> callback = NanPersistentToLocal(handle)->
         Get(NanSymbol("callback")).As<v8::Function>();
-    node::MakeCallback(
+    callback->Call(
         v8::Context::GetCurrent()->Global()
-      , callback
       , argc
       , argv
     );


### PR DESCRIPTION
tested v0.10.26 and v0.11.12

On v0.11.12, the original node::MakeCallback() leads to a dynamic symbol not found, don't use it!
Now async examples and tests work perfectly on node.js 0.10.26 and 0.11.12
