### PR TITLE
nan: auto-delete weak callback object

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ You can use `NanReturnNull()`, `NanReturnEmptyString()`, `NanReturnUndefined()` 
 <a name="api_nan_weak_callback"></a>
 ### NAN_WEAK_CALLBACK(cbname)
 
-Use `NAN_WEAK_CALLBACK` to define your V8 WeakReference callbacks. Do not use for declaration. There is an argument object `const _NanWeakCallbackData<T, P> &data` allowing access to the weak object and the supplied parameter through its `GetValue` and `GetParameter` methods. You can even access the weak callback info object through the `GetCallbackInfo()`method, but you probably should not. You must either `Revive()` the weak handle or `Dispose()` it among with the callback info structure.
+Use `NAN_WEAK_CALLBACK` to define your V8 WeakReference callbacks. Do not use for declaration. There is an argument object `const _NanWeakCallbackData<T, P> &data` allowing access to the weak object and the supplied parameter through its `GetValue` and `GetParameter` methods. You can even access the weak callback info object through the `GetCallbackInfo()`method, but you probably should not. `Revive()` keeps the weak object alive until the next GC round.
 
 ```c++
 NAN_WEAK_CALLBACK(weakCallback) {
@@ -378,7 +378,6 @@ NAN_WEAK_CALLBACK(weakCallback) {
     data.Revive();
   } else {
     delete parameter;
-    data.Dispose();
   }
 }
 ```

--- a/nan.h
+++ b/nan.h
@@ -750,6 +750,10 @@ NAN_INLINE uint32_t NanUInt32OptionValue(
 
     NAN_INLINE P* GetParameter() const { return info_->parameter; }
 
+    NAN_INLINE bool IsNearDeath() const {
+      return info_->persistent.IsNearDeath();
+    }
+
     NAN_INLINE void Revive() const {
       info_->persistent.SetWeak(info_, info_->callback);
     }
@@ -758,8 +762,7 @@ NAN_INLINE uint32_t NanUInt32OptionValue(
       return info_;
     }
 
-    NAN_INLINE void Dispose() const {
-      delete info_;
+    NAN_DEPRECATED NAN_INLINE void Dispose() const {
     }
 
    private:
@@ -774,6 +777,7 @@ NAN_INLINE uint32_t NanUInt32OptionValue(
         _NanWeakCallbackData<T, P> wcbd(                                       \
            data.GetParameter());                                               \
         _Nan_Weak_Callback_ ## name(wcbd);                                     \
+        if (wcbd.IsNearDeath()) delete wcbd.GetCallbackInfo();                 \
     }                                                                          \
                                                                                \
     template<typename T, typename P>                                           \
@@ -1371,6 +1375,10 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
 
     NAN_INLINE P* GetParameter() const { return info_->parameter; }
 
+    NAN_INLINE bool IsNearDeath() const {
+      return info_->persistent.IsNearDeath();
+    }
+
     NAN_INLINE void Revive() const {
       info_->persistent.MakeWeak(info_, info_->callback);
     }
@@ -1379,8 +1387,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
       return info_;
     }
 
-    NAN_INLINE void Dispose() const {
-      delete info_;
+    NAN_DEPRECATED NAN_INLINE void Dispose() const {
     }
 
    private:
@@ -1395,6 +1402,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
         _NanWeakCallbackData<T, P> wcbd(                                       \
            static_cast<_NanWeakCallbackInfo<T, P>*>(data));                    \
         _Nan_Weak_Callback_ ## name(wcbd);                                     \
+        if (wcbd.IsNearDeath()) delete wcbd.GetCallbackInfo();                 \
     }                                                                          \
                                                                                \
     template<typename T, typename P>                                           \

--- a/test/cpp/weak.cpp
+++ b/test/cpp/weak.cpp
@@ -15,7 +15,6 @@ NAN_WEAK_CALLBACK(weakCallback) {
     data.Revive();
   } else {
     delete parameter;
-    data.Dispose();
   }
 }
 


### PR DESCRIPTION
- Check with IsNearDeath() if it's safe to delete the weak callback
  context object.
- Turn _NanWeakCallbackData::Dispose() into a deprecated no-op,
  resource management is now handled automatically.

Incidentally fixes a double-free bug when the user calls Dispose()
twice.

/cc @kkoopa
