### PR TITLE
Don't use deprecated v8::Template::Set() in SetMethod

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1856,10 +1856,10 @@ NAN_INLINE void SetMethod(
   , const char *name
   , FunctionCallback callback) {
   HandleScope scope;
-  v8::Local<v8::Function> fn = GetFunction(New<v8::FunctionTemplate>(
-      callback)).ToLocalChecked();
+  v8::Local<v8::FunctionTemplate> fn = New<v8::FunctionTemplate>(
+      callback);
   v8::Local<v8::String> fn_name = New(name).ToLocalChecked();
-  fn->SetName(fn_name);
+  fn->SetClassName(fn_name);
   recv->Set(fn_name, fn);
 }
 


### PR DESCRIPTION
Same as https://github.com/nodejs/nan/pull/560, but for SetMethod.

I think it's ok for releasing this as 2.3.1.

cc @kkoopa @bnoordhuis 