### PR TITLE
add overload for Nan::NewInstance that takes argc/argv

### DIFF
--- a/doc/maybe_types.md
+++ b/doc/maybe_types.md
@@ -159,6 +159,7 @@ Signature:
 
 ```c++
 Nan::MaybeLocal<v8::Object> Nan::NewInstance(v8::Local<v8::Function> h);
+Nan::MaybeLocal<v8::Object> Nan::NewInstance(v8::Local<v8::Function> h, int argc, v8::Handle<v8::Value> argv[]);
 Nan::MaybeLocal<v8::Object> Nan::NewInstance(v8::Local<v8::ObjectTemplate> h);
 ```
 

--- a/doc/maybe_types.md
+++ b/doc/maybe_types.md
@@ -159,7 +159,7 @@ Signature:
 
 ```c++
 Nan::MaybeLocal<v8::Object> Nan::NewInstance(v8::Local<v8::Function> h);
-Nan::MaybeLocal<v8::Object> Nan::NewInstance(v8::Local<v8::Function> h, int argc, v8::Handle<v8::Value> argv[]);
+Nan::MaybeLocal<v8::Object> Nan::NewInstance(v8::Local<v8::Function> h, int argc, v8::Local<v8::Value> argv[]);
 Nan::MaybeLocal<v8::Object> Nan::NewInstance(v8::Local<v8::ObjectTemplate> h);
 ```
 

--- a/nan_maybe_43_inl.h
+++ b/nan_maybe_43_inl.h
@@ -51,7 +51,7 @@ NAN_INLINE
 MaybeLocal<v8::Object> NewInstance(
       v8::Local<v8::Function> h
     , int argc
-    , v8::Handle<v8::Value> argv[]) {
+    , v8::Local<v8::Value> argv[]) {
   return MaybeLocal<v8::Object>(h->NewInstance(GetCurrentContext(), argc, argv));
 }
 

--- a/nan_maybe_43_inl.h
+++ b/nan_maybe_43_inl.h
@@ -52,7 +52,8 @@ MaybeLocal<v8::Object> NewInstance(
       v8::Local<v8::Function> h
     , int argc
     , v8::Local<v8::Value> argv[]) {
-  return MaybeLocal<v8::Object>(h->NewInstance(GetCurrentContext(), argc, argv));
+  return MaybeLocal<v8::Object>(h->NewInstance(GetCurrentContext(),
+                                argc, argv));
 }
 
 NAN_INLINE

--- a/nan_maybe_43_inl.h
+++ b/nan_maybe_43_inl.h
@@ -48,6 +48,14 @@ MaybeLocal<v8::Object> NewInstance(v8::Local<v8::Function> h) {
 }
 
 NAN_INLINE
+MaybeLocal<v8::Object> NewInstance(
+      v8::Local<v8::Function> h
+    , int argc
+    , v8::Handle<v8::Value> argv[]) {
+  return MaybeLocal<v8::Object>(h->NewInstance(GetCurrentContext(), argc, argv));
+}
+
+NAN_INLINE
 MaybeLocal<v8::Object> NewInstance(v8::Local<v8::ObjectTemplate> h) {
   return MaybeLocal<v8::Object>(h->NewInstance(GetCurrentContext()));
 }

--- a/nan_maybe_pre_43_inl.h
+++ b/nan_maybe_pre_43_inl.h
@@ -118,7 +118,7 @@ NAN_INLINE
 MaybeLocal<v8::Object> NewInstance(
       v8::Local<v8::Function> h
     , int argc
-    , v8::Handle<v8::Value> argv[]) {
+    , v8::Local<v8::Value> argv[]) {
   return MaybeLocal<v8::Object>(h->NewInstance(argc, argv));
 }
 

--- a/nan_maybe_pre_43_inl.h
+++ b/nan_maybe_pre_43_inl.h
@@ -115,6 +115,14 @@ MaybeLocal<v8::Object> NewInstance(v8::Handle<v8::Function> h) {
 }
 
 NAN_INLINE
+MaybeLocal<v8::Object> NewInstance(
+      v8::Local<v8::Function> h
+    , int argc
+    , v8::Handle<v8::Value> argv[]) {
+  return MaybeLocal<v8::Object>(h->NewInstance(argc, argv));
+}
+
+NAN_INLINE
 MaybeLocal<v8::Object> NewInstance(v8::Handle<v8::ObjectTemplate> h) {
   return MaybeLocal<v8::Object>(h->NewInstance());
 }


### PR DESCRIPTION
This adds another overloaded variant of `Nan::NewInstance` that supports passing argc/argv through to the invoked Function.

