### PR TITLE
Bump dependency on node-gyp to 2.0.2 to pick up https:// downloading of node.js source

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "devDependencies": {
     "bindings": "~1.2.1",
-    "node-gyp": "~1.0.2",
+    "node-gyp": "~2.0.2",
     "pangyp": "~2.2.0",
     "tap": "~0.7.1",
     "xtend": "~4.0.0"


### PR DESCRIPTION
`node-gyp` had been using http://nodejs.org for downloading node.js source. This was recently changed in https://github.com/TooTallNate/node-gyp/pull/656 to use https:// instead. Bump dependency to pick up that change.