### PR TITLE
Rename GC*logueCallback to GCCallback for >4.0

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -598,25 +598,33 @@ class TryCatch {
 # define NAN_GC_CALLBACK(name)                                                 \
     void name(v8::Isolate *isolate, v8::GCType type, v8::GCCallbackFlags flags)
 
+#if NODE_MODULE_VERSION <= NODE_4_0_MODULE_VERSION
+  typedef v8::Isolate::GCEpilogueCallback GCEpilogueCallback;
+  typedef v8::Isolate::GCPrologueCallback GCPrologueCallback;
+#else
+  typedef v8::Isolate::GCCallback GCEpilogueCallback;
+  typedef v8::Isolate::GCCallback GCPrologueCallback;
+#endif
+
   NAN_INLINE void AddGCEpilogueCallback(
-      v8::Isolate::GCEpilogueCallback callback
+      GCEpilogueCallback callback
     , v8::GCType gc_type_filter = v8::kGCTypeAll) {
     v8::Isolate::GetCurrent()->AddGCEpilogueCallback(callback, gc_type_filter);
   }
 
   NAN_INLINE void RemoveGCEpilogueCallback(
-      v8::Isolate::GCEpilogueCallback callback) {
+      GCEpilogueCallback callback) {
     v8::Isolate::GetCurrent()->RemoveGCEpilogueCallback(callback);
   }
 
   NAN_INLINE void AddGCPrologueCallback(
-      v8::Isolate::GCPrologueCallback callback
+      GCPrologueCallback callback
     , v8::GCType gc_type_filter = v8::kGCTypeAll) {
     v8::Isolate::GetCurrent()->AddGCPrologueCallback(callback, gc_type_filter);
   }
 
   NAN_INLINE void RemoveGCPrologueCallback(
-      v8::Isolate::GCPrologueCallback callback) {
+      GCPrologueCallback callback) {
     v8::Isolate::GetCurrent()->RemoveGCPrologueCallback(callback);
   }
 


### PR DESCRIPTION
Types were unified in https://codereview.chromium.org/1298113003
This change went into v8 4.6 which made it into Node 5. The
GC*logueCallback types have gone away completely in 4.9.