### PR TITLE
Properly handle null callback in FunctionTemplate factory

### DIFF
--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -118,33 +118,37 @@ Factory<v8::FunctionTemplate>::New( FunctionCallback callback
                                   , v8::Local<v8::Value> data
                                   , v8::Local<v8::Signature> signature) {
   v8::Isolate *isolate = v8::Isolate::GetCurrent();
-  v8::EscapableHandleScope scope(isolate);
-  static std::map<FunctionCallback,  // NOLINT(build/include_what_you_use)
-      imp::FunctionWrapper*> cbmap;
-  v8::Local<v8::ObjectTemplate> tpl = v8::ObjectTemplate::New(isolate);
-  tpl->SetInternalFieldCount(imp::kFunctionFieldCount);
+  if (callback) {
+    v8::EscapableHandleScope scope(isolate);
+    static std::map<FunctionCallback,  // NOLINT(build/include_what_you_use)
+        imp::FunctionWrapper*> cbmap;
+    v8::Local<v8::ObjectTemplate> tpl = v8::ObjectTemplate::New(isolate);
+    tpl->SetInternalFieldCount(imp::kFunctionFieldCount);
 #if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
   (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
-  v8::Local<v8::Object> obj =
-      tpl->NewInstance(isolate->GetCurrentContext()).ToLocalChecked();
+    v8::Local<v8::Object> obj =
+        tpl->NewInstance(isolate->GetCurrentContext()).ToLocalChecked();
 #else
-  v8::Local<v8::Object> obj = tpl->NewInstance();
+    v8::Local<v8::Object> obj = tpl->NewInstance();
 #endif
 
-  obj->SetAlignedPointerInInternalField(
-      imp::kFunctionIndex
-    , imp::GetWrapper<FunctionCallback,
-          imp::FunctionWrapper>(callback));
-  v8::Local<v8::Value> val = v8::Local<v8::Value>::New(isolate, data);
+    obj->SetAlignedPointerInInternalField(
+        imp::kFunctionIndex
+      , imp::GetWrapper<FunctionCallback,
+            imp::FunctionWrapper>(callback));
+    v8::Local<v8::Value> val = v8::Local<v8::Value>::New(isolate, data);
 
-  if (!val.IsEmpty()) {
-    obj->SetInternalField(imp::kDataIndex, val);
+    if (!val.IsEmpty()) {
+      obj->SetInternalField(imp::kDataIndex, val);
+    }
+
+    return scope.Escape(v8::FunctionTemplate::New( isolate
+                                    , imp::FunctionCallbackWrapper
+                                    , obj
+                                    , signature));
+  } else {
+    return v8::FunctionTemplate::New(isolate, 0, data, signature);
   }
-
-  return scope.Escape(v8::FunctionTemplate::New( isolate
-                                  , imp::FunctionCallbackWrapper
-                                  , obj
-                                  , signature));
 }
 
 //=== Number ===================================================================


### PR DESCRIPTION
This should make `New<FunctionTemplate>()` work.
/cc @rvagg 