### PR TITLE
Add helper method for accessing contents of typedarrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ The hooks to access V8 internals—including GC and statistics—are different a
  - <a href="doc/node_misc.md#api_nan_object_wrap"><b><code>Nan::ObjectWrap</code></b></a>
  - <a href="doc/node_misc.md#api_nan_module_init"><b><code>NAN_MODULE_INIT()</code></b></a>
  - <a href="doc/node_misc.md#api_nan_export"><b><code>Nan::Export()</code></b></a>
+ - <a href="doc/node_misc.md#api_nan_typedarray_contents"><b><code>Nan::TypedArrayContents</code></b></a>
 
 <!-- END API -->
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ The hooks to access V8 internals—including GC and statistics—are different a
  - <a href="doc/v8_misc.md#api_nan_get_current_context"><b><code>Nan::GetCurrentContext()</code></b></a>
  - <a href="doc/v8_misc.md#api_nan_set_isolate_data"><b><code>Nan::SetIsolateData()</code></b></a>
  - <a href="doc/v8_misc.md#api_nan_get_isolate_data"><b><code>Nan::GetIsolateData()</code></b></a>
+ - <a href="doc/v8_misc.md#api_nan_typedarray_contents"><b><code>Nan::TypedArrayContents</code></b></a>
 
 
 ### Miscellaneous Node Helpers
@@ -282,7 +283,6 @@ The hooks to access V8 internals—including GC and statistics—are different a
  - <a href="doc/node_misc.md#api_nan_object_wrap"><b><code>Nan::ObjectWrap</code></b></a>
  - <a href="doc/node_misc.md#api_nan_module_init"><b><code>NAN_MODULE_INIT()</code></b></a>
  - <a href="doc/node_misc.md#api_nan_export"><b><code>Nan::Export()</code></b></a>
- - <a href="doc/node_misc.md#api_nan_typedarray_contents"><b><code>Nan::TypedArrayContents</code></b></a>
 
 <!-- END API -->
 

--- a/doc/v8_misc.md
+++ b/doc/v8_misc.md
@@ -67,7 +67,7 @@ T *Nan::GetIsolateData(v8::Isolate *isolate)
 
 A helper class for accessing the contents of an ArrayBufferView (aka a typedarray) from C++.  If the input array is not a valid typedarray, then the data pointer of TypedArrayContents will default to `NULL` and the length will be 0.  If the data pointer is not compatible with the alignment requirements of type, an assertion error will fail.
 
-Note that you must store a pointer to the `array` object while you are accessing the contents of the typedarray object using this interface.
+Note that you must store a reference to the `array` object while you are accessing its contents.
 
 Definition:
 
