### PR TITLE
Allow Value as target for function calls

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -806,17 +806,23 @@ class TryCatch {
     , int argc
     , v8::Local<v8::Value>* argv) {
 #if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
-    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
-        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
-            target->ToObject();
+    v8::Local<v8::Object> target_obj;
+    if (target->IsUndefined() || target->IsNull()) {
+      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+    } else {
+      target_obj = target->ToObject();
+    }
     return New(node::MakeCallback(
-        v8::Isolate::GetCurrent(), target_, func, argc, argv));
+        v8::Isolate::GetCurrent(), target_obj, func, argc, argv));
 #else
-    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
-        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
-            Nan::To<v8::Object>(target).ToLocalChecked();
+    v8::Local<v8::Object> target_obj;
+    if (target->IsUndefined() || target->IsNull()) {
+      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+    } else {
+      target_obj = Nan::To<v8::Object>(target).ToLocalChecked();
+    }
     return node::MakeCallback(
-        v8::Isolate::GetCurrent(), target_, func, argc, argv);
+        v8::Isolate::GetCurrent(), target_obj, func, argc, argv);
 #endif
   }
 
@@ -826,17 +832,23 @@ class TryCatch {
     , int argc
     , v8::Local<v8::Value>* argv) {
 #if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
-    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
-        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
-            target->ToObject();
+    v8::Local<v8::Object> target_obj;
+    if (target->IsUndefined() || target->IsNull()) {
+      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+    } else {
+      target_obj = target->ToObject();
+    }
     return New(node::MakeCallback(
-        v8::Isolate::GetCurrent(), target_, symbol, argc, argv));
+        v8::Isolate::GetCurrent(), target_obj, symbol, argc, argv));
 #else
-    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
-        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
-            Nan::To<v8::Object>(target).ToLocalChecked();
+    v8::Local<v8::Object> target_obj;
+    if (target->IsUndefined() || target->IsNull()) {
+      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+    } else {
+      target_obj = Nan::To<v8::Object>(target).ToLocalChecked();
+    }
     return node::MakeCallback(
-        v8::Isolate::GetCurrent(), target_, symbol, argc, argv);
+        v8::Isolate::GetCurrent(), target_obj, symbol, argc, argv);
 #endif
   }
 
@@ -846,17 +858,23 @@ class TryCatch {
     , int argc
     , v8::Local<v8::Value>* argv) {
 #if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
-    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
-        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
-            target->ToObject();
+    v8::Local<v8::Object> target_obj;
+    if (target->IsUndefined() || target->IsNull()) {
+      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+    } else {
+      target_obj = target->ToObject();
+    }
     return New(node::MakeCallback(
-        v8::Isolate::GetCurrent(), target_, method, argc, argv));
+        v8::Isolate::GetCurrent(), target_obj, method, argc, argv));
 #else
-    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
-        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
-            Nan::To<v8::Object>(target).ToLocalChecked();
+    v8::Local<v8::Object> target_obj;
+    if (target->IsUndefined() || target->IsNull()) {
+      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+    } else {
+      target_obj = Nan::To<v8::Object>(target).ToLocalChecked();
+    }
     return node::MakeCallback(
-        v8::Isolate::GetCurrent(), target_, method, argc, argv);
+        v8::Isolate::GetCurrent(), target_obj, method, argc, argv);
 #endif
   }
 
