### PR TITLE
Remove V8 deprecation warnings

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1986,6 +1986,16 @@ inline bool SetAccessor(
       , New<v8::External>(reinterpret_cast<void *>(setter)));
   }
 
+#if (NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION)
+  return obj->SetAccessor(
+      GetCurrentContext()
+    , name
+    , getter_
+    , setter_
+    , dataobj
+    , settings
+    , attribute).FromMaybe(false);
+#else
   return obj->SetAccessor(
       name
     , getter_
@@ -1993,6 +2003,7 @@ inline bool SetAccessor(
     , dataobj
     , settings
     , attribute);
+#endif
 }
 
 inline void SetNamedPropertyHandler(

--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -37,7 +37,12 @@ Factory<v8::Boolean>::New(bool value) {
 
 Factory<v8::BooleanObject>::return_t
 Factory<v8::BooleanObject>::New(bool value) {
+#if (NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION)
+  return v8::BooleanObject::New(
+    v8::Isolate::GetCurrent(), value).As<v8::BooleanObject>();
+#else
   return v8::BooleanObject::New(value).As<v8::BooleanObject>();
+#endif
 }
 
 //=== Context ==================================================================

--- a/nan_maybe_43_inl.h
+++ b/nan_maybe_43_inl.h
@@ -217,7 +217,21 @@ NAN_INLINE Maybe<int> GetEndColumn(v8::Local<v8::Message> msg) {
 NAN_INLINE MaybeLocal<v8::Object> CloneElementAt(
     v8::Local<v8::Array> array
   , uint32_t index) {
-  return array->CloneElementAt(GetCurrentContext(), index);
+  v8::Local<v8::Context> context = GetCurrentContext();
+#if (NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION)
+  v8::EscapableHandleScope handle_scope(v8::Isolate::GetCurrent());
+  v8::Local<v8::Value> elem;
+  if (!array->Get(context, index).ToLocal(&elem)) {
+    return MaybeLocal<v8::Object>();
+  }
+  v8::Local<v8::Object> obj;
+  if (!elem->ToObject(context).ToLocal(&obj)) {
+    return MaybeLocal<v8::Object>();
+  }
+  return handle_scope.Escape(obj->Clone());
+#else
+  return array->CloneElementAt(context, index);
+#endif
 }
 
 NAN_INLINE MaybeLocal<v8::Value> Call(

--- a/nan_maybe_43_inl.h
+++ b/nan_maybe_43_inl.h
@@ -217,9 +217,9 @@ NAN_INLINE Maybe<int> GetEndColumn(v8::Local<v8::Message> msg) {
 NAN_INLINE MaybeLocal<v8::Object> CloneElementAt(
     v8::Local<v8::Array> array
   , uint32_t index) {
+  v8::EscapableHandleScope handle_scope(v8::Isolate::GetCurrent());
   v8::Local<v8::Context> context = GetCurrentContext();
 #if (NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION)
-  v8::EscapableHandleScope handle_scope(v8::Isolate::GetCurrent());
   v8::Local<v8::Value> elem;
   if (!array->Get(context, index).ToLocal(&elem)) {
     return MaybeLocal<v8::Object>();

--- a/nan_maybe_43_inl.h
+++ b/nan_maybe_43_inl.h
@@ -230,7 +230,7 @@ NAN_INLINE MaybeLocal<v8::Object> CloneElementAt(
   }
   return handle_scope.Escape(obj->Clone());
 #else
-  return array->CloneElementAt(context, index);
+  return handle_scope.Escape(array->CloneElementAt(context, index));
 #endif
 }
 


### PR DESCRIPTION
Current deprecation warnings on Node v6 are SetAccessor, CloneElementAt,
and BooleanObject::New.