### PR TITLE
Fix broken weak callback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ You can use `NanReturnNull()`, `NanReturnEmptyString()`, `NanReturnUndefined()` 
 <a name="api_nan_weak_callback"></a>
 ### NAN_WEAK_CALLBACK(cbname)
 
-Use `NAN_WEAK_CALLBACK` to define your V8 WeakReference callbacks. Do not use for declaration. There is an argument object `const _NanWeakCallbackData<T, P> &data` allowing access to the weak object and the supplied parameter through its `GetValue` and `GetParameter` methods. You can even access the weak callback info object through the `GetCallbackInfo()`method, but you probably should not. `Revive()` keeps the weak object alive until the next GC round.
+Use `NAN_WEAK_CALLBACK` to define your V8 WeakReference callbacks. There is an argument object `const _NanWeakCallbackData<T, P> &data` allowing access to the weak object and the supplied parameter through its `GetValue` and `GetParameter` methods. You can even access the weak callback info object through the `GetCallbackInfo()`method, but you probably should not. `Revive()` keeps the weak object alive until the next GC round.
 
 ```c++
 NAN_WEAK_CALLBACK(weakCallback) {
@@ -794,7 +794,7 @@ NanAssignPersistent(persistentHandle, obj)
 <a name="api_nan_make_weak_persistent"></a>
 ### _NanWeakCallbackInfo&lt;T, P&gt;* NanMakeWeakPersistent(Handle&lt;T&gt;, P*, _NanWeakCallbackInfo&lt;T, P&gt;::Callback)
 
-Creates a weak persistent handle with the supplied parameter and `NAN_WEAK_CALLBACK`. The callback has to be fully specialized to work on all versions of Node.
+Creates a weak persistent handle with the supplied parameter and `NAN_WEAK_CALLBACK`.
 
 ```c++
 NAN_WEAK_CALLBACK(weakCallback) {
@@ -808,7 +808,7 @@ Local<Function> func;
 ...
 
 int *parameter = new int(0);
-NanMakeWeakPersistent(func, parameter, &weakCallback<Function, int>);
+NanMakeWeakPersistent(func, parameter, &weakCallback);
 ```
 
 <a name="api_nan_set_template"></a>

--- a/test/cpp/weak.cpp
+++ b/test/cpp/weak.cpp
@@ -21,7 +21,7 @@ NAN_WEAK_CALLBACK(weakCallback) {
 v8::Handle<v8::String> wrap(v8::Local<v8::Function> func) {
   v8::Local<v8::String> lstring = NanNew<v8::String>("result");
   int *parameter = new int(0);
-  NanMakeWeakPersistent(func, parameter, &weakCallback<v8::Function, int>);
+  NanMakeWeakPersistent(func, parameter, &weakCallback);
   return lstring;
 }
 


### PR DESCRIPTION
This should address #127 while not breaking #123. As a nice side-effect, it no longer appears necessary to fully specialize the callback argument, see L24 in weak.cpp.

I suggest releasing an updated version of NAN.
