### PR TITLE
Removed superfluous scope.

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1979,8 +1979,6 @@ class NanCallback {
   NanCallback *callback;
 
   virtual void HandleOKCallback() {
-    NanScope();
-
     callback->Call(0, NULL);
   }
 


### PR DESCRIPTION
This scope should be unnecessary. See #164.
