### PR TITLE
Docs: note use of free() for disposal of NewBuffer

### DIFF
--- a/doc/buffers.md
+++ b/doc/buffers.md
@@ -11,7 +11,9 @@ NAN's `node::Buffer` helpers exist as the API has changed across supported Node 
 
 Allocate a new `node::Buffer` object with the specified size and optional data. Calls `node::Buffer::New()`.
 
-Note that when creating a `Buffer` using `Nan::NewBuffer()` and an existing `char*`, it is assumed that the ownership of the pointer is being transferred to the new `Buffer` for management. You _must not_ free the memory space manually once you have created a `Buffer` in this way.
+Note that when creating a `Buffer` using `Nan::NewBuffer()` and an existing `char*`, it is assumed that the ownership of the pointer is being transferred to the new `Buffer` for management.
+When a `node::Buffer` instance is garbage collected and a `FreeCallback` has not been specified, `data` will be disposed of via a call to `free()`.
+You _must not_ free the memory space manually once you have created a `Buffer` in this way.
 
 Signature:
 


### PR DESCRIPTION
Hello,

Assuming my understanding of the API is correct, this addition to the docs should help people migrating from v1's `NanBufferUse` to v2's `Nan::NewBuffer`.

Cheers,
Lovell

/cc @JCMais