### PR TITLE
AsyncProgressWorker callback context isolation fix

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1617,40 +1617,40 @@ class Callback {
    public:
     // You could do fancy generics with templates here.
     void Send(const char* data, size_t size) {
-        asyncdata_t* asyncdata = new asyncdata_t;
-        asyncdata->data = new char[size];
-        memcpy(asyncdata->data, data, size);
-        asyncdata->size = size;
-        asyncdata->handle = new uv_async_t;
-        asyncdata->worker = that_;
-        uv_async_init(
-            uv_default_loop()
-            , asyncdata->handle
-            , AsyncProgress_
-        );
-        asyncdata->handle->data = asyncdata;
-        uv_async_send(asyncdata->handle);
+      asyncdata_t* asyncdata = new asyncdata_t;
+      asyncdata->data = new char[size];
+      memcpy(asyncdata->data, data, size);
+      asyncdata->size = size;
+      asyncdata->handle = new uv_async_t;
+      asyncdata->worker = that_;
+      uv_async_init(
+          uv_default_loop()
+        , asyncdata->handle
+        , AsyncProgress_
+      );
+      asyncdata->handle->data = asyncdata;
+      uv_async_send(asyncdata->handle);
     }
 
    private:
     explicit ExecutionProgress(AsyncProgressWorker* that) : that_(that) {}
     NAN_DISALLOW_ASSIGN_COPY_MOVE(ExecutionProgress)
 
-      NAN_INLINE static NAUV_WORK_CB(AsyncProgress_) {
-          asyncdata_t *asyncdata =
-              static_cast<asyncdata_t*>(async->data);
-          asyncdata->worker->WorkProgress(asyncdata->data, asyncdata->size);
-          uv_close(reinterpret_cast<uv_handle_t*>(async), AsyncClose_);
-      }
+    NAN_INLINE static NAUV_WORK_CB(AsyncProgress_) {
+      asyncdata_t *asyncdata =
+        static_cast<asyncdata_t*>(async->data);
+      asyncdata->worker->WorkProgress(asyncdata->data, asyncdata->size);
+      uv_close(reinterpret_cast<uv_handle_t*>(async), AsyncClose_);
+    }
 
-      NAN_INLINE static void AsyncClose_(uv_handle_t* handle) {
-          asyncdata_t *asyncdata =
-              static_cast<asyncdata_t *>(handle->data);
-          delete asyncdata->data;
-          delete reinterpret_cast<uv_async_t*>(handle);
-      }
+    NAN_INLINE static void AsyncClose_(uv_handle_t* handle) {
+      asyncdata_t *asyncdata =
+        static_cast<asyncdata_t *>(handle->data);
+      delete asyncdata->data;
+      delete reinterpret_cast<uv_async_t*>(handle);
+    }
 
-      AsyncProgressWorker* const that_;
+    AsyncProgressWorker* const that_;
   };
 
   virtual void Execute(ExecutionProgress& progress) = 0;