@@ -77,7 +77,7 @@ class Nan::TypedArrayContents {
  public:
   TypedArrayContents(v8::Local<Value> array);
 
-  int length() const;
+  size_t length() const;
 
   T* const operator*();
   const T* const operator*() const;

--- a/doc/v8_misc.md
+++ b/doc/v8_misc.md
@@ -4,6 +4,7 @@
  - <a href="#api_nan_get_current_context"><b><code>Nan::GetCurrentContext()</code></b></a>
  - <a href="#api_nan_set_isolate_data"><b><code>Nan::SetIsolateData()</code></b></a>
  - <a href="#api_nan_get_isolate_data"><b><code>Nan::GetIsolateData()</code></b></a>
+ - <a href="#api_nan_typedarray_contents"><b><code>Nan::TypedArrayContents<T></code></b></a>
 
 
 <a name="api_nan_utf8_string"></a>
@@ -61,3 +62,24 @@ Signature:
 T *Nan::GetIsolateData(v8::Isolate *isolate)
 ```
 
+<a name="api_nan_typedarray_contents"></a>
+### Nan::TypedArrayContents<T>
+
+A helper class for accessing the contents of an ArrayBufferView (aka a typedarray) from C++.  If the input array is not a valid typedarray, then the data pointer of TypedArrayContents will default to `NULL`.
+
+Note that you must store a pointer to the `array` object while you are accessing the contents of the typedarray object.
+
+Definition:
+
+```c++
+template<typename T>
+class Nan::TypedArrayContents {
+ public:
+  TypedArrayContents(v8::Local<Value> array);
+
+  int length() const;
+
+  T* operator*();
+  const T* operator*() const;
+};
+```

--- a/doc/v8_misc.md
+++ b/doc/v8_misc.md
@@ -65,9 +65,9 @@ T *Nan::GetIsolateData(v8::Isolate *isolate)
 <a name="api_nan_typedarray_contents"></a>
 ### Nan::TypedArrayContents<T>
 
-A helper class for accessing the contents of an ArrayBufferView (aka a typedarray) from C++.  If the input array is not a valid typedarray, then the data pointer of TypedArrayContents will default to `NULL`.
+A helper class for accessing the contents of an ArrayBufferView (aka a typedarray) from C++.  If the input array is not a valid typedarray, then the data pointer of TypedArrayContents will default to `NULL` and the length will be 0.  If the data pointer is not compatible with the alignment requirements of type, an assertion error will fail.
 
-Note that you must store a pointer to the `array` object while you are accessing the contents of the typedarray object.
+Note that you must store a pointer to the `array` object while you are accessing the contents of the typedarray object using this interface.
 
 Definition:
 
@@ -79,7 +79,7 @@ class Nan::TypedArrayContents {
 
   int length() const;
 
-  T* operator*();
-  const T* operator*() const;
+  T* const operator*();
+  const T* const operator*() const;
 };
 ```

--- a/nan.h
+++ b/nan.h
@@ -2131,6 +2131,11 @@ struct Tap {
 
 #undef TYPE_CHECK
 
+
+//=== TypedArrayContents =======================================================
+
+#include "nan_typedarray_contents.h"  // NOLINT(build/include)
+
 }  // end of namespace Nan
 
 #endif  // NAN_H_

--- a/nan_typedarray_contents.h
+++ b/nan_typedarray_contents.h
@@ -70,8 +70,8 @@ class TypedArrayContents {
   }
 
   NAN_INLINE size_t length() const            { return length_; }
-  NAN_INLINE T* const operator*()             { return data_;   }
-  NAN_INLINE const T* const operator*() const { return data_;   }
+  NAN_INLINE T* operator*()             { return data_;   }
+  NAN_INLINE const T* operator*() const { return data_;   }
 
  private:
   NAN_DISALLOW_ASSIGN_COPY_MOVE(TypedArrayContents)

--- a/nan_typedarray_contents.h
+++ b/nan_typedarray_contents.h
@@ -58,7 +58,17 @@ class TypedArrayContents {
 
 #endif
 
+
+#if defined(_MSC_VER)
+    assert(reinterpret_cast<uintptr_t>(data_) % __alignof(T) == 0);
+#elif defined(__GNUC__)
+    assert(reinterpret_cast<uintptr_t>(data_) % __alignof__(T) == 0);
+#elif NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION
+    assert(reinterpret_cast<uintptr_t>(data_) % alignof(T) == 0);
+#else
     assert(reinterpret_cast<uintptr_t>(data_) % sizeof(T) == 0);
+#endif
+
   }
 
   NAN_INLINE size_t length() const            { return length_; }

--- a/nan_typedarray_contents.h
+++ b/nan_typedarray_contents.h
@@ -32,7 +32,7 @@ class TypedArrayContents {
       data_   = reinterpret_cast<T*>(data + byte_offset);
     }
 
-#elif NODE_MODULE_VERSION >= NODE_0_8_MODULE_VERSION
+#else
 
     if (from->IsObject() && !from->IsNull()) {
 
@@ -56,18 +56,9 @@ class TypedArrayContents {
       }
     }
 
-#else
-
-    //TypedArrays not supported on node < 0.8
-    assert(false);
-
 #endif
 
-#if NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION
-    assert(reinterpret_cast<uintptr_t>(data_) % alignof(T) == 0);
-#else
     assert(reinterpret_cast<uintptr_t>(data_) % sizeof(T) == 0);
-#endif
   }
 
   NAN_INLINE size_t length() const            { return length_; }

