### PR TITLE
Don't use deprecated v8::Template::Set().

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1867,13 +1867,13 @@ NAN_INLINE void SetPrototypeMethod(
     v8::Local<v8::FunctionTemplate> recv
   , const char* name, FunctionCallback callback) {
   HandleScope scope;
-  v8::Local<v8::Function> fn = GetFunction(New<v8::FunctionTemplate>(
+  v8::Local<v8::FunctionTemplate> t = New<v8::FunctionTemplate>(
       callback
     , v8::Local<v8::Value>()
-    , New<v8::Signature>(recv))).ToLocalChecked();
+    , New<v8::Signature>(recv));
   v8::Local<v8::String> fn_name = New(name).ToLocalChecked();
-  recv->PrototypeTemplate()->Set(fn_name, fn);
-  fn->SetName(fn_name);
+  recv->PrototypeTemplate()->Set(fn_name, t);
+  t->SetClassName(fn_name);
 }
 
 //=== Accessors and Such =======================================================


### PR DESCRIPTION
See [0] and [1]: starting with node.js v6, setting non-primitive values
on FunctionTemplate and ObjectTemplate instances is discouraged; v7 will
downright disallow it.  Update `Nan::SetPrototypeMethod()`.

[0] https://github.com/nodejs/node/issues/6216
[1] https://github.com/nodejs/node/pull/6228