--- a/nan.h
+++ b/nan.h
@@ -1603,7 +1603,6 @@ class Callback {
 
   explicit AsyncProgressWorker(Callback *callback_)
       : AsyncWorker(callback_) {
-<<<<<<< HEAD
     uv_async_init(
         uv_default_loop()
       , &async
@@ -1632,50 +1631,19 @@ class Callback {
     }
   }
 
-  typedef struct asyncdata_t {
-      uv_async_t* handle;
-      char* data;
-      size_t size;
-      AsyncProgressWorker* worker;
-  } asyncdata_t;
-
   class ExecutionProgress {
     friend class AsyncProgressWorker;
    public:
     // You could do fancy generics with templates here.
     void Send(const char* data, size_t size) const {
-      asyncdata_t* asyncdata = new asyncdata_t;
-      asyncdata->data = new char[size];
-      memcpy(asyncdata->data, data, size);
-      asyncdata->size = size;
-      asyncdata->handle = new uv_async_t;
-      asyncdata->worker = that_;
-      uv_async_init(
-          uv_default_loop()
-        , asyncdata->handle
-        , AsyncProgress_
-      );
-      asyncdata->handle->data = asyncdata;
-      uv_async_send(asyncdata->handle);
+        that_->SendProgress_(data, size);
     }
 
    private:
-    explicit ExecutionProgress(AsyncProgressWorker* that) : that_(that) {}
+    explicit ExecutionProgress(AsyncProgressWorker* that) : that_(that) {
+
+    }
     NAN_DISALLOW_ASSIGN_COPY_MOVE(ExecutionProgress)
-
-    NAN_INLINE static NAUV_WORK_CB(AsyncProgress_) {
-      asyncdata_t *asyncdata =
-        static_cast<asyncdata_t*>(async->data);
-      asyncdata->worker->WorkProgress(asyncdata->data, asyncdata->size);
-      uv_close(reinterpret_cast<uv_handle_t*>(async), AsyncClose_);
-    }
-
-    NAN_INLINE static void AsyncClose_(uv_handle_t* handle) {
-      asyncdata_t *asyncdata =
-        static_cast<asyncdata_t *>(handle->data);
-      delete asyncdata->data;
-      delete reinterpret_cast<uv_async_t*>(handle);
-    }
 
     AsyncProgressWorker* const that_;
   };

--- a/nan.h
+++ b/nan.h
@@ -1644,26 +1644,38 @@ class Callback {
    public:
     // You could do fancy generics with templates here.
     void Send(const char* data, size_t size) {
-        asyncdata_t* asyncdata = new asyncdata_t;
-        asyncdata->data = new char[size];
-        memcpy(asyncdata->data, data, size);
-        asyncdata->size = size;
-        asyncdata->handle = new uv_async_t;
-        asyncdata->worker = that_;
-        uv_async_init(
-            uv_default_loop()
-            , asyncdata->handle
-            , AsyncProgress_
-        );
-        asyncdata->handle->data = asyncdata;
-        uv_async_send(asyncdata->handle);
+      asyncdata_t* asyncdata = new asyncdata_t;
+      asyncdata->data = new char[size];
+      memcpy(asyncdata->data, data, size);
+      asyncdata->size = size;
+      asyncdata->handle = new uv_async_t;
+      asyncdata->worker = that_;
+      uv_async_init(
+          uv_default_loop()
+        , asyncdata->handle
+        , AsyncProgress_
+      );
+      asyncdata->handle->data = asyncdata;
+      uv_async_send(asyncdata->handle);
     }
 
    private:
-    explicit ExecutionProgress(AsyncProgressWorker* that) : that_(that) {
-
-    }
+    explicit ExecutionProgress(AsyncProgressWorker* that) : that_(that) {}
     NAN_DISALLOW_ASSIGN_COPY_MOVE(ExecutionProgress)
+
+    NAN_INLINE static NAUV_WORK_CB(AsyncProgress_) {
+      asyncdata_t *asyncdata =
+        static_cast<asyncdata_t*>(async->data);
+      asyncdata->worker->WorkProgress(asyncdata->data, asyncdata->size);
+      uv_close(reinterpret_cast<uv_handle_t*>(async), AsyncClose_);
+    }
+
+    NAN_INLINE static void AsyncClose_(uv_handle_t* handle) {
+      asyncdata_t *asyncdata =
+        static_cast<asyncdata_t *>(handle->data);
+      delete asyncdata->data;
+      delete reinterpret_cast<uv_async_t*>(handle);
+    }
 
     AsyncProgressWorker* const that_;
   };

--- a/nan.h
+++ b/nan.h
@@ -1623,7 +1623,7 @@ class Callback {
         while(!queue.empty()) {
             uv_mutex_lock(&async_lock);
             asyncdata_t *asyncdata = queue.front();
-            queue.pop_front()git ;
+            queue.pop_front();
             uv_mutex_unlock(&async_lock);
             HandleProgressCallback(asyncdata->data, asyncdata->size);
             delete asyncdata;

--- a/nan.h
+++ b/nan.h
@@ -1640,9 +1640,7 @@ class Callback {
     }
 
    private:
-    explicit ExecutionProgress(AsyncProgressWorker* that) : that_(that) {
-
-    }
+    explicit ExecutionProgress(AsyncProgressWorker* that) : that_(that) {}
     NAN_DISALLOW_ASSIGN_COPY_MOVE(ExecutionProgress)
 
     AsyncProgressWorker* const that_;

--- a/nan.h
+++ b/nan.h
@@ -1616,7 +1616,7 @@ class Callback {
     friend class AsyncProgressWorker;
    public:
     // You could do fancy generics with templates here.
-    void Send(const char* data, size_t size) {
+    void Send(const char* data, size_t size) const {
       asyncdata_t* asyncdata = new asyncdata_t;
       asyncdata->data = new char[size];
       memcpy(asyncdata->data, data, size);
@@ -1653,7 +1653,7 @@ class Callback {
     AsyncProgressWorker* const that_;
   };
 
-  virtual void Execute(ExecutionProgress& progress) = 0;
+  virtual void Execute(const ExecutionProgress& progress) = 0;
   virtual void HandleProgressCallback(const char *data, size_t size) = 0;
 
   virtual void Destroy() {

--- a/nan.h
+++ b/nan.h
@@ -37,7 +37,7 @@
 # define NAN_HAS_CPLUSPLUS_11 (__cplusplus >= 201103L)
 #endif
 
-#if NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION && ! NAN_HAS_CPLUSPLUS_11
+#if NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION && !NAN_HAS_CPLUSPLUS_11
 # error This version of node/NAN/v8 requires a C++11 compiler
 #endif
 
@@ -1050,8 +1050,8 @@ class Utf8String {
     // arbitrary buffer lengths requires
     // NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION
     assert(length <= imp::kMaxLength && "too large buffer");
-    return MaybeLocal<v8::Object>(
-        scope.Escape(New(node::Buffer::New(data, length, callback, hint)->handle_)));
+    return MaybeLocal<v8::Object>(scope.Escape(
+        New(node::Buffer::New(data, length, callback, hint)->handle_)));
   }
 
   NAN_INLINE MaybeLocal<v8::Object> CopyBuffer(
@@ -1683,7 +1683,7 @@ NAN_INLINE void AsyncQueueWorker (AsyncWorker* worker) {
       uv_default_loop()
     , &worker->request
     , AsyncExecute
-    , (uv_after_work_cb)AsyncExecuteComplete
+    , reinterpret_cast<uv_after_work_cb>(AsyncExecuteComplete)
   );
 }
 

--- a/nan.h
+++ b/nan.h
@@ -1643,7 +1643,7 @@ class Callback {
     friend class AsyncProgressWorker;
    public:
     // You could do fancy generics with templates here.
-    void Send(const char* data, size_t size) {
+    void Send(const char* data, size_t size) const {
       asyncdata_t* asyncdata = new asyncdata_t;
       asyncdata->data = new char[size];
       memcpy(asyncdata->data, data, size);
@@ -1680,7 +1680,7 @@ class Callback {
     AsyncProgressWorker* const that_;
   };
 
-  virtual void Execute(ExecutionProgress& progress) = 0;
+  virtual void Execute(const ExecutionProgress& progress) = 0;
   virtual void HandleProgressCallback(const char *data, size_t size) = 0;
 
   virtual void Destroy() {

--- a/test/cpp/asyncprogressworker.cpp
+++ b/test/cpp/asyncprogressworker.cpp
@@ -25,7 +25,7 @@ class ProgressWorker : public AsyncProgressWorker {
     , milliseconds(milliseconds), iters(iters) {}
   ~ProgressWorker() {}
 
-  void Execute (const AsyncProgressWorker::ExecutionProgress& progress) {
+  void Execute (AsyncProgressWorker::ExecutionProgress& progress) {
     for (int i = 0; i < iters; ++i) {
       progress.Send(reinterpret_cast<const char*>(&i), sizeof(int));
       Sleep(milliseconds);

--- a/test/cpp/asyncprogressworker.cpp
+++ b/test/cpp/asyncprogressworker.cpp
@@ -25,7 +25,7 @@ class ProgressWorker : public AsyncProgressWorker {
     , milliseconds(milliseconds), iters(iters) {}
   ~ProgressWorker() {}
 
-  void Execute (AsyncProgressWorker::ExecutionProgress& progress) {
+  void Execute (const AsyncProgressWorker::ExecutionProgress& progress) {
     for (int i = 0; i < iters; ++i) {
       progress.Send(reinterpret_cast<const char*>(&i), sizeof(int));
       Sleep(milliseconds);

--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -319,7 +319,7 @@ NAN_METHOD(testString) {
   t.ok(_( stringMatches( New("Hello World", 4).ToLocalChecked(), "Hell")));
   t.ok(_( assertType<String>( New("plonk.", 4).ToLocalChecked())));
 
-  const uint16_t *widestring = reinterpret_cast<const uint16_t *>("H\0e\0l\0l\0o\0");
+  const uint16_t widestring[] = {'H', 'e', 'l', 'l', 'o', '\0'};
   t.ok(_( stringMatches( New(widestring, 4).ToLocalChecked(), "Hell")));
   t.ok(_( assertType<String>( New(widestring, 4).ToLocalChecked())));
 

--- a/test/cpp/objectwraphandle.cpp
+++ b/test/cpp/objectwraphandle.cpp
@@ -31,7 +31,8 @@ class MyObject : public ObjectWrap {
 
   static NAN_METHOD(New) {
     if (info.IsConstructCall()) {
-      double value = info[0]->IsUndefined() ? 0 : Nan::To<double>(info[0]).FromJust();
+      double value =
+          info[0]->IsUndefined() ? 0 : Nan::To<double>(info[0]).FromJust();
       MyObject *obj = new MyObject(value);
       obj->Wrap(info.This());
       info.GetReturnValue().Set(info.This());

--- a/test/cpp/wrappedobjectfactory.cpp
+++ b/test/cpp/wrappedobjectfactory.cpp
@@ -23,7 +23,8 @@ class InnerObject : public ObjectWrap {
     constructor().Reset(GetFunction(tpl).ToLocalChecked());
   }
 
-  static v8::Local<v8::Object> NewInstance(int argc, v8::Local<v8::Value> argv[]) {
+  static
+  v8::Local<v8::Object> NewInstance(int argc, v8::Local<v8::Value> argv[]) {
     v8::Local<v8::Function> cons = Nan::New(constructor());
     return Nan::NewInstance(cons, argc, argv).ToLocalChecked();
   }
@@ -42,7 +43,8 @@ class InnerObject : public ObjectWrap {
       const int argc = 1;
       v8::Local<v8::Value> argv[argc] = {info[0]};
       v8::Local<v8::Function> cons = Nan::New(constructor());
-      info.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
+      info.GetReturnValue().Set(
+          Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 
@@ -76,7 +78,8 @@ class MyObject : public ObjectWrap {
     double value = info[0]->IsNumber() ? To<double>(info[0]).FromJust() : 0;
     const int argc = 1;
     v8::Local<v8::Value> argv[1] = {Nan::New(value)};
-    info.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
+    info.GetReturnValue().Set(
+        Nan::NewInstance(cons, argc, argv).ToLocalChecked());
   }
 
  private:
@@ -93,7 +96,8 @@ class MyObject : public ObjectWrap {
       const int argc = 1;
       v8::Local<v8::Value> argv[argc] = {info[0]};
       v8::Local<v8::Function> cons = Nan::New(constructor());
-      info.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
+      info.GetReturnValue().Set(
+          Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 
@@ -117,11 +121,16 @@ class MyObject : public ObjectWrap {
 };
 
 NAN_MODULE_INIT(Init) {
+  Nan::HandleScope scope;
+
   InnerObject::Init(target);
   MyObject::Init(target);
+  v8::Local<v8::FunctionTemplate> tpl =
+      New<v8::FunctionTemplate>(MyObject::NewInstance);
+
   Set(target
     , New<v8::String>("newFactoryObjectInstance").ToLocalChecked()
-    , GetFunction(New<v8::FunctionTemplate>(MyObject::NewInstance)).ToLocalChecked()
+    , GetFunction(tpl).ToLocalChecked()
   );
 }
 


### PR DESCRIPTION
The current AsyncProgressWorker class implementation has one single pointer to define the callback context (asyncdata_ member var) which can be overwritten in subsequents calls to progress.Send method even before the callback to be called.