--- a/nan_typedarray_contents.h
+++ b/nan_typedarray_contents.h
@@ -1,0 +1,82 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#ifndef NAN_TYPEDARRAY_CONTENTS_H_
+#define NAN_TYPEDARRAY_CONTENTS_H_
+
+template<typename T>
+class TypedArrayContents {
+ public:
+  NAN_INLINE explicit TypedArrayContents(v8::Local<v8::Value> from) :
+      length_(0), data_(NULL) {
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+
+    if(from->IsArrayBufferView()) {
+      v8::Local<v8::ArrayBufferView> array =
+        v8::Local<v8::ArrayBufferView>::Cast(from);
+
+      int byteLength = array->ByteLength();
+      int byteOffset = array->ByteOffset();
+      v8::Local<v8::ArrayBuffer> buffer = array->Buffer();
+
+      void* data = buffer->GetContents().Data();
+      length_ = byteLength / sizeof(T);
+      data_   = (T*)((void*)((char*)data + byteOffset));
+    }
+
+#elif NODE_MODULE_VERSION >= NODE_0_8_MODULE_VERSION
+
+    if (from->IsObject() && !from->IsNull()) {
+
+      v8::Local<v8::Object> array = v8::Local<v8::Object>::Cast(from);
+
+      v8::Local<v8::Value> byteLength = array->Get(
+        Nan::New<v8::String>("byteLength").ToLocalChecked());
+      v8::Local<v8::Value> byteOffset = array->Get(
+        Nan::New<v8::String>("byteOffset").ToLocalChecked());
+
+      if(byteLength->IsUint32() && byteOffset->IsUint32()) {
+
+        unsigned int length = byteLength->Uint32Value();
+        void* data = array->GetIndexedPropertiesExternalArrayData();
+
+        if(data) {
+          length_ = length / sizeof(T);
+          data_   = (T*)((void*)((char*)data));
+        }
+      }
+    }
+
+#endif
+  }
+
+  NAN_INLINE int length() const         { return length_; }
+  NAN_INLINE T* operator*()             { return data_;   }
+  NAN_INLINE const T* operator*() const { return data_;   }
+
+ private:
+   int  length_;
+   T*   data_;
+};
+
+#endif  // NAN_TYPEDARRAY_CONTENTS_H_

--- a/nan_typedarray_contents.h
+++ b/nan_typedarray_contents.h
@@ -56,6 +56,11 @@ class TypedArrayContents {
       }
     }
 
+#else
+
+    //TypedArrays not supported on node < 0.8
+    assert(false);
+
 #endif
 
 #if NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION

--- a/nan_typedarray_contents.h
+++ b/nan_typedarray_contents.h
@@ -1,23 +1,10 @@
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
 
 #ifndef NAN_TYPEDARRAY_CONTENTS_H_
 #define NAN_TYPEDARRAY_CONTENTS_H_
