### PR TITLE
fix the missing return for `_NAN_THROW_ERROR`

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -828,7 +828,8 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
 # define _NAN_THROW_ERROR(fun, errmsg)                                         \
     do {                                                                       \
       NanScope();                                                              \
-      v8::Isolate::GetCurrent()->ThrowException(_NAN_ERROR(fun, errmsg));      \
+      return v8::Isolate::GetCurrent(                                          \
+        )->ThrowException(_NAN_ERROR(fun, errmsg));                            \
     } while (0);
 
   NAN_INLINE v8::Local<v8::Value> NanError(const char* errmsg) {


### PR DESCRIPTION
I found there are 2 places for `_NAN_THROW_ERROR`, we should make sure the consistence for them, just returned the `ThrowException()`'s value for all.
