### PR TITLE
Added nan-example-eol link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ See **[LevelDOWN](https://github.com/rvagg/node-leveldown/pull/48)** for a full 
 
 For a simpler example, see the **[async pi estimation example](https://github.com/rvagg/nan/tree/master/examples/async_pi_estimate)** in the examples directory for full code and an explanation of what this Monte Carlo Pi estimation example does. Below are just some parts of the full example that illustrate the use of **NAN**.
 
+For another example, see **[nan-example-eol](https://github.com/CodeCharmLtd/nan-example-eol)**. It shows newline detection implemented as a native addon.
+
 Compare to the current 0.10 version of this example, found in the [node-addon-examples](https://github.com/rvagg/node-addon-examples/tree/master/9_async_work) repository and also a 0.11 version of the same found [here](https://github.com/kkoopa/node-addon-examples/tree/5c01f58fc993377a567812597e54a83af69686d7/9_async_work).
 
 Note that there is no embedded version sniffing going on here and also the async work is made much simpler, see below for details on the `NanAsyncWorker` class.


### PR DESCRIPTION
Added that link to [nan-example-eol](https://github.com/CodeCharmLtd/nan-example-eol) so we can close #75.
