### PR TITLE
Pass Holder instead of This to ObjectWrap::Unwrap

### DIFF
--- a/doc/object_wrappers.md
+++ b/doc/object_wrappers.md
@@ -54,6 +54,18 @@ class ObjectWrap {
 
 See the Node documentation on [Wrapping C++ Objects](https://nodejs.org/api/addons.html#addons_wrapping_c_objects) for more details.
 
+### This vs. Holder
+
+When calling `Unwrap`, it is important that the argument is indeed some JavaScript object which got wrapped by a `Wrap` call for this class or any derived class.
+The `Signature` installed by [`Nan::SetPrototypeMethod()`](methods.md#api_nan_set_prototype_method) does ensure that `info.Holder()` is just such an instance.
+In Node 0.12 and later, `info.This()` will also be of such a type, since otherwise the invocation will get rejected.
+However, in Node 0.10 and before it was possible to invoke a method on a JavaScript object which just had the extension type in its prototype chain.
+In such a situation, calling `Unwrap` on `info.This()` will likely lead to a failed assertion causing a crash, but could lead to even more serious corruption.
+
+On the other hand, calling `Unwrap` in an [accessor](methods.md#api_nan_set_accessor) should not use `Holder()` if the accessor is defined on the prototype.
+So either define your accessors on the instance template,
+or use `This()` after verifying that it is indeed a valid object.
+
 ### Examples
 
 #### Basic

--- a/doc/object_wrappers.md
+++ b/doc/object_wrappers.md
@@ -93,12 +93,12 @@ class MyObject : public Nan::ObjectWrap {
   }
 
   static NAN_METHOD(GetHandle) {
-    MyObject* obj = Nan::ObjectWrap::Unwrap<MyObject>(info.This());
+    MyObject* obj = Nan::ObjectWrap::Unwrap<MyObject>(info.Holder());
     info.GetReturnValue().Set(obj->handle());
   }
 
   static NAN_METHOD(GetValue) {
-    MyObject* obj = Nan::ObjectWrap::Unwrap<MyObject>(info.This());
+    MyObject* obj = Nan::ObjectWrap::Unwrap<MyObject>(info.Holder());
     info.GetReturnValue().Set(obj->value_);
   }
 
@@ -168,7 +168,7 @@ class MyFactoryObject : public Nan::ObjectWrap {
   }
 
   static NAN_METHOD(GetValue) {
-    MyFactoryObject* obj = ObjectWrap::Unwrap<MyFactoryObject>(info.This());
+    MyFactoryObject* obj = ObjectWrap::Unwrap<MyFactoryObject>(info.Holder());
     info.GetReturnValue().Set(obj->value_);
   }
 

--- a/test/cpp/accessors.cpp
+++ b/test/cpp/accessors.cpp
@@ -88,7 +88,7 @@ NAN_METHOD(SetterGetter::New) {
 
 NAN_GETTER(SetterGetter::GetProp1) {
   SetterGetter* settergetter =
-    ObjectWrap::Unwrap<SetterGetter>(info.This());
+    ObjectWrap::Unwrap<SetterGetter>(info.Holder());
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
   strncat(
       settergetter->log
@@ -110,7 +110,7 @@ NAN_GETTER(SetterGetter::GetProp1) {
 
 NAN_GETTER(SetterGetter::GetProp2) {
   SetterGetter* settergetter =
-    ObjectWrap::Unwrap<SetterGetter>(info.This());
+    ObjectWrap::Unwrap<SetterGetter>(info.Holder());
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
   strncat(
       settergetter->log
@@ -132,7 +132,7 @@ NAN_GETTER(SetterGetter::GetProp2) {
 
 NAN_SETTER(SetterGetter::SetProp2) {
   SetterGetter* settergetter =
-      ObjectWrap::Unwrap<SetterGetter>(info.This());
+      ObjectWrap::Unwrap<SetterGetter>(info.Holder());
   strncpy(
       settergetter->prop2
     , *Utf8String(value)
@@ -157,7 +157,7 @@ NAN_SETTER(SetterGetter::SetProp2) {
 
 NAN_METHOD(SetterGetter::Log) {
   SetterGetter* settergetter =
-    ObjectWrap::Unwrap<SetterGetter>(info.This());
+    ObjectWrap::Unwrap<SetterGetter>(info.Holder());
 
   info.GetReturnValue().Set(Nan::New(settergetter->log).ToLocalChecked());
 }

--- a/test/cpp/accessors.cpp
+++ b/test/cpp/accessors.cpp
@@ -48,13 +48,13 @@ NAN_MODULE_INIT(SetterGetter::Init) {
   tpl->SetClassName(Nan::New<v8::String>("SetterGetter").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
   SetPrototypeMethod(tpl, "log", SetterGetter::Log);
-  v8::Local<v8::ObjectTemplate> proto = tpl->PrototypeTemplate();
+  v8::Local<v8::ObjectTemplate> itpl = tpl->InstanceTemplate();
   SetAccessor(
-      proto
+      itpl
     , Nan::New("prop1").ToLocalChecked()
     , SetterGetter::GetProp1);
   SetAccessor(
-      proto
+      itpl
     , Nan::New<v8::String>("prop2").ToLocalChecked()
     , SetterGetter::GetProp2
     , SetterGetter::SetProp2

--- a/test/cpp/accessors2.cpp
+++ b/test/cpp/accessors2.cpp
@@ -86,7 +86,7 @@ NAN_METHOD(SetterGetter::New) {
 
 NAN_GETTER(SetterGetter::GetProp1) {
   SetterGetter* settergetter =
-    ObjectWrap::Unwrap<SetterGetter>(info.This());
+    ObjectWrap::Unwrap<SetterGetter>(info.Holder());
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
   strncat(
       settergetter->log
@@ -108,7 +108,7 @@ NAN_GETTER(SetterGetter::GetProp1) {
 
 NAN_GETTER(SetterGetter::GetProp2) {
   SetterGetter* settergetter =
-    ObjectWrap::Unwrap<SetterGetter>(info.This());
+    ObjectWrap::Unwrap<SetterGetter>(info.Holder());
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
   strncat(
       settergetter->log
@@ -130,7 +130,7 @@ NAN_GETTER(SetterGetter::GetProp2) {
 
 NAN_SETTER(SetterGetter::SetProp2) {
   SetterGetter* settergetter =
-      ObjectWrap::Unwrap<SetterGetter>(info.This());
+      ObjectWrap::Unwrap<SetterGetter>(info.Holder());
   strncpy(
       settergetter->prop2
     , *v8::String::Utf8Value(value)
@@ -155,7 +155,7 @@ NAN_SETTER(SetterGetter::SetProp2) {
 
 NAN_METHOD(SetterGetter::Log) {
   SetterGetter* settergetter =
-    ObjectWrap::Unwrap<SetterGetter>(info.This());
+    ObjectWrap::Unwrap<SetterGetter>(info.Holder());
 
   info.GetReturnValue().Set(Nan::New(settergetter->log).ToLocalChecked());
 }

--- a/test/cpp/indexedinterceptors.cpp
+++ b/test/cpp/indexedinterceptors.cpp
@@ -72,7 +72,7 @@ NAN_METHOD(IndexedInterceptor::New) {
 
 NAN_INDEX_GETTER(IndexedInterceptor::PropertyGetter) {
   IndexedInterceptor* interceptor =
-    ObjectWrap::Unwrap<IndexedInterceptor>(info.This());
+    ObjectWrap::Unwrap<IndexedInterceptor>(info.Holder());
   if (index == 0) {
     info.GetReturnValue().Set(Nan::New(interceptor->buf).ToLocalChecked());
   } else {
@@ -82,7 +82,7 @@ NAN_INDEX_GETTER(IndexedInterceptor::PropertyGetter) {
 
 NAN_INDEX_SETTER(IndexedInterceptor::PropertySetter) {
   IndexedInterceptor* interceptor =
-    ObjectWrap::Unwrap<IndexedInterceptor>(info.This());
+    ObjectWrap::Unwrap<IndexedInterceptor>(info.Holder());
   if (index == 0) {
     std::strncpy(
         interceptor->buf
@@ -102,7 +102,7 @@ NAN_INDEX_ENUMERATOR(IndexedInterceptor::PropertyEnumerator) {
 
 NAN_INDEX_DELETER(IndexedInterceptor::PropertyDeleter) {
   IndexedInterceptor* interceptor =
-    ObjectWrap::Unwrap<IndexedInterceptor>(info.This());
+    ObjectWrap::Unwrap<IndexedInterceptor>(info.Holder());
   std::strncpy(interceptor->buf, "goober", sizeof (interceptor->buf));
   info.GetReturnValue().Set(True());
 }

--- a/test/cpp/namedinterceptors.cpp
+++ b/test/cpp/namedinterceptors.cpp
@@ -72,7 +72,7 @@ NAN_METHOD(NamedInterceptor::New) {
 
 NAN_PROPERTY_GETTER(NamedInterceptor::PropertyGetter) {
   NamedInterceptor* interceptor =
-    ObjectWrap::Unwrap<NamedInterceptor>(info.This());
+    ObjectWrap::Unwrap<NamedInterceptor>(info.Holder());
   if (!std::strcmp(*v8::String::Utf8Value(property), "prop")) {
     info.GetReturnValue().Set(Nan::New(interceptor->buf).ToLocalChecked());
   } else {
@@ -82,7 +82,7 @@ NAN_PROPERTY_GETTER(NamedInterceptor::PropertyGetter) {
 
 NAN_PROPERTY_SETTER(NamedInterceptor::PropertySetter) {
   NamedInterceptor* interceptor =
-    ObjectWrap::Unwrap<NamedInterceptor>(info.This());
+    ObjectWrap::Unwrap<NamedInterceptor>(info.Holder());
   if (!std::strcmp(*v8::String::Utf8Value(property), "prop")) {
     std::strncpy(
         interceptor->buf
@@ -102,7 +102,7 @@ NAN_PROPERTY_ENUMERATOR(NamedInterceptor::PropertyEnumerator) {
 
 NAN_PROPERTY_DELETER(NamedInterceptor::PropertyDeleter) {
   NamedInterceptor* interceptor =
-    ObjectWrap::Unwrap<NamedInterceptor>(info.This());
+    ObjectWrap::Unwrap<NamedInterceptor>(info.Holder());
   std::strncpy(interceptor->buf, "goober", sizeof (interceptor->buf));
   info.GetReturnValue().Set(True());
 }

--- a/test/cpp/objectwraphandle.cpp
+++ b/test/cpp/objectwraphandle.cpp
@@ -45,12 +45,12 @@ class MyObject : public ObjectWrap {
   }
 
   static NAN_METHOD(GetHandle) {
-    MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.This());
+    MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.Holder());
     info.GetReturnValue().Set(obj->handle());
   }
 
   static NAN_METHOD(GetValue) {
-    MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.This());
+    MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.Holder());
     info.GetReturnValue().Set(obj->value_);
   }
 

--- a/test/cpp/wrappedobjectfactory.cpp
+++ b/test/cpp/wrappedobjectfactory.cpp
@@ -49,7 +49,7 @@ class InnerObject : public ObjectWrap {
   }
 
   static NAN_METHOD(GetValue) {
-    InnerObject* obj = ObjectWrap::Unwrap<InnerObject>(info.This());
+    InnerObject* obj = ObjectWrap::Unwrap<InnerObject>(info.Holder());
     info.GetReturnValue().Set(obj->value_);
   }
 
@@ -102,7 +102,7 @@ class MyObject : public ObjectWrap {
   }
 
   static NAN_METHOD(GetValue) {
-    MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.This());
+    MyObject* obj = ObjectWrap::Unwrap<MyObject>(info.Holder());
     info.GetReturnValue().Set(obj->value_);
   }
 

--- a/test/js/accessors-test.js
+++ b/test/js/accessors-test.js
@@ -11,7 +11,7 @@ const test     = require('tap').test
     , bindings = require('bindings')({ module_root: testRoot, bindings: 'accessors' });
 
 test('accessors', function (t) {
-  t.plan(4)
+  t.plan(7)
   var settergetter = bindings.create()
   t.equal(settergetter.prop1, 'this is property 1')
   t.ok(settergetter.prop2 === '')
@@ -24,4 +24,9 @@ test('accessors', function (t) {
     'Prop2:SETTER(setting a value)\n' +
     'Prop2:GETTER(setting a value)\n'
   )
+  var derived = Object.create(settergetter)
+  t.equal(derived.prop1, 'this is property 1')
+  derived.prop2 = 'setting a new value'
+  t.equal(derived.prop2, 'setting a new value')
+  t.equal(settergetter.prop2, 'setting a new value')
 })

--- a/test/js/objectwraphandle-test.js
+++ b/test/js/objectwraphandle-test.js
@@ -11,7 +11,7 @@ const test     = require('tap').test
     , bindings = require('bindings')({ module_root: testRoot, bindings: 'objectwraphandle' });
 
 test('objectwraphandle', function (t) {
-  t.plan(5);
+  t.plan(7);
 
   t.type(bindings.MyObject, 'function');
 
@@ -21,4 +21,14 @@ test('objectwraphandle', function (t) {
   t.type(obj.getValue, 'function');
   t.type(obj.getHandle(), 'object');
   t.type(obj.getValue(), 'number');
+
+  var derived = Object.create(obj);
+  t.type(derived, bindings.MyObject);
+  try {
+    // In Node 0.10 this call is valid:
+    t.equal(derived.getValue(), 10);
+  } catch (err) {
+    // In Node >= 0.12 it throws instead:
+    t.type(err, TypeError);
+  }
 });


### PR DESCRIPTION
This is after reading [Christian 'Little Jim' Plesner's answer to “What is the difference between Arguments::Holder() and Arguments::This()?”](https://groups.google.com/d/msg/v8-users/Axf4hF_RfZo/hA6Mvo78AqAJ) in the context of [my Stack Overflow question “This vs. Holder for ObjectWrap::Unwrap”](http://stackoverflow.com/q/34257458/1468366). Without the fix in my second commit, the test case from my first commit can lead to a failed assertion on Node 0.10. The change is also in line with [the `node::ObjectWrap` documentation](https://nodejs.org/api/addons.html#addons_wrapping_c_objects).