### PR TITLE
AsyncProgressWorker callback context isolation fix (reviewed)

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1610,6 +1610,11 @@ class Callback {
     uv_mutex_destroy(&async_lock);
   }
 
+  virtual void WorkComplete() {
+    WorkProgress();
+    AsyncWorker::WorkComplete();
+  }
+
   void WorkProgress() {
     // Dont send progress events after we've already completed.
     if (callback) {

--- a/nan.h
+++ b/nan.h
@@ -1592,7 +1592,6 @@ class Callback {
 
 /* abstract */ class AsyncProgressWorker : public AsyncWorker {
  public:
-
   typedef std::deque<std::string> async_queue_t;
 
   explicit AsyncProgressWorker(Callback *callback_)

--- a/test/js/asyncprogressworker-test.js
+++ b/test/js/asyncprogressworker-test.js
@@ -52,7 +52,6 @@ test('asyncprogressnowait100x', function (t) {
     , self = this;
   self.progressed = 0;
   worker(100, function(i) {
-    console.log(i);
     self.progressed++;
   }, function () {
     t.ok(self.progressed === 100, '100 messages - got ' + self.progressed);

--- a/test/js/asyncprogressworker-test.js
+++ b/test/js/asyncprogressworker-test.js
@@ -12,12 +12,50 @@ const test     = require('tap').test
 
 test('asyncprogressworker', function (t) {
   var worker = bindings.a
-    , progressed = 0
+    , self = this;
+  self.progressed = 0;
   worker(100, 5, function(i) {
-    t.ok(i === progressed, 'got the progress updates #' + i);
-    progressed++;
+    t.ok(i === self.progressed, 'got the progress updates #' + i);
+    self.progressed++;
   }, function () {
-    t.ok(progressed === 5, 'got all progress updates')
-    t.end()
+    t.ok(self.progressed === 5, 'got all progress updates');
+    t.end();
   })
-})
+});
+
+test('asyncprogressnowait1x', function (t) {
+  var worker = bindings.b
+    , self = this;
+  self.progressed = 0;
+  worker(1, function(i) {
+    self.progressed++;
+  }, function () {
+    t.ok(self.progressed === 1, 'one message - got ' + self.progressed);
+    t.end();
+  })
+});
+
+test('asyncprogressnowait2x', function (t) {
+  var worker = bindings.b
+    , self = this;
+  self.progressed = 0;
+  worker(2, function(i) {
+    self.progressed++;
+  }, function () {
+    t.ok(self.progressed === 2, 'two messages - got ' + self.progressed);
+    t.end();
+  })
+});
+
+test('asyncprogressnowait100x', function (t) {
+  var worker = bindings.b
+    , self = this;
+  self.progressed = 0;
+  worker(100, function(i) {
+    console.log(i);
+    self.progressed++;
+  }, function () {
+    t.ok(self.progressed === 100, '100 messages - got ' + self.progressed);
+    t.end();
+  })
+});


### PR DESCRIPTION
The current AsyncProgressWorker class implementation has one single pointer to define the callback context (asyncdata_ member var) which can be overwritten in subsequents calls to progress.Send method even before the callback to be called.
This PR follows @bnoordhuis suggestion and uses std::deque to temporarily store async data.
