### PR TITLE
Don't use deprecated v8::Template::Set()

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1867,13 +1867,12 @@ NAN_INLINE void SetPrototypeMethod(
     v8::Local<v8::FunctionTemplate> recv
   , const char* name, FunctionCallback callback) {
   HandleScope scope;
-  v8::Local<v8::Function> fn = GetFunction(New<v8::FunctionTemplate>(
+  v8::Local<v8::FunctionTemplate> fn = New<v8::FunctionTemplate>(
       callback
     , v8::Local<v8::Value>()
-    , New<v8::Signature>(recv))).ToLocalChecked();
+    , New<v8::Signature>(recv));
   v8::Local<v8::String> fn_name = New(name).ToLocalChecked();
   recv->PrototypeTemplate()->Set(fn_name, fn);
-  fn->SetName(fn_name);
 }
 
 //=== Accessors and Such =======================================================


### PR DESCRIPTION
Setting non-primitive values on FunctionTemplate and ObjectTemplate
instances is depreciated.
Fixes #558