### PR TITLE
Removed unnecessary local handle creation.

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1002,7 +1002,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
 
   template<typename T>
   NAN_INLINE v8::Local<T> NanNew() {
-    return v8::Local<T>::New(T::New());
+    return T::New();
   }
 
   template<typename T>
@@ -1033,12 +1033,12 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
 
   template<typename T, typename P>
   NAN_INLINE v8::Local<T> NanNew(P arg) {
-    return v8::Local<T>::New(T::New(arg));
+    return T::New(arg);
   }
 
   template<typename T, typename P>
   NAN_INLINE v8::Local<T> NanNew(P arg, int length) {
-    return v8::Local<T>::New(T::New(arg, length));
+    return T::New(arg, length);
   }
 
   template<typename T>
@@ -1083,6 +1083,11 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
   template<>
   NAN_INLINE v8::Local<v8::Date> NanNew<v8::Date>(int time) {
     return v8::Date::New(time).As<v8::Date>();
+  }
+
+  template<>
+  NAN_INLINE v8::Local<v8::Boolean> NanNew<v8::Boolean>(bool value) {
+    return v8::Local<v8::Boolean>::New(v8::Boolean::New(value));
   }
 
   typedef v8::Script NanUnboundScript;

--- a/test/cpp/news.cpp
+++ b/test/cpp/news.cpp
@@ -144,6 +144,11 @@ NAN_METHOD(NewArray) {
   NanReturnValue(NanNew<v8::Array>());
 }
 
+NAN_METHOD(NewBoolean) {
+  NanScope();
+  NanReturnValue(NanNew<v8::Boolean>(true));
+}
+
 void Init(v8::Handle<v8::Object> target) {
   target->Set(
       NanNew<v8::String>("newNumber")
@@ -236,6 +241,10 @@ void Init(v8::Handle<v8::Object> target) {
   target->Set(
       NanNew<v8::String>("newArray")
     , NanNew<v8::FunctionTemplate>(NewArray)->GetFunction()
+  );
+  target->Set(
+      NanNew<v8::String>("newBoolean")
+    , NanNew<v8::FunctionTemplate>(NewBoolean)->GetFunction()
   );
 }
 

--- a/test/js/news-test.js
+++ b/test/js/news-test.js
@@ -3,7 +3,7 @@ const test     = require('tap').test
     , bindings = require('bindings')({ module_root: testRoot, bindings: 'news' });
 
 test('news', function (t) {
-  t.plan(46);
+  t.plan(48);
   t.type(bindings.newNumber, 'function');
   t.type(bindings.newPositiveInteger, 'function');
   t.type(bindings.newNegativeInteger, 'function');
@@ -27,6 +27,7 @@ test('news', function (t) {
   t.type(bindings.compileScript2, 'function');
   t.type(bindings.newDate, 'function');
   t.type(bindings.newArray, 'function');
+  t.type(bindings.newBoolean, 'function');
 
   t.equal(bindings.newNumber(), 0.5);
   t.equal(bindings.newPositiveInteger(), 1);
@@ -51,4 +52,5 @@ test('news', function (t) {
   t.equals(bindings.compileScript2(), 6);
   t.deepEquals(bindings.newDate(), new Date(1337));
   t.deepEquals(bindings.newArray(), []);
+  t.equal(bindings.newBoolean(), true);
 });


### PR DESCRIPTION
This should speed up handle creation on old Node.

On another note: Would it be worthwhile to make `NanNew<T>(v8::Persistent<T>)` check for possible weakness and just do a typecast if the handle is not weak? Only reason I don't like it is because it then would not return a _new_ handle, which the name implies it should. Is there any performance to gain here in the first place?