@@ -1160,10 +1178,13 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
     , v8::Local<v8::Function> func
     , int argc
     , v8::Local<v8::Value>* argv) {
-    v8::Local<v8::Object> target_ =
-        target->IsUndefined() || target->IsNull() ?
-            v8::Context::GetCurrent()->Global() : target->ToObject();
-    return New(node::MakeCallback(target_, func, argc, argv));
+    v8::Local<v8::Object> target_obj;
+    if (target->IsUndefined() || target->IsNull()) {
+      target_obj = v8::Context::GetCurrent()->Global();
+    } else {
+      target_obj = target->ToObject();
+    }
+    return New(node::MakeCallback(target_obj, func, argc, argv));
   }
 
   NAN_INLINE v8::Local<v8::Value> MakeCallback(
@@ -1171,10 +1192,13 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
     , v8::Local<v8::String> symbol
     , int argc
     , v8::Local<v8::Value>* argv) {
-    v8::Local<v8::Object> target_ =
-        target->IsUndefined() || target->IsNull() ?
-            v8::Context::GetCurrent()->Global() : target->ToObject();
-    return New(node::MakeCallback(target_, symbol, argc, argv));
+    v8::Local<v8::Object> target_obj;
+    if (target->IsUndefined() || target->IsNull()) {
+      target_obj = v8::Context::GetCurrent()->Global();
+    } else {
+      target_obj = target->ToObject();
+    }
+    return New(node::MakeCallback(target_obj, symbol, argc, argv));
   }
 
   NAN_INLINE v8::Local<v8::Value> MakeCallback(
@@ -1182,10 +1206,13 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
     , const char* method
     , int argc
     , v8::Local<v8::Value>* argv) {
-    v8::Local<v8::Object> target_ =
-        target->IsUndefined() || target->IsNull() ?
-            v8::Context::GetCurrent()->Global() : target->ToObject();
-    return New(node::MakeCallback(target_, method, argc, argv));
+    v8::Local<v8::Object> target_obj;
+    if (target->IsUndefined() || target->IsNull()) {
+      target_obj = v8::Context::GetCurrent()->Global();
+    } else {
+      target_obj = target->ToObject();
+    }
+    return New(node::MakeCallback(target_obj, method, argc, argv));
   }
 
   NAN_INLINE void FatalException(const TryCatch& try_catch) {
@@ -1469,23 +1496,29 @@ class Callback {
     v8::Local<v8::Function> callback = New(handle)->
         Get(kCallbackIndex).As<v8::Function>();
 # if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
-    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
-        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
-            target->ToObject();
+    v8::Local<v8::Object> target_obj;
+    if (target->IsUndefined() || target->IsNull()) {
+      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+    } else {
+      target_obj = target->ToObject();
+    }
     return scope.Escape(New(node::MakeCallback(
         isolate
-      , target_
+      , target_obj
       , callback
       , argc
       , argv
     )));
 # else
-    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
-        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
-            Nan::To<v8::Object>(target).ToLocalChecked();
+    v8::Local<v8::Object> target_obj;
+    if (target->IsUndefined() || target->IsNull()) {
+      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+    } else {
+      target_obj = Nan::To<v8::Object>(target).ToLocalChecked();
+    }
     return scope.Escape(node::MakeCallback(
         isolate
-      , target_
+      , target_obj
       , callback
       , argc
       , argv
@@ -1498,12 +1531,16 @@ class Callback {
                            , v8::Local<v8::Value> argv[]) const {
     EscapableHandleScope scope;
 
-    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
-        v8::Context::GetCurrent()->Global() : target->ToObject();
+    v8::Local<v8::Object> target_obj;
+    if (target->IsUndefined() || target->IsNull()) {
+      target_obj = v8::Context::GetCurrent()->Global();
+    } else {
+      target_obj = target->ToObject();
+    }
     v8::Local<v8::Function> callback = New(handle)->
         Get(kCallbackIndex).As<v8::Function>();
     return scope.Escape(New(node::MakeCallback(
-        target_
+        target_obj
       , callback
       , argc
       , argv

--- a/nan.h
+++ b/nan.h
@@ -801,44 +801,62 @@ class TryCatch {
 #endif
 
   NAN_INLINE v8::Local<v8::Value> MakeCallback(
-      v8::Local<v8::Object> target
+      v8::Local<v8::Value> target
     , v8::Local<v8::Function> func
     , int argc
     , v8::Local<v8::Value>* argv) {
 #if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
+        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
+            target->ToObject();
     return New(node::MakeCallback(
-        v8::Isolate::GetCurrent(), target, func, argc, argv));
+        v8::Isolate::GetCurrent(), target_, func, argc, argv));
 #else
+    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
+        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
+            Nan::To<v8::Object>(target).ToLocalChecked();
     return node::MakeCallback(
-        v8::Isolate::GetCurrent(), target, func, argc, argv);
+        v8::Isolate::GetCurrent(), target_, func, argc, argv);
 #endif
   }
 
   NAN_INLINE v8::Local<v8::Value> MakeCallback(
-      v8::Local<v8::Object> target
+      v8::Local<v8::Value> target
     , v8::Local<v8::String> symbol
     , int argc
     , v8::Local<v8::Value>* argv) {
 #if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
+        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
+            target->ToObject();
     return New(node::MakeCallback(
-        v8::Isolate::GetCurrent(), target, symbol, argc, argv));
+        v8::Isolate::GetCurrent(), target_, symbol, argc, argv));
 #else
+    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
+        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
+            Nan::To<v8::Object>(target).ToLocalChecked();
     return node::MakeCallback(
-        v8::Isolate::GetCurrent(), target, symbol, argc, argv);
+        v8::Isolate::GetCurrent(), target_, symbol, argc, argv);
 #endif
   }
 
   NAN_INLINE v8::Local<v8::Value> MakeCallback(
-      v8::Local<v8::Object> target
+      v8::Local<v8::Value> target
     , const char* method
     , int argc
     , v8::Local<v8::Value>* argv) {
 #if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
+        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
+            target->ToObject();
     return New(node::MakeCallback(
-        v8::Isolate::GetCurrent(), target, method, argc, argv));
+        v8::Isolate::GetCurrent(), target_, method, argc, argv));
 #else
+    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
+        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
+            Nan::To<v8::Object>(target).ToLocalChecked();
     return node::MakeCallback(
-        v8::Isolate::GetCurrent(), target, method, argc, argv);
+        v8::Isolate::GetCurrent(), target_, method, argc, argv);
 #endif
   }
 
