### PR TITLE
Dataless progress callbacks for AsyncProgressWorker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ LINT_SOURCES = \
 	test/cpp/accessors2.cpp \
 	test/cpp/asyncworker.cpp \
 	test/cpp/asyncprogressworker.cpp \
+	test/cpp/asyncprogressworkersignal.cpp \
 	test/cpp/asyncworkererror.cpp \
 	test/cpp/buffer.cpp \
 	test/cpp/bufferworkerpersistent.cpp \

--- a/doc/asyncworker.md
+++ b/doc/asyncworker.md
@@ -75,6 +75,7 @@ class AsyncProgressWorker : public AsyncWorker {
 
   class ExecutionProgress {
    public:
+    void Signal() const;
     void Send(const char* data, size_t size) const;
   };
 

--- a/nan.h
+++ b/nan.h
@@ -1632,6 +1632,9 @@ class Callback {
     friend class AsyncProgressWorker;
    public:
     // You could do fancy generics with templates here.
+    void Signal() const {
+        uv_async_send(that_->async);
+    }
     void Send(const char* data, size_t size) const {
         that_->SendProgress_(data, size);
     }

--- a/nan.h
+++ b/nan.h
@@ -1631,10 +1631,10 @@ class Callback {
   class ExecutionProgress {
     friend class AsyncProgressWorker;
    public:
-    // You could do fancy generics with templates here.
     void Signal() const {
         uv_async_send(that_->async);
     }
+    // You could do fancy generics with templates here.
     void Send(const char* data, size_t size) const {
         that_->SendProgress_(data, size);
     }

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -98,6 +98,10 @@
       , "sources"     : [ "cpp/asyncprogressworker.cpp" ]
     }
     , {
+        "target_name" : "asyncprogressworkersignal"
+      , "sources"     : ["cpp/asyncprogressworkersignal.cpp"]
+    }
+    , {
         "target_name" : "nancallback"
       , "sources"     : [ "cpp/nancallback.cpp" ]
     }

--- a/test/cpp/asyncprogressworkersignal.cpp
+++ b/test/cpp/asyncprogressworkersignal.cpp
@@ -35,10 +35,8 @@ class ProgressWorker : public AsyncProgressWorker {
   void HandleProgressCallback(const char *data, size_t size) {
     HandleScope scope;
 
-    v8::Local<v8::Value> argv[] = {
-        New<v8::Boolean>(data == NULL && size == 0)
-    };
-    progress->Call(1, argv);
+    v8::Local<v8::Value> arg = New<v8::Boolean>(data == NULL && size == 0);
+    progress->Call(1, &arg);
   }
 
  private:

--- a/test/cpp/asyncprogressworkersignal.cpp
+++ b/test/cpp/asyncprogressworkersignal.cpp
@@ -1,0 +1,66 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2016 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef _WIN32
+#include <unistd.h>
+#define Sleep(x) usleep((x)*1000)
+#endif
+#include <nan.h>
+
+using namespace Nan;  // NOLINT(build/namespaces)
+
+class ProgressWorker : public AsyncProgressWorker {
+ public:
+  ProgressWorker(
+      Callback *callback
+    , Callback *progress
+    , int milliseconds
+    , int iters)
+    : AsyncProgressWorker(callback), progress(progress)
+    , milliseconds(milliseconds), iters(iters) {}
+  ~ProgressWorker() {}
+
+  void Execute (const AsyncProgressWorker::ExecutionProgress& progress) {
+    for (int i = 0; i < iters; ++i) {
+      progress.Signal();
+      Sleep(milliseconds);
+    }
+  }
+
+  void HandleProgressCallback(const char *data, size_t size) {
+    HandleScope scope;
+
+    v8::Local<v8::Value> argv[] = {
+        New<v8::Boolean>(data == NULL && size == 0)
+    };
+    progress->Call(1, argv);
+  }
+
+ private:
+  Callback *progress;
+  int milliseconds;
+  int iters;
+};
+
+NAN_METHOD(DoProgress) {
+  Callback *progress = new Callback(info[2].As<v8::Function>());
+  Callback *callback = new Callback(info[3].As<v8::Function>());
+  AsyncQueueWorker(new ProgressWorker(
+      callback
+    , progress
+    , To<uint32_t>(info[0]).FromJust()
+    , To<uint32_t>(info[1]).FromJust()));
+}
+
+NAN_MODULE_INIT(Init) {
+  Set(target
+    , New<v8::String>("a").ToLocalChecked()
+    , New<v8::FunctionTemplate>(DoProgress)->GetFunction());
+}
+
+NODE_MODULE(asyncprogressworker, Init)

--- a/test/js/asyncprogressworkersignal-test.js
+++ b/test/js/asyncprogressworkersignal-test.js
@@ -1,0 +1,23 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2016 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+const test     = require('tap').test
+    , testRoot = require('path').resolve(__dirname, '..')
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'asyncprogressworkersignal' });
+
+test('asyncprogressworkersignal', function (t) {
+  var worker = bindings.a
+    , progressed = 0
+  worker(100, 5, function(i) {
+    t.ok(i === true, 'data being left at NULL');
+    progressed++;
+  }, function () {
+    t.ok(progressed === 5, 'got all progress updates')
+    t.end()
+  })
+})


### PR DESCRIPTION
I'd like the ability to efficiently send progress without data. Since `uv_async_send` coalesces callbacks, it's probably must more common for people to implement data callbacks with a queue as a member variable anyways.