### PR TITLE
Add test for getting wrapped value to ObjectWrap test suite

### DIFF
--- a/test/cpp/objectwraphandle.cpp
+++ b/test/cpp/objectwraphandle.cpp
@@ -18,6 +18,7 @@ class MyObject : public ObjectWrap {
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
     SetPrototypeMethod(tpl, "getHandle", GetHandle);
+    SetPrototypeMethod(tpl, "getValue", GetValue);
 
     constructor.Reset(tpl->GetFunction());
     Set(target, Nan::New("MyObject").ToLocalChecked(), tpl->GetFunction());
@@ -44,6 +45,11 @@ class MyObject : public ObjectWrap {
   static NAN_METHOD(GetHandle) {
     MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.This());
     info.GetReturnValue().Set(obj->handle());
+  }
+
+  static NAN_METHOD(GetValue) {
+    MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.This());
+    info.GetReturnValue().Set(obj->value_);
   }
 
   static Persistent<v8::Function> constructor;

--- a/test/js/objectwraphandle-test.js
+++ b/test/js/objectwraphandle-test.js
@@ -11,12 +11,14 @@ const test     = require('tap').test
     , bindings = require('bindings')({ module_root: testRoot, bindings: 'objectwraphandle' });
 
 test('objectwraphandle', function (t) {
-  t.plan(3);
+  t.plan(5);
 
   t.type(bindings.MyObject, 'function');
 
   var obj = new bindings.MyObject(10);
 
   t.type(obj.getHandle, 'function');
+  t.type(obj.getValue, 'function');
   t.type(obj.getHandle(), 'object');
+  t.type(obj.getValue(), 'number');
 });


### PR DESCRIPTION
Fixes warning about unused member variable