### PR TITLE
Use only spaces for indentation in addon example

### DIFF
--- a/examples/async_pi_estimate/addon.js
+++ b/examples/async_pi_estimate/addon.js
@@ -12,40 +12,40 @@ var calculations = process.argv[2] || 100000000;
 function printResult(type, pi, ms) {
   console.log(type, 'method:')
   console.log('\tπ ≈ ' + pi
-  		+ ' (' + Math.abs(pi - Math.PI) + ' away from actual)')
-	console.log('\tTook ' + ms + 'ms');
-	console.log()
+    + ' (' + Math.abs(pi - Math.PI) + ' away from actual)')
+  console.log('\tTook ' + ms + 'ms');
+  console.log()
 }
 
 function runSync () {
   var start = Date.now();
   // Estimate() will execute in the current thread,
   // the next line won't return until it is finished
-	var result = addon.calculateSync(calculations);
+  var result = addon.calculateSync(calculations);
   printResult('Sync', result, Date.now() - start)
 }
 
 function runAsync () {
   // how many batches should we split the work in to?
-	var batches = process.argv[3] || 16;
-	var ended = 0;
-	var total = 0;
-	var start = Date.now();
+  var batches = process.argv[3] || 16;
+  var ended = 0;
+  var total = 0;
+  var start = Date.now();
 
-	function done (err, result) {
-		total += result;
-
+  function done (err, result) {
+    total += result;
+    
     // have all the batches finished executing?
-		if (++ended == batches) {
-			printResult('Async', total / batches, Date.now() - start)
-		}
-	}
-
+    if (++ended == batches) {
+      printResult('Async', total / batches, Date.now() - start)
+    }
+  }
+  
   // for each batch of work, request an async Estimate() for
   // a portion of the total number of calculations
-	for (var i = 0; i < batches; i++) {
-		addon.calculateAsync(calculations / batches, done);
-	}
+  for (var i = 0; i < batches; i++) {
+    addon.calculateAsync(calculations / batches, done);
+  }
 }
 
 runSync()


### PR DESCRIPTION
Right now, both tabs and spaces are mixed (in some weird way) in this file, making it look strangely in some editors.