@@ -31,17 +18,18 @@ class TypedArrayContents {
 #if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
   (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
 
-    if(from->IsArrayBufferView()) {
+    if (from->IsArrayBufferView()) {
       v8::Local<v8::ArrayBufferView> array =
         v8::Local<v8::ArrayBufferView>::Cast(from);
 
-      int byteLength = array->ByteLength();
-      int byteOffset = array->ByteOffset();
+      const size_t    byteLength = array->ByteLength();
+      const ptrdiff_t byteOffset = array->ByteOffset();
       v8::Local<v8::ArrayBuffer> buffer = array->Buffer();
 
-      void* data = buffer->GetContents().Data();
+      char* data = reinterpret_cast<char*>(buffer->GetContents().Data());
+
       length_ = byteLength / sizeof(T);
-      data_   = (T*)((void*)((char*)data + byteOffset));
+      data_   = reinterpret_cast<T*>(data + byteOffset);
     }
 
 #elif NODE_MODULE_VERSION >= NODE_0_8_MODULE_VERSION
@@ -50,19 +38,20 @@ class TypedArrayContents {
 
       v8::Local<v8::Object> array = v8::Local<v8::Object>::Cast(from);
 
-      v8::Local<v8::Value> byteLength = array->Get(
+      MaybeLocal<v8::Value> byteLength = Get(array,
         Nan::New<v8::String>("byteLength").ToLocalChecked());
-      v8::Local<v8::Value> byteOffset = array->Get(
+      MaybeLocal<v8::Value> byteOffset = Get(array,
         Nan::New<v8::String>("byteOffset").ToLocalChecked());
 
-      if(byteLength->IsUint32() && byteOffset->IsUint32()) {
+      if (!byteLength.IsEmpty() && byteLength.ToLocalChecked()->IsUint32() &&
+          !byteOffset.IsEmpty() && byteOffset.ToLocalChecked()->IsUint32()) {
 
-        unsigned int length = byteLength->Uint32Value();
+        const size_t length = byteLength.ToLocalChecked()->Uint32Value();
         void* data = array->GetIndexedPropertiesExternalArrayData();
 
-        if(data) {
+        if (data) {
           length_ = length / sizeof(T);
-          data_   = (T*)((void*)((char*)data));
+          data_   = reinterpret_cast<T*>(data);
         }
       }
     }
@@ -70,13 +59,19 @@ class TypedArrayContents {
 #endif
   }
 
-  NAN_INLINE int length() const         { return length_; }
-  NAN_INLINE T* operator*()             { return data_;   }
-  NAN_INLINE const T* operator*() const { return data_;   }
+  NAN_INLINE size_t length() const            { return length_; }
+  NAN_INLINE T* const operator*()             { return data_;   }
+  NAN_INLINE const T* const operator*() const { return data_;   }
 
  private:
-   int  length_;
-   T*   data_;
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(TypedArrayContents)
+
+  //Disable heap allocation
+  void *operator new(size_t size);
+  void operator delete(void *, size_t);
+
+  size_t  length_;
+  T*      data_;
 };
 
 #endif  // NAN_TYPEDARRAY_CONTENTS_H_

--- a/nan_typedarray_contents.h
+++ b/nan_typedarray_contents.h
@@ -38,12 +38,15 @@ class TypedArrayContents {
     if (from->IsObject() && !from->IsNull()) {
       v8::Local<v8::Object> array = v8::Local<v8::Object>::Cast(from);
 
+      MaybeLocal<v8::Value> buffer = Get(array,
+        New<v8::String>("buffer").ToLocalChecked());
       MaybeLocal<v8::Value> byte_length = Get(array,
         New<v8::String>("byteLength").ToLocalChecked());
       MaybeLocal<v8::Value> byte_offset = Get(array,
         New<v8::String>("byteOffset").ToLocalChecked());
 
-      if (!byte_length.IsEmpty() && byte_length.ToLocalChecked()->IsUint32() &&
+      if (!buffer.IsEmpty() &&
+          !byte_length.IsEmpty() && byte_length.ToLocalChecked()->IsUint32() &&
           !byte_offset.IsEmpty() && byte_offset.ToLocalChecked()->IsUint32()) {
         data = array->GetIndexedPropertiesExternalArrayData();
         if(data) {

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -132,4 +132,8 @@
         "target_name" : "trycatch"
       , "sources"     : [ "cpp/trycatch.cpp" ]
     }
+    , {
+        "target_name" : "typedarrays"
+      , "sources"     : [ "cpp/typedarrays.cpp" ]
+    }
 ]}

--- a/test/cpp/typedarrays.cpp
+++ b/test/cpp/typedarrays.cpp
@@ -13,50 +13,48 @@
 using namespace Nan;  // NOLINT(build/namespaces)
 
 NAN_METHOD(ReadU8) {
-  Nan::TypedArrayContents<uint8_t> data(info[0]);
+  TypedArrayContents<uint8_t> data(info[0]);
 
-  v8::Local<v8::Array> result = Nan::New<v8::Array>(data.length());
-  for (size_t i=0; i<data.length(); ++i) {
-    Nan::Set(result, i, Nan::New<v8::Number>((*data)[i]));
+  v8::Local<v8::Array> result = New<v8::Array>(data.length());
+  for (size_t i=0; i<data.length(); i++) {
+    Set(result, i, New<v8::Number>((*data)[i]));
   }
 
   info.GetReturnValue().Set(result);
 }
 
 NAN_METHOD(ReadI32) {
-  Nan::TypedArrayContents<int32_t> data(info[0]);
+  TypedArrayContents<int32_t> data(info[0]);
 
-  v8::Local<v8::Array> result = Nan::New<v8::Array>(data.length());
-  for (size_t i=0; i<data.length(); ++i) {
-    Nan::Set(result, i, Nan::New<v8::Number>((*data)[i]));
+  v8::Local<v8::Array> result = New<v8::Array>(data.length());
+  for (size_t i=0; i<data.length(); i++) {
+    Set(result, i, New<v8::Number>((*data)[i]));
   }
 
   info.GetReturnValue().Set(result);
 }
 
-
 NAN_METHOD(ReadFloat) {
-  Nan::TypedArrayContents<float> data(info[0]);
+  TypedArrayContents<float> data(info[0]);
 
-  v8::Local<v8::Array> result = Nan::New<v8::Array>(data.length());
-  for (size_t i=0; i<data.length(); ++i) {
-    Nan::Set(result, i, Nan::New<v8::Number>((*data)[i]));
+  v8::Local<v8::Array> result = New<v8::Array>(data.length());\
+  for (size_t i=0; i<data.length(); i++) {
+    Set(result, i, New<v8::Number>((*data)[i]));
   }
 
   info.GetReturnValue().Set(result);
 }
 
 NAN_METHOD(ReadDouble) {
-  Nan::TypedArrayContents<double> data(info[0]);
+  TypedArrayContents<double> data(info[0]);
 
-  v8::Local<v8::Array> result = Nan::New<v8::Array>(data.length());
-  for (size_t i=0; i<data.length(); ++i) {
-    Nan::Set(result, i, Nan::New<v8::Number>((*data)[i]));
+  v8::Local<v8::Array> result = New<v8::Array>(data.length());
+  for (size_t i=0; i<data.length(); i++) {
+    Set(result, i, New<v8::Number>((*data)[i]));
   }
 
   info.GetReturnValue().Set(result);
 }
-
 
 NAN_MODULE_INIT(Init) {
   NAN_EXPORT(target, ReadU8);

--- a/test/cpp/typedarrays.cpp
+++ b/test/cpp/typedarrays.cpp
@@ -16,8 +16,8 @@ NAN_METHOD(ReadU8) {
   Nan::TypedArrayContents<uint8_t> data(info[0]);
 
   v8::Local<v8::Array> result = Nan::New<v8::Array>(data.length());
-  for (int i=0; i<data.length(); ++i) {
-    result->Set(i, Nan::New<v8::Number>((*data)[i]));
+  for (size_t i=0; i<data.length(); ++i) {
+    Nan::Set(result, i, Nan::New<v8::Number>((*data)[i]));
   }
 
   info.GetReturnValue().Set(result);
@@ -27,8 +27,8 @@ NAN_METHOD(ReadI32) {
   Nan::TypedArrayContents<int32_t> data(info[0]);
 
   v8::Local<v8::Array> result = Nan::New<v8::Array>(data.length());
-  for (int i=0; i<data.length(); ++i) {
-    result->Set(i, Nan::New<v8::Number>((*data)[i]));
+  for (size_t i=0; i<data.length(); ++i) {
+    Nan::Set(result, i, Nan::New<v8::Number>((*data)[i]));
   }
 
   info.GetReturnValue().Set(result);
@@ -39,8 +39,8 @@ NAN_METHOD(ReadFloat) {
   Nan::TypedArrayContents<float> data(info[0]);
 
   v8::Local<v8::Array> result = Nan::New<v8::Array>(data.length());
-  for (int i=0; i<data.length(); ++i) {
-    result->Set(i, Nan::New<v8::Number>((*data)[i]));
+  for (size_t i=0; i<data.length(); ++i) {
+    Nan::Set(result, i, Nan::New<v8::Number>((*data)[i]));
   }
 
   info.GetReturnValue().Set(result);
@@ -50,8 +50,8 @@ NAN_METHOD(ReadDouble) {
   Nan::TypedArrayContents<double> data(info[0]);
 
   v8::Local<v8::Array> result = Nan::New<v8::Array>(data.length());
-  for (int i=0; i<data.length(); ++i) {
-    result->Set(i, Nan::New<v8::Number>((*data)[i]));
+  for (size_t i=0; i<data.length(); ++i) {
+    Nan::Set(result, i, Nan::New<v8::Number>((*data)[i]));
   }
 
   info.GetReturnValue().Set(result);

--- a/test/cpp/typedarrays.cpp
+++ b/test/cpp/typedarrays.cpp
@@ -1,0 +1,68 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#include <nan.h>
+
+#include <stdint.h>
+
+using namespace Nan;  // NOLINT(build/namespaces)
+
+NAN_METHOD(ReadU8) {
+  Nan::TypedArrayContents<uint8_t> data(info[0]);
+
+  v8::Local<v8::Array> result = Nan::New<v8::Array>(data.length());
+  for (int i=0; i<data.length(); ++i) {
+    result->Set(i, Nan::New<v8::Number>((*data)[i]));
+  }
+
+  info.GetReturnValue().Set(result);
+}
+
+NAN_METHOD(ReadI32) {
+  Nan::TypedArrayContents<int32_t> data(info[0]);
+
+  v8::Local<v8::Array> result = Nan::New<v8::Array>(data.length());
+  for (int i=0; i<data.length(); ++i) {
+    result->Set(i, Nan::New<v8::Number>((*data)[i]));
+  }
+
+  info.GetReturnValue().Set(result);
+}
+
+
+NAN_METHOD(ReadFloat) {
+  Nan::TypedArrayContents<float> data(info[0]);
+
+  v8::Local<v8::Array> result = Nan::New<v8::Array>(data.length());
+  for (int i=0; i<data.length(); ++i) {
+    result->Set(i, Nan::New<v8::Number>((*data)[i]));
+  }
+
+  info.GetReturnValue().Set(result);
+}
+
+NAN_METHOD(ReadDouble) {
+  Nan::TypedArrayContents<double> data(info[0]);
+
+  v8::Local<v8::Array> result = Nan::New<v8::Array>(data.length());
+  for (int i=0; i<data.length(); ++i) {
+    result->Set(i, Nan::New<v8::Number>((*data)[i]));
+  }
+
+  info.GetReturnValue().Set(result);
+}
+
+
+NAN_MODULE_INIT(Init) {
+  NAN_EXPORT(target, ReadU8);
+  NAN_EXPORT(target, ReadI32);
+  NAN_EXPORT(target, ReadFloat);
+  NAN_EXPORT(target, ReadDouble);
+}
+
+NODE_MODULE(typedarrays, Init)

--- a/test/js/typedarrays-test.js
+++ b/test/js/typedarrays-test.js
@@ -10,6 +10,13 @@ test('typedarrays - simple cases', function (t) {
 
   } else {
 
+    var zeros = new Uint8Array(5)
+    t.same(bindings.ReadU8(zeros), [0,0,0,0,0])
+
+    var y = zeros[0]
+    t.equals(y, 0)
+    t.same(bindings.ReadU8(zeros), [0,0,0,0,0])
+
     var u8array = new Uint8Array([1, 255, 3]);
     t.same(bindings.ReadU8(u8array), [1, 255, 3]);
     t.same(bindings.ReadU8(u8array.subarray(1)), [255, 3]);

--- a/test/js/typedarrays-test.js
+++ b/test/js/typedarrays-test.js
@@ -1,0 +1,64 @@
+const test     = require('tap').test
+    , testRoot = require('path').resolve(__dirname, '..')
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'typedarrays' });
+
+test('typedarrays - simple cases', function (t) {
+  if(typeof Uint8Array === 'object') {
+    t.pass('typedarrays not supported');
+    t.end();
+  } else {
+
+    var u8array = new Uint8Array([1, 255, 3]);
+    t.same(bindings.ReadU8(u8array), [1, 255, 3]);
+    t.same(bindings.ReadU8(u8array.subarray(1)), [255, 3]);
+    t.same(bindings.ReadU8(u8array.subarray(0, 2)), [1, 255]);
+    t.same(bindings.ReadU8(u8array.subarray(1, 2)), [255]);
+
+    t.same(bindings.ReadU8(new Uint8Array(u8array)), [1, 255, 3]);
+    t.same(bindings.ReadU8(new Uint8Array(u8array.subarray(1))), [255, 3]);
+    t.same(bindings.ReadU8(new Uint8Array(u8array.subarray(0, 2))), [1, 255]);
+    t.same(bindings.ReadU8(new Uint8Array(u8array.subarray(1, 2))), [255]);
+
+    t.same(bindings.ReadU8((new Uint8Array(u8array.buffer)).subarray(1)), [255, 3]);
+
+
+    var i32array = new Int32Array([0, 1, -1, 1073741824, -1073741824]);
+    t.same(bindings.ReadI32(i32array), [0, 1, -1, 1073741824, -1073741824]);
+
+    var f32array = new Float32Array([1, -1, Infinity, -Infinity, 0, +0, -0]);
+    t.same(bindings.ReadFloat(f32array), [1, -1, Infinity, -Infinity, 0, +0, -0]);
+    t.same(bindings.ReadFloat(f32array.subarray(1)), [-1, Infinity, -Infinity, 0, +0, -0]);
+    t.same(bindings.ReadFloat(f32array.subarray(0,4)), [1, -1, Infinity, -Infinity]);
+    t.same(bindings.ReadFloat(f32array.subarray(1,3)), [-1, Infinity]);
+
+    t.end();
+  }
+});
+
+test('typedarrays - bad arguments', function (t) {
+  if(typeof Uint8Array === 'object') {
+    t.same(bindings.ReadU8(new Buffer(10)), []);
+
+    t.end();
+  } else {
+
+    t.same(bindings.ReadU8(0), []);
+    t.same(bindings.ReadU8(1), []);
+    t.same(bindings.ReadU8(null), []);
+    t.same(bindings.ReadU8(), []);
+    t.same(bindings.ReadU8('foobar'), []);
+    t.same(bindings.ReadU8([]), []);
+    t.same(bindings.ReadU8([1,2]), []);
+    t.same(bindings.ReadU8({}), []);
+    t.same(bindings.ReadU8(Uint8Array), []);
+    t.same(bindings.ReadU8(new Float32Array(0)), []);
+
+    t.same(bindings.ReadU8({
+      byteLength: 10000000,
+      byteOffset: 100000,
+      buffer: null
+    }), [])
+
+    t.end();
+  }
+});

--- a/test/js/typedarrays-test.js
+++ b/test/js/typedarrays-test.js
@@ -3,9 +3,11 @@ const test     = require('tap').test
     , bindings = require('bindings')({ module_root: testRoot, bindings: 'typedarrays' });
 
 test('typedarrays - simple cases', function (t) {
-  if (typeof Uint8Array === 'object') {
+  if (typeof Uint8Array !== 'function') {
+
     t.pass('typedarrays not supported');
     t.end();
+
   } else {
 
     var u8array = new Uint8Array([1, 255, 3]);
@@ -36,10 +38,11 @@ test('typedarrays - simple cases', function (t) {
 });
 
 test('typedarrays - bad arguments', function (t) {
-  if (typeof Uint8Array === 'object') {
-    t.same(bindings.ReadU8(new Buffer(10)), []);
+  if (typeof Uint8Array !== 'function') {
 
+    t.pass('typedarrays not supported');
     t.end();
+
   } else {
 
     t.same(bindings.ReadU8(0), []);

--- a/test/js/typedarrays-test.js
+++ b/test/js/typedarrays-test.js
@@ -3,7 +3,7 @@ const test     = require('tap').test
     , bindings = require('bindings')({ module_root: testRoot, bindings: 'typedarrays' });
 
 test('typedarrays - simple cases', function (t) {
-  if(typeof Uint8Array === 'object') {
+  if (typeof Uint8Array === 'object') {
     t.pass('typedarrays not supported');
     t.end();
   } else {
@@ -36,7 +36,7 @@ test('typedarrays - simple cases', function (t) {
 });
 
 test('typedarrays - bad arguments', function (t) {
-  if(typeof Uint8Array === 'object') {
+  if (typeof Uint8Array === 'object') {
     t.same(bindings.ReadU8(new Buffer(10)), []);
 
     t.end();


### PR DESCRIPTION
This PR adds a portable helper method for reading the contents of a typedarray (ArrayBufferView) from C++, fixing https://github.com/nodejs/nan/issues/455.

I tried to follow the API conventions from `Utf8String` for this module closely.  Note that this does not make a copy of the typedarray data or hold a reference to the underlying array object, so it would require the user to know what they are doing and not try to access these bytes outside the natural lifetime of the object.