@@ -1138,27 +1156,36 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
   }
 
   NAN_INLINE v8::Local<v8::Value> MakeCallback(
-      v8::Local<v8::Object> target
+      v8::Local<v8::Value> target
     , v8::Local<v8::Function> func
     , int argc
     , v8::Local<v8::Value>* argv) {
-    return New(node::MakeCallback(target, func, argc, argv));
+    v8::Local<v8::Object> target_ =
+        target->IsUndefined() || target->IsNull() ?
+            v8::Context::GetCurrent()->Global() : target->ToObject();
+    return New(node::MakeCallback(target_, func, argc, argv));
   }
 
   NAN_INLINE v8::Local<v8::Value> MakeCallback(
-      v8::Local<v8::Object> target
+      v8::Local<v8::Value> target
     , v8::Local<v8::String> symbol
     , int argc
     , v8::Local<v8::Value>* argv) {
-    return New(node::MakeCallback(target, symbol, argc, argv));
+    v8::Local<v8::Object> target_ =
+        target->IsUndefined() || target->IsNull() ?
+            v8::Context::GetCurrent()->Global() : target->ToObject();
+    return New(node::MakeCallback(target_, symbol, argc, argv));
   }
 
   NAN_INLINE v8::Local<v8::Value> MakeCallback(
-      v8::Local<v8::Object> target
+      v8::Local<v8::Value> target
     , const char* method
     , int argc
     , v8::Local<v8::Value>* argv) {
-    return New(node::MakeCallback(target, method, argc, argv));
+    v8::Local<v8::Object> target_ =
+        target->IsUndefined() || target->IsNull() ?
+            v8::Context::GetCurrent()->Global() : target->ToObject();
+    return New(node::MakeCallback(target_, method, argc, argv));
   }
 
   NAN_INLINE void FatalException(const TryCatch& try_catch) {
@@ -1377,7 +1404,7 @@ class Callback {
   v8::Local<v8::Function> operator*() const { return this->GetFunction(); }
 
   NAN_INLINE v8::Local<v8::Value> operator()(
-      v8::Local<v8::Object> target
+      v8::Local<v8::Value> target
     , int argc = 0
     , v8::Local<v8::Value> argv[] = 0) const {
     return this->Call(target, argc, argv);
@@ -1406,7 +1433,7 @@ class Callback {
   }
 
   NAN_INLINE v8::Local<v8::Value>
-  Call(v8::Local<v8::Object> target
+  Call(v8::Local<v8::Value> target
      , int argc
      , v8::Local<v8::Value> argv[]) const {
 #if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
@@ -1434,7 +1461,7 @@ class Callback {
 
 #if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
   v8::Local<v8::Value> Call_(v8::Isolate *isolate
-                           , v8::Local<v8::Object> target
+                           , v8::Local<v8::Value> target
                            , int argc
                            , v8::Local<v8::Value> argv[]) const {
     EscapableHandleScope scope;
@@ -1442,17 +1469,23 @@ class Callback {
     v8::Local<v8::Function> callback = New(handle)->
         Get(kCallbackIndex).As<v8::Function>();
 # if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
+        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
+            target->ToObject();
     return scope.Escape(New(node::MakeCallback(
         isolate
-      , target
+      , target_
       , callback
       , argc
       , argv
     )));
 # else
+    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
+        v8::Isolate::GetCurrent()->GetCurrentContext()->Global() :
+            Nan::To<v8::Object>(target).ToLocalChecked();
     return scope.Escape(node::MakeCallback(
         isolate
-      , target
+      , target_
       , callback
       , argc
       , argv
@@ -1460,15 +1493,17 @@ class Callback {
 # endif
   }
 #else
-  v8::Local<v8::Value> Call_(v8::Local<v8::Object> target
+  v8::Local<v8::Value> Call_(v8::Local<v8::Value> target
                            , int argc
                            , v8::Local<v8::Value> argv[]) const {
     EscapableHandleScope scope;
 
+    v8::Local<v8::Object> target_ = target->IsUndefined() || target->IsNull() ?
+        v8::Context::GetCurrent()->Global() : target->ToObject();
     v8::Local<v8::Function> callback = New(handle)->
         Get(kCallbackIndex).As<v8::Function>();
     return scope.Escape(New(node::MakeCallback(
-        target
+        target_
       , callback
       , argc
       , argv

--- a/nan.h
+++ b/nan.h
@@ -805,24 +805,25 @@ class TryCatch {
     , v8::Local<v8::Function> func
     , int argc
     , v8::Local<v8::Value>* argv) {
-#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    v8::Isolate *isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
     v8::Local<v8::Object> target_obj;
+#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
     if (target->IsUndefined() || target->IsNull()) {
-      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+      target_obj = isolate->GetCurrentContext()->Global();
     } else {
       target_obj = target->ToObject();
     }
-    return New(node::MakeCallback(
-        v8::Isolate::GetCurrent(), target_obj, func, argc, argv));
+    return scope.Escape(
+        New(node::MakeCallback(isolate, target_obj, func, argc, argv)));
 #else
-    v8::Local<v8::Object> target_obj;
     if (target->IsUndefined() || target->IsNull()) {
-      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+      target_obj = isolate->GetCurrentContext()->Global();
     } else {
       target_obj = Nan::To<v8::Object>(target).ToLocalChecked();
     }
-    return node::MakeCallback(
-        v8::Isolate::GetCurrent(), target_obj, func, argc, argv);
+    return scope.Escape(
+        node::MakeCallback(isolate, target_obj, func, argc, argv));
 #endif
   }
 
@@ -831,24 +832,25 @@ class TryCatch {
     , v8::Local<v8::String> symbol
     , int argc
     , v8::Local<v8::Value>* argv) {
-#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    v8::Isolate *isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
     v8::Local<v8::Object> target_obj;
+#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
     if (target->IsUndefined() || target->IsNull()) {
-      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+      target_obj = isolate->GetCurrentContext()->Global();
     } else {
       target_obj = target->ToObject();
     }
-    return New(node::MakeCallback(
-        v8::Isolate::GetCurrent(), target_obj, symbol, argc, argv));
+    return scope.Escape(
+        New(node::MakeCallback(isolate, target_obj, symbol, argc, argv)));
 #else
-    v8::Local<v8::Object> target_obj;
     if (target->IsUndefined() || target->IsNull()) {
-      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+      target_obj = isolate->GetCurrentContext()->Global();
     } else {
       target_obj = Nan::To<v8::Object>(target).ToLocalChecked();
     }
-    return node::MakeCallback(
-        v8::Isolate::GetCurrent(), target_obj, symbol, argc, argv);
+    return scope.Escape(
+        node::MakeCallback(isolate, target_obj, symbol, argc, argv));
 #endif
   }
 
@@ -857,24 +859,25 @@ class TryCatch {
     , const char* method
     , int argc
     , v8::Local<v8::Value>* argv) {
-#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
+    v8::Isolate *isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
     v8::Local<v8::Object> target_obj;
+#if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
     if (target->IsUndefined() || target->IsNull()) {
-      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+      target_obj = isolate->GetCurrentContext()->Global();
     } else {
       target_obj = target->ToObject();
     }
-    return New(node::MakeCallback(
-        v8::Isolate::GetCurrent(), target_obj, method, argc, argv));
+    return scope.Escape(
+        New(node::MakeCallback(isolate, target_obj, method, argc, argv)));
 #else
-    v8::Local<v8::Object> target_obj;
     if (target->IsUndefined() || target->IsNull()) {
-      target_obj = v8::Isolate::GetCurrent()->GetCurrentContext()->Global();
+      target_obj = isolate->GetCurrentContext()->Global();
     } else {
       target_obj = Nan::To<v8::Object>(target).ToLocalChecked();
     }
-    return node::MakeCallback(
-        v8::Isolate::GetCurrent(), target_obj, method, argc, argv);
+    return scope.Escape(
+        node::MakeCallback(isolate, target_obj, method, argc, argv));
 #endif
   }
 
@@ -1178,13 +1181,14 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
     , v8::Local<v8::Function> func
     , int argc
     , v8::Local<v8::Value>* argv) {
+    v8::HandleScope scope;
     v8::Local<v8::Object> target_obj;
     if (target->IsUndefined() || target->IsNull()) {
       target_obj = v8::Context::GetCurrent()->Global();
     } else {
       target_obj = target->ToObject();
     }
-    return New(node::MakeCallback(target_obj, func, argc, argv));
+    return scope.Close(New(node::MakeCallback(target_obj, func, argc, argv)));
   }
 
   NAN_INLINE v8::Local<v8::Value> MakeCallback(
@@ -1192,13 +1196,14 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
     , v8::Local<v8::String> symbol
     , int argc
     , v8::Local<v8::Value>* argv) {
+    v8::HandleScope scope;
     v8::Local<v8::Object> target_obj;
     if (target->IsUndefined() || target->IsNull()) {
       target_obj = v8::Context::GetCurrent()->Global();
     } else {
       target_obj = target->ToObject();
     }
-    return New(node::MakeCallback(target_obj, symbol, argc, argv));
+    return scope.Close(New(node::MakeCallback(target_obj, symbol, argc, argv)));
   }
 
   NAN_INLINE v8::Local<v8::Value> MakeCallback(
@@ -1206,13 +1211,14 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
     , const char* method
     , int argc
     , v8::Local<v8::Value>* argv) {
+    v8::HandleScope scope;
     v8::Local<v8::Object> target_obj;
     if (target->IsUndefined() || target->IsNull()) {
       target_obj = v8::Context::GetCurrent()->Global();
     } else {
       target_obj = target->ToObject();
     }
-    return New(node::MakeCallback(target_obj, method, argc, argv));
+    return scope.Close(New(node::MakeCallback(target_obj, method, argc, argv)));
   }
 
   NAN_INLINE void FatalException(const TryCatch& try_catch) {

--- a/nan_maybe_43_inl.h
+++ b/nan_maybe_43_inl.h
@@ -186,7 +186,7 @@ NAN_INLINE MaybeLocal<v8::Value> GetRealNamedProperty(
 
 NAN_INLINE MaybeLocal<v8::Value> CallAsFunction(
     v8::Local<v8::Object> obj
-  , v8::Local<v8::Object> recv
+  , v8::Local<v8::Value> recv
   , int argc
   , v8::Local<v8::Value> argv[]) {
   return obj->CallAsFunction(GetCurrentContext(), recv, argc, argv);

--- a/nan_maybe_pre_43_inl.h
+++ b/nan_maybe_pre_43_inl.h
@@ -262,9 +262,13 @@ NAN_INLINE MaybeLocal<v8::Value> CallAsFunction(
 #if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
   return MaybeLocal<v8::Value>(obj->CallAsFunction(recv, argc, argv));
 #else
-  v8::Local<v8::Object> recv_ = recv->IsUndefined() || recv->IsNull() ?
-      v8::Context::GetCurrent()->Global() : recv->ToObject();
-  return MaybeLocal<v8::Value>(obj->CallAsFunction(recv_, argc, argv));
+  v8::Local<v8::Object> recv_obj;
+  if (recv->IsUndefined() || recv->IsNull()) {
+    recv_obj = v8::Context::GetCurrent()->Global();
+  } else {
+    recv_obj = recv->ToObject();
+  }
+  return MaybeLocal<v8::Value>(obj->CallAsFunction(recv_obj, argc, argv));
 #endif
 }
 

--- a/nan_maybe_pre_43_inl.h
+++ b/nan_maybe_pre_43_inl.h
@@ -256,10 +256,16 @@ NAN_INLINE MaybeLocal<v8::Value> GetRealNamedProperty(
 
 NAN_INLINE MaybeLocal<v8::Value> CallAsFunction(
     v8::Handle<v8::Object> obj
-  , v8::Handle<v8::Object> recv
+  , v8::Handle<v8::Value> recv
   , int argc
   , v8::Handle<v8::Value> argv[]) {
+#if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
   return MaybeLocal<v8::Value>(obj->CallAsFunction(recv, argc, argv));
+#else
+  v8::Local<v8::Object> recv_ = recv->IsUndefined() || recv->IsNull() ?
+      v8::Context::GetCurrent()->Global() : recv->ToObject();
+  return MaybeLocal<v8::Value>(obj->CallAsFunction(recv_, argc, argv));
+#endif
 }
 
 NAN_INLINE MaybeLocal<v8::Value> CallAsConstructor(

--- a/nan_maybe_pre_43_inl.h
+++ b/nan_maybe_pre_43_inl.h
@@ -262,13 +262,15 @@ NAN_INLINE MaybeLocal<v8::Value> CallAsFunction(
 #if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
   return MaybeLocal<v8::Value>(obj->CallAsFunction(recv, argc, argv));
 #else
+  v8::HandleScope scope;
   v8::Local<v8::Object> recv_obj;
   if (recv->IsUndefined() || recv->IsNull()) {
     recv_obj = v8::Context::GetCurrent()->Global();
   } else {
     recv_obj = recv->ToObject();
   }
-  return MaybeLocal<v8::Value>(obj->CallAsFunction(recv_obj, argc, argv));
+  return MaybeLocal<v8::Value>(
+      scope.Close(obj->CallAsFunction(recv_obj, argc, argv)));
 #endif
 }
 

--- a/test/js/converters-test.js
+++ b/test/js/converters-test.js
@@ -11,7 +11,7 @@ const test     = require('tap').test
     , bindings = require('bindings')({ module_root: testRoot, bindings: 'converters' });
 
 test('converters', function (t) {
-  t.plan(28);
+  t.plan(30);
 
   var converters = bindings;
   t.type(converters.toBoolean, 'function');
@@ -33,6 +33,8 @@ test('converters', function (t) {
   t.equal(converters.toString('sol'), 'sol');
   t.equal(converters.toDetailString('sol'), 'sol');
   t.strictDeepEqual(converters.toObject({prop : 'x'}), {prop : 'x'});
+  t.strictDeepEqual(converters.toObject(5), new Number(5));
+  t.type(converters.toObject(5), 'object');
   t.equal(converters.toInteger(12), 12);
   t.equal(converters.toUint32(12), 12);
   t.equal(converters.toInt32(-12), -12);


### PR DESCRIPTION
Fixes #497

R: @bnoordhuis

Also, Node should be fixed to allow `v8::Value` in `node::MakeCallback`.