### PR TITLE
Workaround for crash in GetWrapper

### DIFF
--- a/nan_callbacks.h
+++ b/nan_callbacks.h
@@ -102,15 +102,7 @@ static const int kIndexPropertyFieldCount =      6;
 
 template<typename T, typename P>
 P *GetWrapper(T needle) {
-  static std::map<T, P*> haystack;
-  typename std::map<T, P*>::iterator it =  // NOLINT(build/include_what_you_use)
-      haystack.find(needle);
-
-  if (it == haystack.end()) {
-    return haystack.insert(it, std::make_pair(needle, new P(needle)))->second;
-  } else {
-    return it->second;
-  }
+  return new P(needle);
 }
 }  // end of namespace imp
 


### PR DESCRIPTION
Due to some static intialization
issues, do not use static map to
store function wrappers: always
generate a new one.

This is a workaround for a crash
where two node modules compiled
against libstdc++ and llvm libc++
meet to use GetWrapper() static
wrapper cache.

Workaround for: https://github.com/strongloop/fsevents/issues/82