### PR TITLE
new: allow utf16 string with length

### DIFF
--- a/doc/new.md
+++ b/doc/new.md
@@ -57,6 +57,7 @@ v8::Local<v8::Uint32> Nan::New<T>(uint32_t value);
 v8::Local<v8::Number> Nan::New<T>(double value);
 v8::Local<v8::String> Nan::New<T>(std::string const& value);
 v8::Local<v8::String> Nan::New<T>(const char * value, int length);
+v8::Local<v8::String> Nan::New<T>(const uint16_t * value, int length);
 v8::Local<v8::String> Nan::New<T>(const char * value);
 v8::Local<v8::String> Nan::New<T>(const uint16_t * value);
 ```
@@ -124,7 +125,7 @@ Call [`v8::String::Empty`](https://v8docs.nodesource.com/io.js-3.0/d2/db3/classv
 Signature:
 
 ```c++
-v8::Local<v8::String> Nan::EmptyString() 
+v8::Local<v8::String> Nan::EmptyString()
 ```
 
 
@@ -137,5 +138,5 @@ Signature:
 
 ```c++
 Nan::MaybeLocal<v8::String> Nan::NewOneByteString(const uint8_t * value,
-                                                  int length = -1) 
+                                                  int length = -1)
 ```

--- a/nan_new.h
+++ b/nan_new.h
@@ -301,6 +301,12 @@ New(const char * value, int length) {
 
 inline
 imp::Factory<v8::String>::return_t
+New(const uint16_t * value, int length) {
+  return New<v8::String>(value, length);
+}
+
+inline
+imp::Factory<v8::String>::return_t
 New(const char * value) {
   return New<v8::String>(value);
 }

--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -289,7 +289,7 @@ NAN_METHOD(testSignature) {
 NAN_METHOD(testString) {
   Tap t(info[0]);
 
-  t.plan(14);
+  t.plan(16);
 
   t.ok(_( stringMatches(
       New<String>("Hello World").ToLocalChecked(), "Hello World")));
@@ -318,6 +318,10 @@ NAN_METHOD(testString) {
 
   t.ok(_( stringMatches( New("Hello World", 4).ToLocalChecked(), "Hell")));
   t.ok(_( assertType<String>( New("plonk.", 4).ToLocalChecked())));
+
+  const uint16_t *widestring = reinterpret_cast<const uint16_t *>("H\0e\0l\0l\0o\0");
+  t.ok(_( stringMatches( New(widestring, 4).ToLocalChecked(), "Hell")));
+  t.ok(_( assertType<String>( New(widestring, 4).ToLocalChecked())));
 
   t.ok(_( stringMatches( New(std::string("bar")).ToLocalChecked(), "bar")));
   t.ok(_( assertType<String>( New(std::string("plonk.")).ToLocalChecked())));


### PR DESCRIPTION
Patches Nan::New so that it can be initialized with pointer to wides string and length.

Without this the following code failed:

```c++
Nan::New(pointer, length)
```

But the following code worked:

```c++
Nan::New<v8::String>(pointer, length)
```

After this patch they both work. It also adds tests and documentation for this feature.