### PR TITLE
nan: declare inner callback in `NAN_WEAK_CALLBACK`

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -772,6 +772,9 @@ NAN_INLINE uint32_t NanUInt32OptionValue(
 // do not use for declaration
 # define NAN_WEAK_CALLBACK(name)                                               \
     template<typename T, typename P>                                           \
+    static NAN_INLINE void _Nan_Weak_Callback_ ## name(                        \
+    const _NanWeakCallbackData<T, P> &data);                                   \
+    template<typename T, typename P>                                           \
     static void name(                                                          \
       const v8::WeakCallbackData<T, _NanWeakCallbackInfo<T, P> > &data) {      \
         _NanWeakCallbackData<T, P> wcbd(                                       \
@@ -1396,6 +1399,9 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
 
 // do not use for declaration
 # define NAN_WEAK_CALLBACK(name)                                               \
+    template<typename T, typename P>                                           \
+    static NAN_INLINE void _Nan_Weak_Callback_ ## name(                        \
+    const _NanWeakCallbackData<T, P> &data);                                   \
     template<typename T, typename P>                                           \
     static void name(                                                          \
       v8::Persistent<v8::Value> object, void *data) {                          \


### PR DESCRIPTION
Fixes OS X LLVM compiler error:

```
N_WEAK_CALLBACK(write_object_cb) {
^
../node_modules/nan/nan.h:779:9: note: expanded from macro 'NAN_WEAK_CALLBACK'
        _Nan_Weak_Callback_ ## name(wcbd);                                     \
        ^
<scratch space>:236:1: note: expanded from here
_Nan_Weak_Callback_write_object_cb
^
../src/binding.cc:187:87: note: in instantiation of function template specialization '<anonymous namespace>::write_object_cb<v8::Object, void>' requested here
    _NanWeakCallbackInfo<Object, void>* info = NanMakeWeakPersistent(val, user_data, &write_object_cb<Object, void>);
                                                                                      ^
../src/binding.cc:150:1: note: '_Nan_Weak_Callback_write_object_cb' should be declared prior to the call site or in an associated namespace of one of its arguments
NAN_WEAK_CALLBACK(write_object_cb) {
^
../node_modules/nan/nan.h:784:28: note: expanded from macro 'NAN_WEAK_CALLBACK'
    static NAN_INLINE void _Nan_Weak_Callback_ ## name(                        \
                           ^
<scratch space>:2:1: note: expanded from here
_Nan_Weak_Callback_write_object_cb
^
1 error generated.
```

Special thanks to @kkoopa for coming up with the patch.
I'm just submitting it.

See https://github.com/TooTallNate/ref/pull/14 for more details.
