### PR TITLE
fix tap version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bindings": "~1.2.1",
     "node-gyp": "~1.0.2",
     "pangyp": "~2.2.0",
-    "tap": "~1.1.2",
+    "tap": "~1.1.0",
     "xtend": "~4.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
Fix the failing at [AppVeyor](https://ci.appveyor.com/project/RodVagg/nan/build/job/sa4i4frsxsqt4c5c), because the current tap version is [1.1.0](https://www.npmjs.com/package/tap), but we were using 1.1.2.

Related commit: 2600bd138d3cd1c1c01414ca663d44a2ebd9d053
R=@kkoopa