### PR TITLE
Add dereference and function call operators to NanCallback

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1601,6 +1601,22 @@ class NanCallback {
     return !this->operator==(other);
   }
 
+  NAN_INLINE
+  v8::Local<v8::Function> operator*() const { return this->GetFunction(); }
+
+  NAN_INLINE v8::Local<v8::Value> operator()(
+      v8::Handle<v8::Object> target
+    , int argc = 0
+    , v8::Handle<v8::Value> argv[] = 0) const {
+    return this->Call(target, argc, argv);
+  }
+
+  NAN_INLINE v8::Local<v8::Value> operator()(
+      int argc = 0
+    , v8::Handle<v8::Value> argv[] = 0) const {
+    return this->Call(argc, argv);
+  }
+
   NAN_INLINE void SetFunction(const v8::Handle<v8::Function> &fn) {
     NanScope();
     NanNew(handle)->Set(kCallbackIndex, fn);
@@ -1617,7 +1633,7 @@ class NanCallback {
     return NanNew(handle)->Get(kCallbackIndex)->IsUndefined();
   }
 
-  NAN_INLINE v8::Handle<v8::Value>
+  NAN_INLINE v8::Local<v8::Value>
   Call(v8::Handle<v8::Object> target
      , int argc
      , v8::Handle<v8::Value> argv[]) const {
@@ -1629,7 +1645,7 @@ class NanCallback {
 #endif
   }
 
-  NAN_INLINE v8::Handle<v8::Value>
+  NAN_INLINE v8::Local<v8::Value>
   Call(int argc, v8::Handle<v8::Value> argv[]) const {
 #if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
     v8::Isolate *isolate = v8::Isolate::GetCurrent();
@@ -1645,7 +1661,7 @@ class NanCallback {
   static const uint32_t kCallbackIndex = 0;
 
 #if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
-  v8::Handle<v8::Value> Call_(v8::Isolate *isolate
+  v8::Local<v8::Value> Call_(v8::Isolate *isolate
                            , v8::Handle<v8::Object> target
                            , int argc
                            , v8::Handle<v8::Value> argv[]) const {
@@ -1653,16 +1669,16 @@ class NanCallback {
 
     v8::Local<v8::Function> callback = NanNew(handle)->
         Get(kCallbackIndex).As<v8::Function>();
-    return NanEscapeScope(node::MakeCallback(
+    return NanEscapeScope(NanNew(node::MakeCallback(
         isolate
       , target
       , callback
       , argc
       , argv
-    ));
+    )));
   }
 #else
-  v8::Handle<v8::Value> Call_(v8::Handle<v8::Object> target
+  v8::Local<v8::Value> Call_(v8::Handle<v8::Object> target
                            , int argc
                            , v8::Handle<v8::Value> argv[]) const {
     NanEscapableScope();
@@ -1670,12 +1686,12 @@ class NanCallback {
 #if NODE_VERSION_AT_LEAST(0, 8, 0)
     v8::Local<v8::Function> callback = handle->
         Get(kCallbackIndex).As<v8::Function>();
-    return NanEscapeScope(node::MakeCallback(
+    return NanEscapeScope(NanNew(node::MakeCallback(
         target
       , callback
       , argc
       , argv
-    ));
+    )));
 #else
     v8::Local<v8::Function> callback = handle->
         Get(kCallbackIndex).As<v8::Function>();

--- a/test/cpp/nancallback.cpp
+++ b/test/cpp/nancallback.cpp
@@ -42,6 +42,23 @@ NAN_METHOD(CompareCallbacks) {
   NanReturnValue(NanNew<v8::Boolean>(cb1 == cb2 && cb1 != cb3));
 }
 
+NAN_METHOD(CallDirect) {
+  NanScope();
+
+  NanCallback cb(args[0].As<v8::Function>());
+  (*cb)->Call(NanGetCurrentContext()->Global(), 0, NULL);
+
+  NanReturnUndefined();
+}
+
+NAN_METHOD(CallAsFunction) {
+  NanScope();
+
+  NanCallback(args[0].As<v8::Function>())();
+
+  NanReturnUndefined();
+}
+
 void Init (v8::Handle<v8::Object> target) {
   target->Set(
       NanNew<v8::String>("globalContext")
@@ -58,6 +75,14 @@ void Init (v8::Handle<v8::Object> target) {
   target->Set(
       NanNew<v8::String>("compareCallbacks")
     , NanNew<v8::FunctionTemplate>(CompareCallbacks)->GetFunction()
+  );
+  target->Set(
+      NanNew<v8::String>("callDirect")
+    , NanNew<v8::FunctionTemplate>(CallDirect)->GetFunction()
+  );
+  target->Set(
+      NanNew<v8::String>("callAsFunction")
+    , NanNew<v8::FunctionTemplate>(CallAsFunction)->GetFunction()
   );
 }
 

--- a/test/js/nancallback-test.js
+++ b/test/js/nancallback-test.js
@@ -12,16 +12,20 @@ const test     = require('tap').test
     , round = Math.round;
 
 test('nancallback', function (t) {
-  t.plan(9)
+  t.plan(13)
 
   var persistent = bindings;
   t.type(persistent.globalContext, 'function');
   t.type(persistent.specificContext, 'function');
   t.type(persistent.customReceiver, 'function');
   t.type(persistent.compareCallbacks, 'function');
+  t.type(persistent.callDirect, 'function');
+  t.type(persistent.callAsFunction, 'function');
   persistent.globalContext(function () { t.ok(true); });
   persistent.specificContext(function () { t.ok(true); });
   persistent.customReceiver(function () { t.equal(this, process); }, process);
+  persistent.callDirect(function () { t.ok(true); });
+  persistent.callAsFunction(function () { t.ok(true); });
 
   var round2 = Math.round
     , x = function(param) { return param + 1; }


### PR DESCRIPTION
As a way of addressing #284, I added a dereference operator to `NanCallback` as a shorthand for `GetFunction`. I also added a function call operator as a shorthand for `Call`.

Should be included in #365.