### PR TITLE
Replace NAN_INLINE with 'inline' keyword.

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -84,14 +84,6 @@
 
 namespace Nan {
 
-#if defined(__GNUC__) && !(defined(DEBUG) && DEBUG)
-# define NAN_INLINE inline __attribute__((always_inline))
-#elif defined(_MSC_VER) && !(defined(DEBUG) && DEBUG)
-# define NAN_INLINE __forceinline
-#else
-# define NAN_INLINE inline
-#endif
-
 #if defined(__GNUC__) && \
     !(defined(V8_DISABLE_DEPRECATIONS) && V8_DISABLE_DEPRECATIONS)
 # define NAN_DEPRECATED __attribute__((deprecated))
@@ -412,11 +404,11 @@ class TryCatch {
   TryCatch() : try_catch_(v8::Isolate::GetCurrent()) {}
 #endif
 
-  NAN_INLINE bool HasCaught() const { return try_catch_.HasCaught(); }
+  inline bool HasCaught() const { return try_catch_.HasCaught(); }
 
-  NAN_INLINE bool CanContinue() const { return try_catch_.CanContinue(); }
+  inline bool CanContinue() const { return try_catch_.CanContinue(); }
 
-  NAN_INLINE v8::Local<v8::Value> ReThrow() {
+  inline v8::Local<v8::Value> ReThrow() {
 #if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
     return New(try_catch_.ReThrow());
 #else
@@ -424,30 +416,30 @@ class TryCatch {
 #endif
   }
 
-  NAN_INLINE v8::Local<v8::Value> Exception() const {
+  inline v8::Local<v8::Value> Exception() const {
     return try_catch_.Exception();
   }
 
 #if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
   (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
-  NAN_INLINE v8::MaybeLocal<v8::Value> StackTrace() const {
+  inline v8::MaybeLocal<v8::Value> StackTrace() const {
     return try_catch_.StackTrace(GetCurrentContext());
   }
 #else
-  NAN_INLINE MaybeLocal<v8::Value> StackTrace() const {
+  inline MaybeLocal<v8::Value> StackTrace() const {
     return MaybeLocal<v8::Value>(try_catch_.StackTrace());
   }
 #endif
 
-  NAN_INLINE v8::Local<v8::Message> Message() const {
+  inline v8::Local<v8::Message> Message() const {
     return try_catch_.Message();
   }
 
-  NAN_INLINE void Reset() { try_catch_.Reset(); }
+  inline void Reset() { try_catch_.Reset(); }
 
-  NAN_INLINE void SetVerbose(bool value) { try_catch_.SetVerbose(value); }
+  inline void SetVerbose(bool value) { try_catch_.SetVerbose(value); }
 
-  NAN_INLINE void SetCaptureMessage(bool value) {
+  inline void SetCaptureMessage(bool value) {
     try_catch_.SetCaptureMessage(value);
   }
 };
@@ -456,71 +448,71 @@ class TryCatch {
 
 /* node 0.12  */
 #if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION
-  NAN_INLINE
+  inline
   void SetCounterFunction(v8::CounterLookupCallback cb) {
     v8::Isolate::GetCurrent()->SetCounterFunction(cb);
   }
 
-  NAN_INLINE
+  inline
   void SetCreateHistogramFunction(v8::CreateHistogramCallback cb) {
     v8::Isolate::GetCurrent()->SetCreateHistogramFunction(cb);
   }
 
-  NAN_INLINE
+  inline
   void SetAddHistogramSampleFunction(v8::AddHistogramSampleCallback cb) {
     v8::Isolate::GetCurrent()->SetAddHistogramSampleFunction(cb);
   }
 
 #if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
   (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
-  NAN_INLINE bool IdleNotification(int idle_time_in_ms) {
+  inline bool IdleNotification(int idle_time_in_ms) {
     return v8::Isolate::GetCurrent()->IdleNotificationDeadline(
         idle_time_in_ms * 0.001);
   }
 # else
-  NAN_INLINE bool IdleNotification(int idle_time_in_ms) {
+  inline bool IdleNotification(int idle_time_in_ms) {
     return v8::Isolate::GetCurrent()->IdleNotification(idle_time_in_ms);
   }
 #endif
 
-  NAN_INLINE void LowMemoryNotification() {
+  inline void LowMemoryNotification() {
     v8::Isolate::GetCurrent()->LowMemoryNotification();
   }
 
-  NAN_INLINE void ContextDisposedNotification() {
+  inline void ContextDisposedNotification() {
     v8::Isolate::GetCurrent()->ContextDisposedNotification();
   }
 #else
-  NAN_INLINE
+  inline
   void SetCounterFunction(v8::CounterLookupCallback cb) {
     v8::V8::SetCounterFunction(cb);
   }
 
-  NAN_INLINE
+  inline
   void SetCreateHistogramFunction(v8::CreateHistogramCallback cb) {
     v8::V8::SetCreateHistogramFunction(cb);
   }
 
-  NAN_INLINE
+  inline
   void SetAddHistogramSampleFunction(v8::AddHistogramSampleCallback cb) {
     v8::V8::SetAddHistogramSampleFunction(cb);
   }
 
-  NAN_INLINE bool IdleNotification(int idle_time_in_ms) {
+  inline bool IdleNotification(int idle_time_in_ms) {
     return v8::V8::IdleNotification(idle_time_in_ms);
   }
 
-  NAN_INLINE void LowMemoryNotification() {
+  inline void LowMemoryNotification() {
     v8::V8::LowMemoryNotification();
   }
 
-  NAN_INLINE void ContextDisposedNotification() {
+  inline void ContextDisposedNotification() {
     v8::V8::ContextDisposedNotification();
   }
 #endif
 
 #if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)  // Node 0.12
-  NAN_INLINE v8::Local<v8::Primitive> Undefined() {
+  inline v8::Local<v8::Primitive> Undefined() {
 # if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
     EscapableHandleScope scope;
     return scope.Escape(New(v8::Undefined(v8::Isolate::GetCurrent())));
@@ -529,7 +521,7 @@ class TryCatch {
 # endif
   }
 
-  NAN_INLINE v8::Local<v8::Primitive> Null() {
+  inline v8::Local<v8::Primitive> Null() {
 # if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
     EscapableHandleScope scope;
     return scope.Escape(New(v8::Null(v8::Isolate::GetCurrent())));
@@ -538,7 +530,7 @@ class TryCatch {
 # endif
   }
 
-  NAN_INLINE v8::Local<v8::Boolean> True() {
+  inline v8::Local<v8::Boolean> True() {
 # if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
     EscapableHandleScope scope;
     return scope.Escape(New(v8::True(v8::Isolate::GetCurrent())));
@@ -547,7 +539,7 @@ class TryCatch {
 # endif
   }
 
-  NAN_INLINE v8::Local<v8::Boolean> False() {
+  inline v8::Local<v8::Boolean> False() {
 # if NODE_MODULE_VERSION < IOJS_3_0_MODULE_VERSION
     EscapableHandleScope scope;
     return scope.Escape(New(v8::False(v8::Isolate::GetCurrent())));
@@ -556,23 +548,23 @@ class TryCatch {
 # endif
   }
 
-  NAN_INLINE v8::Local<v8::String> EmptyString() {
+  inline v8::Local<v8::String> EmptyString() {
     return v8::String::Empty(v8::Isolate::GetCurrent());
   }
 
-  NAN_INLINE int AdjustExternalMemory(int bc) {
+  inline int AdjustExternalMemory(int bc) {
     return static_cast<int>(
         v8::Isolate::GetCurrent()->AdjustAmountOfExternalAllocatedMemory(bc));
   }
 
-  NAN_INLINE void SetTemplate(
+  inline void SetTemplate(
       v8::Local<v8::Template> templ
     , const char *name
     , v8::Local<v8::Data> value) {
     templ->Set(v8::Isolate::GetCurrent(), name, value);
   }
 
-  NAN_INLINE void SetTemplate(
+  inline void SetTemplate(
       v8::Local<v8::Template> templ
     , v8::Local<v8::String> name
     , v8::Local<v8::Data> value
@@ -580,17 +572,17 @@ class TryCatch {
     templ->Set(name, value, attributes);
   }
 
-  NAN_INLINE v8::Local<v8::Context> GetCurrentContext() {
+  inline v8::Local<v8::Context> GetCurrentContext() {
     return v8::Isolate::GetCurrent()->GetCurrentContext();
   }
 
-  NAN_INLINE void* GetInternalFieldPointer(
+  inline void* GetInternalFieldPointer(
       v8::Local<v8::Object> object
     , int index) {
     return object->GetAlignedPointerFromInternalField(index);
   }
 
-  NAN_INLINE void SetInternalFieldPointer(
+  inline void SetInternalFieldPointer(
       v8::Local<v8::Object> object
     , int index
     , void* value) {
@@ -608,51 +600,51 @@ class TryCatch {
   typedef v8::Isolate::GCCallback GCPrologueCallback;
 #endif
 
-  NAN_INLINE void AddGCEpilogueCallback(
+  inline void AddGCEpilogueCallback(
       GCEpilogueCallback callback
     , v8::GCType gc_type_filter = v8::kGCTypeAll) {
     v8::Isolate::GetCurrent()->AddGCEpilogueCallback(callback, gc_type_filter);
   }
 
-  NAN_INLINE void RemoveGCEpilogueCallback(
+  inline void RemoveGCEpilogueCallback(
       GCEpilogueCallback callback) {
     v8::Isolate::GetCurrent()->RemoveGCEpilogueCallback(callback);
   }
 
-  NAN_INLINE void AddGCPrologueCallback(
+  inline void AddGCPrologueCallback(
       GCPrologueCallback callback
     , v8::GCType gc_type_filter = v8::kGCTypeAll) {
     v8::Isolate::GetCurrent()->AddGCPrologueCallback(callback, gc_type_filter);
   }
 
-  NAN_INLINE void RemoveGCPrologueCallback(
+  inline void RemoveGCPrologueCallback(
       GCPrologueCallback callback) {
     v8::Isolate::GetCurrent()->RemoveGCPrologueCallback(callback);
   }
 
-  NAN_INLINE void GetHeapStatistics(
+  inline void GetHeapStatistics(
       v8::HeapStatistics *heap_statistics) {
     v8::Isolate::GetCurrent()->GetHeapStatistics(heap_statistics);
   }
 
 # define X(NAME)                                                               \
-    NAN_INLINE v8::Local<v8::Value> NAME(const char *msg) {                    \
+    inline v8::Local<v8::Value> NAME(const char *msg) {                    \
       EscapableHandleScope scope;                                              \
       return scope.Escape(v8::Exception::NAME(New(msg).ToLocalChecked()));     \
     }                                                                          \
                                                                                \
-    NAN_INLINE                                                                 \
+    inline                                                                 \
     v8::Local<v8::Value> NAME(v8::Local<v8::String> msg) {                     \
       return v8::Exception::NAME(msg);                                         \
     }                                                                          \
                                                                                \
-    NAN_INLINE void Throw ## NAME(const char *msg) {                           \
+    inline void Throw ## NAME(const char *msg) {                           \
       HandleScope scope;                                                       \
       v8::Isolate::GetCurrent()->ThrowException(                               \
           v8::Exception::NAME(New(msg).ToLocalChecked()));                     \
     }                                                                          \
                                                                                \
-    NAN_INLINE void Throw ## NAME(v8::Local<v8::String> msg) {                 \
+    inline void Throw ## NAME(v8::Local<v8::String> msg) {                 \
       HandleScope scope;                                                       \
       v8::Isolate::GetCurrent()->ThrowException(                               \
           v8::Exception::NAME(msg));                                           \
@@ -666,11 +658,11 @@ class TryCatch {
 
 # undef X
 
-  NAN_INLINE void ThrowError(v8::Local<v8::Value> error) {
+  inline void ThrowError(v8::Local<v8::Value> error) {
     v8::Isolate::GetCurrent()->ThrowException(error);
   }
 
-  NAN_INLINE MaybeLocal<v8::Object> NewBuffer(
+  inline MaybeLocal<v8::Object> NewBuffer(
       char *data
     , size_t length
 #if NODE_MODULE_VERSION > IOJS_2_0_MODULE_VERSION
@@ -692,7 +684,7 @@ class TryCatch {
 #endif
   }
 
-  NAN_INLINE MaybeLocal<v8::Object> CopyBuffer(
+  inline MaybeLocal<v8::Object> CopyBuffer(
       const char *data
     , uint32_t size
   ) {
@@ -708,7 +700,7 @@ class TryCatch {
 #endif
   }
 
-  NAN_INLINE MaybeLocal<v8::Object> NewBuffer(uint32_t size) {
+  inline MaybeLocal<v8::Object> NewBuffer(uint32_t size) {
     // arbitrary buffer lengths requires
     // NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION
     assert(size <= imp::kMaxLength && "too large buffer");
@@ -721,7 +713,7 @@ class TryCatch {
 #endif
   }
 
-  NAN_INLINE MaybeLocal<v8::Object> NewBuffer(
+  inline MaybeLocal<v8::Object> NewBuffer(
       char* data
     , uint32_t size
   ) {
@@ -738,13 +730,13 @@ class TryCatch {
 
 #if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
   (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
-  NAN_INLINE MaybeLocal<v8::String>
+  inline MaybeLocal<v8::String>
   NewOneByteString(const uint8_t * value, int length = -1) {
     return v8::String::NewFromOneByte(v8::Isolate::GetCurrent(), value,
           v8::NewStringType::kNormal, length);
   }
 
-  NAN_INLINE MaybeLocal<BoundScript> CompileScript(
+  inline MaybeLocal<BoundScript> CompileScript(
       v8::Local<v8::String> s
     , const v8::ScriptOrigin& origin
   ) {
@@ -752,26 +744,26 @@ class TryCatch {
     return v8::ScriptCompiler::Compile(GetCurrentContext(), &source);
   }
 
-  NAN_INLINE MaybeLocal<BoundScript> CompileScript(
+  inline MaybeLocal<BoundScript> CompileScript(
       v8::Local<v8::String> s
   ) {
     v8::ScriptCompiler::Source source(s);
     return v8::ScriptCompiler::Compile(GetCurrentContext(), &source);
   }
 
-  NAN_INLINE MaybeLocal<v8::Value> RunScript(
+  inline MaybeLocal<v8::Value> RunScript(
       v8::Local<UnboundScript> script
   ) {
     return script->BindToCurrentContext()->Run(GetCurrentContext());
   }
 
-  NAN_INLINE MaybeLocal<v8::Value> RunScript(
+  inline MaybeLocal<v8::Value> RunScript(
       v8::Local<BoundScript> script
   ) {
     return script->Run(GetCurrentContext());
   }
 #else
-  NAN_INLINE MaybeLocal<v8::String>
+  inline MaybeLocal<v8::String>
   NewOneByteString(const uint8_t * value, int length = -1) {
     return MaybeLocal<v8::String>(
         v8::String::NewFromOneByte(
@@ -780,7 +772,7 @@ class TryCatch {
           , v8::String::kNormalString, length));
   }
 
-  NAN_INLINE MaybeLocal<BoundScript> CompileScript(
+  inline MaybeLocal<BoundScript> CompileScript(
       v8::Local<v8::String> s
     , const v8::ScriptOrigin& origin
   ) {
@@ -789,7 +781,7 @@ class TryCatch {
         v8::ScriptCompiler::Compile(v8::Isolate::GetCurrent(), &source));
   }
 
-  NAN_INLINE MaybeLocal<BoundScript> CompileScript(
+  inline MaybeLocal<BoundScript> CompileScript(
       v8::Local<v8::String> s
   ) {
     v8::ScriptCompiler::Source source(s);
@@ -797,20 +789,20 @@ class TryCatch {
         v8::ScriptCompiler::Compile(v8::Isolate::GetCurrent(), &source));
   }
 
-  NAN_INLINE MaybeLocal<v8::Value> RunScript(
+  inline MaybeLocal<v8::Value> RunScript(
       v8::Local<UnboundScript> script
   ) {
     return MaybeLocal<v8::Value>(script->BindToCurrentContext()->Run());
   }
 
-  NAN_INLINE MaybeLocal<v8::Value> RunScript(
+  inline MaybeLocal<v8::Value> RunScript(
       v8::Local<BoundScript> script
   ) {
     return MaybeLocal<v8::Value>(script->Run());
   }
 #endif
 
-  NAN_INLINE v8::Local<v8::Value> MakeCallback(
+  inline v8::Local<v8::Value> MakeCallback(
       v8::Local<v8::Object> target
     , v8::Local<v8::Function> func
     , int argc
@@ -824,7 +816,7 @@ class TryCatch {
 #endif
   }
 
-  NAN_INLINE v8::Local<v8::Value> MakeCallback(
+  inline v8::Local<v8::Value> MakeCallback(
       v8::Local<v8::Object> target
     , v8::Local<v8::String> symbol
     , int argc
@@ -838,7 +830,7 @@ class TryCatch {
 #endif
   }
 
-  NAN_INLINE v8::Local<v8::Value> MakeCallback(
+  inline v8::Local<v8::Value> MakeCallback(
       v8::Local<v8::Object> target
     , const char* method
     , int argc
@@ -852,11 +844,11 @@ class TryCatch {
 #endif
   }
 
-  NAN_INLINE void FatalException(const TryCatch& try_catch) {
+  inline void FatalException(const TryCatch& try_catch) {
     node::FatalException(v8::Isolate::GetCurrent(), try_catch.try_catch_);
   }
 
-  NAN_INLINE v8::Local<v8::Value> ErrnoException(
+  inline v8::Local<v8::Value> ErrnoException(
           int errorno
        ,  const char* syscall = NULL
        ,  const char* message = NULL
@@ -865,7 +857,7 @@ class TryCatch {
             message, path);
   }
 
-  NAN_DEPRECATED NAN_INLINE v8::Local<v8::Value> NanErrnoException(
+  NAN_DEPRECATED inline v8::Local<v8::Value> NanErrnoException(
           int errorno
        ,  const char* syscall = NULL
        ,  const char* message = NULL
@@ -874,7 +866,7 @@ class TryCatch {
   }
 
   template<typename T>
-  NAN_INLINE void SetIsolateData(
+  inline void SetIsolateData(
       v8::Isolate *isolate
     , T *data
   ) {
@@ -882,7 +874,7 @@ class TryCatch {
   }
 
   template<typename T>
-  NAN_INLINE T *GetIsolateData(
+  inline T *GetIsolateData(
       v8::Isolate *isolate
   ) {
       return static_cast<T*>(isolate->GetData(0));
@@ -890,7 +882,7 @@ class TryCatch {
 
 class Utf8String {
  public:
-  NAN_INLINE explicit Utf8String(v8::Local<v8::Value> from) :
+  inline explicit Utf8String(v8::Local<v8::Value> from) :
       length_(0), str_(str_st_) {
     if (!from.IsEmpty()) {
       v8::Local<v8::String> string = from->ToString();
@@ -909,14 +901,14 @@ class Utf8String {
     }
   }
 
-  NAN_INLINE int length() const {
+  inline int length() const {
     return length_;
   }
 
-  NAN_INLINE char* operator*() { return str_; }
-  NAN_INLINE const char* operator*() const { return str_; }
+  inline char* operator*() { return str_; }
+  inline const char* operator*() const { return str_; }
 
-  NAN_INLINE ~Utf8String() {
+  inline ~Utf8String() {
     if (str_ != str_st_) {
       free(str_);
     }
@@ -931,42 +923,42 @@ class Utf8String {
 };
 
 #else  // Node 0.8 and 0.10
-  NAN_INLINE v8::Local<v8::Primitive> Undefined() {
+  inline v8::Local<v8::Primitive> Undefined() {
     EscapableHandleScope scope;
     return scope.Escape(New(v8::Undefined()));
   }
 
-  NAN_INLINE v8::Local<v8::Primitive> Null() {
+  inline v8::Local<v8::Primitive> Null() {
     EscapableHandleScope scope;
     return scope.Escape(New(v8::Null()));
   }
 
-  NAN_INLINE v8::Local<v8::Boolean> True() {
+  inline v8::Local<v8::Boolean> True() {
     EscapableHandleScope scope;
     return scope.Escape(New(v8::True()));
   }
 
-  NAN_INLINE v8::Local<v8::Boolean> False() {
+  inline v8::Local<v8::Boolean> False() {
     EscapableHandleScope scope;
     return scope.Escape(New(v8::False()));
   }
 
-  NAN_INLINE v8::Local<v8::String> EmptyString() {
+  inline v8::Local<v8::String> EmptyString() {
     return v8::String::Empty();
   }
 
-  NAN_INLINE int AdjustExternalMemory(int bc) {
+  inline int AdjustExternalMemory(int bc) {
     return static_cast<int>(v8::V8::AdjustAmountOfExternalAllocatedMemory(bc));
   }
 
-  NAN_INLINE void SetTemplate(
+  inline void SetTemplate(
       v8::Local<v8::Template> templ
     , const char *name
     , v8::Local<v8::Data> value) {
     templ->Set(name, value);
   }
 
-  NAN_INLINE void SetTemplate(
+  inline void SetTemplate(
       v8::Local<v8::Template> templ
     , v8::Local<v8::String> name
     , v8::Local<v8::Data> value
@@ -974,17 +966,17 @@ class Utf8String {
     templ->Set(name, value, attributes);
   }
 
-  NAN_INLINE v8::Local<v8::Context> GetCurrentContext() {
+  inline v8::Local<v8::Context> GetCurrentContext() {
     return v8::Context::GetCurrent();
   }
 
-  NAN_INLINE void* GetInternalFieldPointer(
+  inline void* GetInternalFieldPointer(
       v8::Local<v8::Object> object
     , int index) {
     return object->GetPointerFromInternalField(index);
   }
 
-  NAN_INLINE void SetInternalFieldPointer(
+  inline void SetInternalFieldPointer(
       v8::Local<v8::Object> object
     , int index
     , void* value) {
@@ -994,46 +986,46 @@ class Utf8String {
 # define NAN_GC_CALLBACK(name)                                                 \
     void name(v8::GCType type, v8::GCCallbackFlags flags)
 
-  NAN_INLINE void AddGCEpilogueCallback(
+  inline void AddGCEpilogueCallback(
     v8::GCEpilogueCallback callback
   , v8::GCType gc_type_filter = v8::kGCTypeAll) {
     v8::V8::AddGCEpilogueCallback(callback, gc_type_filter);
   }
-  NAN_INLINE void RemoveGCEpilogueCallback(
+  inline void RemoveGCEpilogueCallback(
     v8::GCEpilogueCallback callback) {
     v8::V8::RemoveGCEpilogueCallback(callback);
   }
-  NAN_INLINE void AddGCPrologueCallback(
+  inline void AddGCPrologueCallback(
     v8::GCPrologueCallback callback
   , v8::GCType gc_type_filter = v8::kGCTypeAll) {
     v8::V8::AddGCPrologueCallback(callback, gc_type_filter);
   }
-  NAN_INLINE void RemoveGCPrologueCallback(
+  inline void RemoveGCPrologueCallback(
     v8::GCPrologueCallback callback) {
     v8::V8::RemoveGCPrologueCallback(callback);
   }
-  NAN_INLINE void GetHeapStatistics(
+  inline void GetHeapStatistics(
     v8::HeapStatistics *heap_statistics) {
     v8::V8::GetHeapStatistics(heap_statistics);
   }
 
 # define X(NAME)                                                               \
-    NAN_INLINE v8::Local<v8::Value> NAME(const char *msg) {                    \
+    inline v8::Local<v8::Value> NAME(const char *msg) {                    \
       EscapableHandleScope scope;                                              \
       return scope.Escape(v8::Exception::NAME(New(msg).ToLocalChecked()));     \
     }                                                                          \
                                                                                \
-    NAN_INLINE                                                                 \
+    inline                                                                 \
     v8::Local<v8::Value> NAME(v8::Local<v8::String> msg) {                     \
       return v8::Exception::NAME(msg);                                         \
     }                                                                          \
                                                                                \
-    NAN_INLINE void Throw ## NAME(const char *msg) {                           \
+    inline void Throw ## NAME(const char *msg) {                           \
       HandleScope scope;                                                       \
       v8::ThrowException(v8::Exception::NAME(New(msg).ToLocalChecked()));      \
     }                                                                          \
                                                                                \
-    NAN_INLINE                                                                 \
+    inline                                                                 \
     void Throw ## NAME(v8::Local<v8::String> errmsg) {                         \
       v8::ThrowException(v8::Exception::NAME(errmsg));                         \
     }
@@ -1046,11 +1038,11 @@ class Utf8String {
 
 # undef X
 
-  NAN_INLINE void ThrowError(v8::Local<v8::Value> error) {
+  inline void ThrowError(v8::Local<v8::Value> error) {
     v8::ThrowException(error);
   }
 
-  NAN_INLINE MaybeLocal<v8::Object> NewBuffer(
+  inline MaybeLocal<v8::Object> NewBuffer(
       char *data
     , size_t length
     , node::Buffer::free_callback callback
@@ -1064,7 +1056,7 @@ class Utf8String {
         New(node::Buffer::New(data, length, callback, hint)->handle_)));
   }
 
-  NAN_INLINE MaybeLocal<v8::Object> CopyBuffer(
+  inline MaybeLocal<v8::Object> CopyBuffer(
       const char *data
     , uint32_t size
   ) {
@@ -1081,7 +1073,7 @@ class Utf8String {
 #endif
   }
 
-  NAN_INLINE MaybeLocal<v8::Object> NewBuffer(uint32_t size) {
+  inline MaybeLocal<v8::Object> NewBuffer(uint32_t size) {
     // arbitrary buffer lengths requires
     // NODE_MODULE_VERSION >= IOJS_3_0_MODULE_VERSION
     EscapableHandleScope scope;
@@ -1090,12 +1082,12 @@ class Utf8String {
         scope.Escape(New(node::Buffer::New(size)->handle_)));
   }
 
-  NAN_INLINE void FreeData(char *data, void *hint) {
+  inline void FreeData(char *data, void *hint) {
     (void) hint;  // unused
     delete[] data;
   }
 
-  NAN_INLINE MaybeLocal<v8::Object> NewBuffer(
+  inline MaybeLocal<v8::Object> NewBuffer(
       char* data
     , uint32_t size
   ) {
@@ -1108,7 +1100,7 @@ class Utf8String {
   }
 
 namespace imp {
-NAN_INLINE void
+inline void
 widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
   size_t len = static_cast<size_t>(l);
   if (l < 0) {
@@ -1120,7 +1112,7 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
 }
 }  // end of namespace imp
 
-  NAN_INLINE MaybeLocal<v8::String>
+  inline MaybeLocal<v8::String>
   NewOneByteString(const uint8_t * value, int length = -1) {
     std::vector<uint16_t> wideString;  // NOLINT(build/include_what_you_use)
     imp::widenString(&wideString, value, length);
@@ -1128,7 +1120,7 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
         &wideString.front(), static_cast<int>(wideString.size())));
   }
 
-  NAN_INLINE MaybeLocal<BoundScript> CompileScript(
+  inline MaybeLocal<BoundScript> CompileScript(
       v8::Local<v8::String> s
     , const v8::ScriptOrigin& origin
   ) {
@@ -1136,18 +1128,18 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
         v8::Script::Compile(s, const_cast<v8::ScriptOrigin *>(&origin)));
   }
 
-  NAN_INLINE MaybeLocal<BoundScript> CompileScript(
+  inline MaybeLocal<BoundScript> CompileScript(
     v8::Local<v8::String> s
   ) {
     return MaybeLocal<BoundScript>(v8::Script::Compile(s));
   }
 
-  NAN_INLINE
+  inline
   MaybeLocal<v8::Value> RunScript(v8::Local<v8::Script> script) {
     return MaybeLocal<v8::Value>(script->Run());
   }
 
-  NAN_INLINE v8::Local<v8::Value> MakeCallback(
+  inline v8::Local<v8::Value> MakeCallback(
       v8::Local<v8::Object> target
     , v8::Local<v8::Function> func
     , int argc
@@ -1155,7 +1147,7 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
     return New(node::MakeCallback(target, func, argc, argv));
   }
 
-  NAN_INLINE v8::Local<v8::Value> MakeCallback(
+  inline v8::Local<v8::Value> MakeCallback(
       v8::Local<v8::Object> target
     , v8::Local<v8::String> symbol
     , int argc
@@ -1163,7 +1155,7 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
     return New(node::MakeCallback(target, symbol, argc, argv));
   }
 
-  NAN_INLINE v8::Local<v8::Value> MakeCallback(
+  inline v8::Local<v8::Value> MakeCallback(
       v8::Local<v8::Object> target
     , const char* method
     , int argc
@@ -1171,11 +1163,11 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
     return New(node::MakeCallback(target, method, argc, argv));
   }
 
-  NAN_INLINE void FatalException(const TryCatch& try_catch) {
+  inline void FatalException(const TryCatch& try_catch) {
     node::FatalException(const_cast<v8::TryCatch &>(try_catch.try_catch_));
   }
 
-  NAN_INLINE v8::Local<v8::Value> ErrnoException(
+  inline v8::Local<v8::Value> ErrnoException(
           int errorno
        ,  const char* syscall = NULL
        ,  const char* message = NULL
@@ -1183,7 +1175,7 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
     return node::ErrnoException(errorno, syscall, message, path);
   }
 
-  NAN_DEPRECATED NAN_INLINE v8::Local<v8::Value> NanErrnoException(
+  NAN_DEPRECATED inline v8::Local<v8::Value> NanErrnoException(
           int errorno
        ,  const char* syscall = NULL
        ,  const char* message = NULL
@@ -1193,7 +1185,7 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
 
 
   template<typename T>
-  NAN_INLINE void SetIsolateData(
+  inline void SetIsolateData(
       v8::Isolate *isolate
     , T *data
   ) {
@@ -1201,7 +1193,7 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
   }
 
   template<typename T>
-  NAN_INLINE T *GetIsolateData(
+  inline T *GetIsolateData(
       v8::Isolate *isolate
   ) {
       return static_cast<T*>(isolate->GetData());
@@ -1209,7 +1201,7 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l) {
 
 class Utf8String {
  public:
-  NAN_INLINE explicit Utf8String(v8::Local<v8::Value> from) :
+  inline explicit Utf8String(v8::Local<v8::Value> from) :
       length_(0), str_(str_st_) {
     if (!from.IsEmpty()) {
       v8::Local<v8::String> string = from->ToString();
@@ -1228,14 +1220,14 @@ class Utf8String {
     }
   }
 
-  NAN_INLINE int length() const {
+  inline int length() const {
     return length_;
   }
 
-  NAN_INLINE char* operator*() { return str_; }
-  NAN_INLINE const char* operator*() const { return str_; }
+  inline char* operator*() { return str_; }
+  inline const char* operator*() const { return str_; }
 
-  NAN_INLINE ~Utf8String() {
+  inline ~Utf8String() {
     if (str_ != str_st_) {
       free(str_);
     }
@@ -1383,39 +1375,39 @@ class Callback {
     return !this->operator==(other);
   }
 
-  NAN_INLINE
+  inline
   v8::Local<v8::Function> operator*() const { return this->GetFunction(); }
 
-  NAN_INLINE v8::Local<v8::Value> operator()(
+  inline v8::Local<v8::Value> operator()(
       v8::Local<v8::Object> target
     , int argc = 0
     , v8::Local<v8::Value> argv[] = 0) const {
     return this->Call(target, argc, argv);
   }
 
-  NAN_INLINE v8::Local<v8::Value> operator()(
+  inline v8::Local<v8::Value> operator()(
       int argc = 0
     , v8::Local<v8::Value> argv[] = 0) const {
     return this->Call(argc, argv);
   }
 
-  NAN_INLINE void SetFunction(const v8::Local<v8::Function> &fn) {
+  inline void SetFunction(const v8::Local<v8::Function> &fn) {
     HandleScope scope;
     Set(New(handle), kCallbackIndex, fn);
   }
 
-  NAN_INLINE v8::Local<v8::Function> GetFunction() const {
+  inline v8::Local<v8::Function> GetFunction() const {
     EscapableHandleScope scope;
     return scope.Escape(New(handle)->Get(kCallbackIndex)
         .As<v8::Function>());
   }
 
-  NAN_INLINE bool IsEmpty() const {
+  inline bool IsEmpty() const {
     HandleScope scope;
     return New(handle)->Get(kCallbackIndex)->IsUndefined();
   }
 
-  NAN_INLINE v8::Local<v8::Value>
+  inline v8::Local<v8::Value>
   Call(v8::Local<v8::Object> target
      , int argc
      , v8::Local<v8::Value> argv[]) const {
@@ -1427,7 +1419,7 @@ class Callback {
 #endif
   }
 
-  NAN_INLINE v8::Local<v8::Value>
+  inline v8::Local<v8::Value>
   Call(int argc, v8::Local<v8::Value> argv[]) const {
 #if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
     v8::Isolate *isolate = v8::Isolate::GetCurrent();
@@ -1518,37 +1510,37 @@ class Callback {
     callback = NULL;
   }
 
-  NAN_INLINE void SaveToPersistent(
+  inline void SaveToPersistent(
       const char *key, const v8::Local<v8::Value> &value) {
     HandleScope scope;
     New(persistentHandle)->Set(New(key).ToLocalChecked(), value);
   }
 
-  NAN_INLINE void SaveToPersistent(
+  inline void SaveToPersistent(
       const v8::Local<v8::String> &key, const v8::Local<v8::Value> &value) {
     HandleScope scope;
     New(persistentHandle)->Set(key, value);
   }
 
-  NAN_INLINE void SaveToPersistent(
+  inline void SaveToPersistent(
       uint32_t index, const v8::Local<v8::Value> &value) {
     HandleScope scope;
     New(persistentHandle)->Set(index, value);
   }
 
-  NAN_INLINE v8::Local<v8::Value> GetFromPersistent(const char *key) const {
+  inline v8::Local<v8::Value> GetFromPersistent(const char *key) const {
     EscapableHandleScope scope;
     return scope.Escape(
         New(persistentHandle)->Get(New(key).ToLocalChecked()));
   }
 
-  NAN_INLINE v8::Local<v8::Value>
+  inline v8::Local<v8::Value>
   GetFromPersistent(const v8::Local<v8::String> &key) const {
     EscapableHandleScope scope;
     return scope.Escape(New(persistentHandle)->Get(key));
   }
 
-  NAN_INLINE v8::Local<v8::Value> GetFromPersistent(uint32_t index) const {
+  inline v8::Local<v8::Value> GetFromPersistent(uint32_t index) const {
     EscapableHandleScope scope;
     return scope.Escape(New(persistentHandle)->Get(index));
   }
@@ -1674,13 +1666,13 @@ class Callback {
     uv_async_send(async);
   }
 
-  NAN_INLINE static NAUV_WORK_CB(AsyncProgress_) {
+  inline static NAUV_WORK_CB(AsyncProgress_) {
     AsyncProgressWorker *worker =
             static_cast<AsyncProgressWorker*>(async->data);
     worker->WorkProgress();
   }
 
-  NAN_INLINE static void AsyncClose_(uv_handle_t* handle) {
+  inline static void AsyncClose_(uv_handle_t* handle) {
     AsyncProgressWorker *worker =
             static_cast<AsyncProgressWorker*>(handle->data);
     delete reinterpret_cast<uv_async_t*>(handle);
@@ -1693,18 +1685,18 @@ class Callback {
   size_t asyncsize_;
 };
 
-NAN_INLINE void AsyncExecute (uv_work_t* req) {
+inline void AsyncExecute (uv_work_t* req) {
   AsyncWorker *worker = static_cast<AsyncWorker*>(req->data);
   worker->Execute();
 }
 
-NAN_INLINE void AsyncExecuteComplete (uv_work_t* req) {
+inline void AsyncExecuteComplete (uv_work_t* req) {
   AsyncWorker* worker = static_cast<AsyncWorker*>(req->data);
   worker->WorkComplete();
   worker->Destroy();
 }
 
-NAN_INLINE void AsyncQueueWorker (AsyncWorker* worker) {
+inline void AsyncQueueWorker (AsyncWorker* worker) {
   uv_queue_work(
       uv_default_loop()
     , &worker->request
@@ -1743,7 +1735,7 @@ enum Encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER};
 # include "nan_string_bytes.h"  // NOLINT(build/include)
 #endif
 
-NAN_INLINE v8::Local<v8::Value> Encode(
+inline v8::Local<v8::Value> Encode(
     const void *buf, size_t len, enum Encoding encoding = BINARY) {
 #if (NODE_MODULE_VERSION >= ATOM_0_21_MODULE_VERSION)
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
@@ -1775,7 +1767,7 @@ NAN_INLINE v8::Local<v8::Value> Encode(
 #endif
 }
 
-NAN_INLINE ssize_t DecodeBytes(
+inline ssize_t DecodeBytes(
     v8::Local<v8::Value> val, enum Encoding encoding = BINARY) {
 #if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
   return node::DecodeBytes(
@@ -1792,7 +1784,7 @@ NAN_INLINE ssize_t DecodeBytes(
 #endif
 }
 
-NAN_INLINE ssize_t DecodeWrite(
+inline ssize_t DecodeWrite(
     char *buf
   , size_t len
   , v8::Local<v8::Value> val
@@ -1818,7 +1810,7 @@ NAN_INLINE ssize_t DecodeWrite(
 #endif
 }
 
-NAN_INLINE void SetPrototypeTemplate(
+inline void SetPrototypeTemplate(
     v8::Local<v8::FunctionTemplate> templ
   , const char *name
   , v8::Local<v8::Data> value
@@ -1826,7 +1818,7 @@ NAN_INLINE void SetPrototypeTemplate(
   SetTemplate(templ->PrototypeTemplate(), name, value);
 }
 
-NAN_INLINE void SetPrototypeTemplate(
+inline void SetPrototypeTemplate(
     v8::Local<v8::FunctionTemplate> templ
   , v8::Local<v8::String> name
   , v8::Local<v8::Data> value
@@ -1835,7 +1827,7 @@ NAN_INLINE void SetPrototypeTemplate(
   SetTemplate(templ->PrototypeTemplate(), name, value, attributes);
 }
 
-NAN_INLINE void SetInstanceTemplate(
+inline void SetInstanceTemplate(
     v8::Local<v8::FunctionTemplate> templ
   , const char *name
   , v8::Local<v8::Data> value
@@ -1843,7 +1835,7 @@ NAN_INLINE void SetInstanceTemplate(
   SetTemplate(templ->InstanceTemplate(), name, value);
 }
 
-NAN_INLINE void SetInstanceTemplate(
+inline void SetInstanceTemplate(
     v8::Local<v8::FunctionTemplate> templ
   , v8::Local<v8::String> name
   , v8::Local<v8::Data> value
@@ -1859,7 +1851,7 @@ namespace imp {
 // handles everything else. The final argument only serves as discriminator and
 // is unused.
 template <typename T>
-NAN_INLINE
+inline
 void
 SetMethodAux(T recv,
              v8::Local<v8::String> name,
@@ -1869,7 +1861,7 @@ SetMethodAux(T recv,
 }
 
 template <typename T>
-NAN_INLINE
+inline
 void
 SetMethodAux(T recv,
              v8::Local<v8::String> name,
@@ -1881,7 +1873,7 @@ SetMethodAux(T recv,
 }  // end of namespace imp
 
 template <typename T, template <typename> class HandleType>
-NAN_INLINE void SetMethod(
+inline void SetMethod(
     HandleType<T> recv
   , const char *name
   , FunctionCallback callback) {
@@ -1894,7 +1886,7 @@ NAN_INLINE void SetMethod(
   imp::SetMethodAux(recv, fn_name, t, static_cast<T*>(0));
 }
 
-NAN_INLINE void SetPrototypeMethod(
+inline void SetPrototypeMethod(
     v8::Local<v8::FunctionTemplate> recv
   , const char* name, FunctionCallback callback) {
   HandleScope scope;

--- a/nan.h
+++ b/nan.h
@@ -84,6 +84,8 @@
 
 namespace Nan {
 
+#define NAN_INLINE inline  // TODO(bnoordhuis) Remove in v3.0.0.
+
 #if defined(__GNUC__) && \
     !(defined(V8_DISABLE_DEPRECATIONS) && V8_DISABLE_DEPRECATIONS)
 # define NAN_DEPRECATED __attribute__((deprecated))

--- a/nan_callbacks_pre_12_inl.h
+++ b/nan_callbacks_pre_12_inl.h
@@ -275,7 +275,7 @@ class ReturnValueImp : public ReturnValue<T> {
  public:
   explicit ReturnValueImp(ReturnValue<T> that) :
       ReturnValue<T>(that) {}
-  NAN_INLINE v8::Handle<T> Value() {
+  inline v8::Handle<T> Value() {
       return *ReturnValue<T>::value_;
   }
 };

--- a/nan_converters.h
+++ b/nan_converters.h
@@ -49,7 +49,7 @@ X(int32_t)
 }  // end of namespace imp
 
 template<typename T>
-NAN_INLINE
+inline
 typename imp::ToFactory<T>::return_t To(v8::Local<v8::Value> val) {
   return imp::ToFactory<T>::convert(val);
 }

--- a/nan_maybe_43_inl.h
+++ b/nan_maybe_43_inl.h
@@ -16,38 +16,38 @@ template<typename T>
 using Maybe = v8::Maybe<T>;
 
 template<typename T>
-NAN_INLINE Maybe<T> Nothing() {
+inline Maybe<T> Nothing() {
   return v8::Nothing<T>();
 }
 
 template<typename T>
-NAN_INLINE Maybe<T> Just(const T& t) {
+inline Maybe<T> Just(const T& t) {
   return v8::Just<T>(t);
 }
 
 v8::Local<v8::Context> GetCurrentContext();
 
-NAN_INLINE
+inline
 MaybeLocal<v8::String> ToDetailString(v8::Local<v8::Value> val) {
   return val->ToDetailString(GetCurrentContext());
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Uint32> ToArrayIndex(v8::Local<v8::Value> val) {
   return val->ToArrayIndex(GetCurrentContext());
 }
 
-NAN_INLINE
+inline
 Maybe<bool> Equals(v8::Local<v8::Value> a, v8::Local<v8::Value>(b)) {
   return a->Equals(GetCurrentContext(), b);
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Object> NewInstance(v8::Local<v8::Function> h) {
   return h->NewInstance(GetCurrentContext());
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Object> NewInstance(
       v8::Local<v8::Function> h
     , int argc
@@ -55,32 +55,32 @@ MaybeLocal<v8::Object> NewInstance(
   return h->NewInstance(GetCurrentContext(), argc, argv);
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Object> NewInstance(v8::Local<v8::ObjectTemplate> h) {
   return h->NewInstance(GetCurrentContext());
 }
 
 
-NAN_INLINE MaybeLocal<v8::Function> GetFunction(
+inline MaybeLocal<v8::Function> GetFunction(
     v8::Local<v8::FunctionTemplate> t) {
   return t->GetFunction(GetCurrentContext());
 }
 
-NAN_INLINE Maybe<bool> Set(
+inline Maybe<bool> Set(
     v8::Local<v8::Object> obj
   , v8::Local<v8::Value> key
   , v8::Local<v8::Value> value) {
   return obj->Set(GetCurrentContext(), key, value);
 }
 
-NAN_INLINE Maybe<bool> Set(
+inline Maybe<bool> Set(
     v8::Local<v8::Object> obj
   , uint32_t index
   , v8::Local<v8::Value> value) {
   return obj->Set(GetCurrentContext(), index, value);
 }
 
-NAN_INLINE Maybe<bool> ForceSet(
+inline Maybe<bool> ForceSet(
     v8::Local<v8::Object> obj
   , v8::Local<v8::Value> key
   , v8::Local<v8::Value> value
@@ -88,102 +88,102 @@ NAN_INLINE Maybe<bool> ForceSet(
   return obj->ForceSet(GetCurrentContext(), key, value, attribs);
 }
 
-NAN_INLINE MaybeLocal<v8::Value> Get(
+inline MaybeLocal<v8::Value> Get(
     v8::Local<v8::Object> obj
   , v8::Local<v8::Value> key) {
   return obj->Get(GetCurrentContext(), key);
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Value> Get(v8::Local<v8::Object> obj, uint32_t index) {
   return obj->Get(GetCurrentContext(), index);
 }
 
-NAN_INLINE v8::PropertyAttribute GetPropertyAttributes(
+inline v8::PropertyAttribute GetPropertyAttributes(
     v8::Local<v8::Object> obj
   , v8::Local<v8::Value> key) {
   return obj->GetPropertyAttributes(GetCurrentContext(), key).FromJust();
 }
 
-NAN_INLINE Maybe<bool> Has(
+inline Maybe<bool> Has(
     v8::Local<v8::Object> obj
   , v8::Local<v8::String> key) {
   return obj->Has(GetCurrentContext(), key);
 }
 
-NAN_INLINE Maybe<bool> Has(v8::Local<v8::Object> obj, uint32_t index) {
+inline Maybe<bool> Has(v8::Local<v8::Object> obj, uint32_t index) {
   return obj->Has(GetCurrentContext(), index);
 }
 
-NAN_INLINE Maybe<bool> Delete(
+inline Maybe<bool> Delete(
     v8::Local<v8::Object> obj
   , v8::Local<v8::String> key) {
   return obj->Delete(GetCurrentContext(), key);
 }
 
-NAN_INLINE
+inline
 Maybe<bool> Delete(v8::Local<v8::Object> obj, uint32_t index) {
   return obj->Delete(GetCurrentContext(), index);
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Array> GetPropertyNames(v8::Local<v8::Object> obj) {
   return obj->GetPropertyNames(GetCurrentContext());
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Array> GetOwnPropertyNames(v8::Local<v8::Object> obj) {
   return obj->GetOwnPropertyNames(GetCurrentContext());
 }
 
-NAN_INLINE Maybe<bool> SetPrototype(
+inline Maybe<bool> SetPrototype(
     v8::Local<v8::Object> obj
   , v8::Local<v8::Value> prototype) {
   return obj->SetPrototype(GetCurrentContext(), prototype);
 }
 
-NAN_INLINE MaybeLocal<v8::String> ObjectProtoToString(
+inline MaybeLocal<v8::String> ObjectProtoToString(
     v8::Local<v8::Object> obj) {
   return obj->ObjectProtoToString(GetCurrentContext());
 }
 
-NAN_INLINE Maybe<bool> HasOwnProperty(
+inline Maybe<bool> HasOwnProperty(
     v8::Local<v8::Object> obj
   , v8::Local<v8::String> key) {
   return obj->HasOwnProperty(GetCurrentContext(), key);
 }
 
-NAN_INLINE Maybe<bool> HasRealNamedProperty(
+inline Maybe<bool> HasRealNamedProperty(
     v8::Local<v8::Object> obj
   , v8::Local<v8::String> key) {
   return obj->HasRealNamedProperty(GetCurrentContext(), key);
 }
 
-NAN_INLINE Maybe<bool> HasRealIndexedProperty(
+inline Maybe<bool> HasRealIndexedProperty(
     v8::Local<v8::Object> obj
   , uint32_t index) {
   return obj->HasRealIndexedProperty(GetCurrentContext(), index);
 }
 
-NAN_INLINE Maybe<bool> HasRealNamedCallbackProperty(
+inline Maybe<bool> HasRealNamedCallbackProperty(
     v8::Local<v8::Object> obj
   , v8::Local<v8::String> key) {
   return obj->HasRealNamedCallbackProperty(GetCurrentContext(), key);
 }
 
-NAN_INLINE MaybeLocal<v8::Value> GetRealNamedPropertyInPrototypeChain(
+inline MaybeLocal<v8::Value> GetRealNamedPropertyInPrototypeChain(
     v8::Local<v8::Object> obj
   , v8::Local<v8::String> key) {
   return obj->GetRealNamedPropertyInPrototypeChain(GetCurrentContext(), key);
 }
 
-NAN_INLINE MaybeLocal<v8::Value> GetRealNamedProperty(
+inline MaybeLocal<v8::Value> GetRealNamedProperty(
     v8::Local<v8::Object> obj
   , v8::Local<v8::String> key) {
   return obj->GetRealNamedProperty(GetCurrentContext(), key);
 }
 
-NAN_INLINE MaybeLocal<v8::Value> CallAsFunction(
+inline MaybeLocal<v8::Value> CallAsFunction(
     v8::Local<v8::Object> obj
   , v8::Local<v8::Object> recv
   , int argc
@@ -191,30 +191,30 @@ NAN_INLINE MaybeLocal<v8::Value> CallAsFunction(
   return obj->CallAsFunction(GetCurrentContext(), recv, argc, argv);
 }
 
-NAN_INLINE MaybeLocal<v8::Value> CallAsConstructor(
+inline MaybeLocal<v8::Value> CallAsConstructor(
     v8::Local<v8::Object> obj
   , int argc, v8::Local<v8::Value> argv[]) {
   return obj->CallAsConstructor(GetCurrentContext(), argc, argv);
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::String> GetSourceLine(v8::Local<v8::Message> msg) {
   return msg->GetSourceLine(GetCurrentContext());
 }
 
-NAN_INLINE Maybe<int> GetLineNumber(v8::Local<v8::Message> msg) {
+inline Maybe<int> GetLineNumber(v8::Local<v8::Message> msg) {
   return msg->GetLineNumber(GetCurrentContext());
 }
 
-NAN_INLINE Maybe<int> GetStartColumn(v8::Local<v8::Message> msg) {
+inline Maybe<int> GetStartColumn(v8::Local<v8::Message> msg) {
   return msg->GetStartColumn(GetCurrentContext());
 }
 
-NAN_INLINE Maybe<int> GetEndColumn(v8::Local<v8::Message> msg) {
+inline Maybe<int> GetEndColumn(v8::Local<v8::Message> msg) {
   return msg->GetEndColumn(GetCurrentContext());
 }
 
-NAN_INLINE MaybeLocal<v8::Object> CloneElementAt(
+inline MaybeLocal<v8::Object> CloneElementAt(
     v8::Local<v8::Array> array
   , uint32_t index) {
 #if (NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION)
@@ -234,7 +234,7 @@ NAN_INLINE MaybeLocal<v8::Object> CloneElementAt(
 #endif
 }
 
-NAN_INLINE MaybeLocal<v8::Value> Call(
+inline MaybeLocal<v8::Value> Call(
     v8::Local<v8::Function> fun
   , v8::Local<v8::Object> recv
   , int argc

--- a/nan_maybe_pre_43_inl.h
+++ b/nan_maybe_pre_43_inl.h
@@ -12,25 +12,25 @@
 template<typename T>
 class MaybeLocal {
  public:
-  NAN_INLINE MaybeLocal() : val_(v8::Local<T>()) {}
+  inline MaybeLocal() : val_(v8::Local<T>()) {}
 
   template<typename S>
 # if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION
-  NAN_INLINE MaybeLocal(v8::Local<S> that) : val_(that) {}
+  inline MaybeLocal(v8::Local<S> that) : val_(that) {}
 # else
-  NAN_INLINE MaybeLocal(v8::Local<S> that) :
+  inline MaybeLocal(v8::Local<S> that) :
       val_(*reinterpret_cast<v8::Local<T>*>(&that)) {}
 # endif
 
-  NAN_INLINE bool IsEmpty() const { return val_.IsEmpty(); }
+  inline bool IsEmpty() const { return val_.IsEmpty(); }
 
   template<typename S>
-  NAN_INLINE bool ToLocal(v8::Local<S> *out) const {
+  inline bool ToLocal(v8::Local<S> *out) const {
     *out = val_;
     return !IsEmpty();
   }
 
-  NAN_INLINE v8::Local<T> ToLocalChecked() const {
+  inline v8::Local<T> ToLocalChecked() const {
 #if defined(V8_ENABLE_CHECKS)
     assert(!IsEmpty() && "ToLocalChecked is Empty");
 #endif  // V8_ENABLE_CHECKS
@@ -38,7 +38,7 @@ class MaybeLocal {
   }
 
   template<typename S>
-  NAN_INLINE v8::Local<S> FromMaybe(v8::Local<S> default_value) const {
+  inline v8::Local<S> FromMaybe(v8::Local<S> default_value) const {
     return IsEmpty() ? default_value : val_;
   }
 
@@ -49,26 +49,26 @@ class MaybeLocal {
 template<typename T>
 class Maybe {
  public:
-  NAN_INLINE bool IsNothing() const { return !has_value_; }
-  NAN_INLINE bool IsJust() const { return has_value_; }
+  inline bool IsNothing() const { return !has_value_; }
+  inline bool IsJust() const { return has_value_; }
 
-  NAN_INLINE T FromJust() const {
+  inline T FromJust() const {
 #if defined(V8_ENABLE_CHECKS)
     assert(IsJust() && "FromJust is Nothing");
 #endif  // V8_ENABLE_CHECKS
     return value_;
   }
 
-  NAN_INLINE T FromMaybe(const T& default_value) const {
+  inline T FromMaybe(const T& default_value) const {
     return has_value_ ? value_ : default_value;
   }
 
-  NAN_INLINE bool operator==(const Maybe &other) const {
+  inline bool operator==(const Maybe &other) const {
     return (IsJust() == other.IsJust()) &&
         (!IsJust() || FromJust() == other.FromJust());
   }
 
-  NAN_INLINE bool operator!=(const Maybe &other) const {
+  inline bool operator!=(const Maybe &other) const {
     return !operator==(other);
   }
 
@@ -94,27 +94,27 @@ inline Maybe<T> Just(const T& t) {
   return Maybe<T>(t);
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::String> ToDetailString(v8::Handle<v8::Value> val) {
   return MaybeLocal<v8::String>(val->ToDetailString());
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Uint32> ToArrayIndex(v8::Handle<v8::Value> val) {
   return MaybeLocal<v8::Uint32>(val->ToArrayIndex());
 }
 
-NAN_INLINE
+inline
 Maybe<bool> Equals(v8::Handle<v8::Value> a, v8::Handle<v8::Value>(b)) {
   return Just<bool>(a->Equals(b));
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Object> NewInstance(v8::Handle<v8::Function> h) {
   return MaybeLocal<v8::Object>(h->NewInstance());
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Object> NewInstance(
       v8::Local<v8::Function> h
     , int argc
@@ -122,31 +122,31 @@ MaybeLocal<v8::Object> NewInstance(
   return MaybeLocal<v8::Object>(h->NewInstance(argc, argv));
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Object> NewInstance(v8::Handle<v8::ObjectTemplate> h) {
   return MaybeLocal<v8::Object>(h->NewInstance());
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Function> GetFunction(v8::Handle<v8::FunctionTemplate> t) {
   return MaybeLocal<v8::Function>(t->GetFunction());
 }
 
-NAN_INLINE Maybe<bool> Set(
+inline Maybe<bool> Set(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::Value> key
   , v8::Handle<v8::Value> value) {
   return Just<bool>(obj->Set(key, value));
 }
 
-NAN_INLINE Maybe<bool> Set(
+inline Maybe<bool> Set(
     v8::Handle<v8::Object> obj
   , uint32_t index
   , v8::Handle<v8::Value> value) {
   return Just<bool>(obj->Set(index, value));
 }
 
-NAN_INLINE Maybe<bool> ForceSet(
+inline Maybe<bool> ForceSet(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::Value> key
   , v8::Handle<v8::Value> value
@@ -154,107 +154,107 @@ NAN_INLINE Maybe<bool> ForceSet(
   return Just<bool>(obj->ForceSet(key, value, attribs));
 }
 
-NAN_INLINE MaybeLocal<v8::Value> Get(
+inline MaybeLocal<v8::Value> Get(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::Value> key) {
   return MaybeLocal<v8::Value>(obj->Get(key));
 }
 
-NAN_INLINE MaybeLocal<v8::Value> Get(
+inline MaybeLocal<v8::Value> Get(
     v8::Handle<v8::Object> obj
   , uint32_t index) {
   return MaybeLocal<v8::Value>(obj->Get(index));
 }
 
-NAN_INLINE Maybe<v8::PropertyAttribute> GetPropertyAttributes(
+inline Maybe<v8::PropertyAttribute> GetPropertyAttributes(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::Value> key) {
   return Just<v8::PropertyAttribute>(obj->GetPropertyAttributes(key));
 }
 
-NAN_INLINE Maybe<bool> Has(
+inline Maybe<bool> Has(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::String> key) {
   return Just<bool>(obj->Has(key));
 }
 
-NAN_INLINE Maybe<bool> Has(
+inline Maybe<bool> Has(
     v8::Handle<v8::Object> obj
   , uint32_t index) {
   return Just<bool>(obj->Has(index));
 }
 
-NAN_INLINE Maybe<bool> Delete(
+inline Maybe<bool> Delete(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::String> key) {
   return Just<bool>(obj->Delete(key));
 }
 
-NAN_INLINE Maybe<bool> Delete(
+inline Maybe<bool> Delete(
     v8::Handle<v8::Object> obj
   , uint32_t index) {
   return Just<bool>(obj->Delete(index));
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Array> GetPropertyNames(v8::Handle<v8::Object> obj) {
   return MaybeLocal<v8::Array>(obj->GetPropertyNames());
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::Array> GetOwnPropertyNames(v8::Handle<v8::Object> obj) {
   return MaybeLocal<v8::Array>(obj->GetOwnPropertyNames());
 }
 
-NAN_INLINE Maybe<bool> SetPrototype(
+inline Maybe<bool> SetPrototype(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::Value> prototype) {
   return Just<bool>(obj->SetPrototype(prototype));
 }
 
-NAN_INLINE MaybeLocal<v8::String> ObjectProtoToString(
+inline MaybeLocal<v8::String> ObjectProtoToString(
     v8::Handle<v8::Object> obj) {
   return MaybeLocal<v8::String>(obj->ObjectProtoToString());
 }
 
-NAN_INLINE Maybe<bool> HasOwnProperty(
+inline Maybe<bool> HasOwnProperty(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::String> key) {
   return Just<bool>(obj->HasOwnProperty(key));
 }
 
-NAN_INLINE Maybe<bool> HasRealNamedProperty(
+inline Maybe<bool> HasRealNamedProperty(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::String> key) {
   return Just<bool>(obj->HasRealNamedProperty(key));
 }
 
-NAN_INLINE Maybe<bool> HasRealIndexedProperty(
+inline Maybe<bool> HasRealIndexedProperty(
     v8::Handle<v8::Object> obj
   , uint32_t index) {
   return Just<bool>(obj->HasRealIndexedProperty(index));
 }
 
-NAN_INLINE Maybe<bool> HasRealNamedCallbackProperty(
+inline Maybe<bool> HasRealNamedCallbackProperty(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::String> key) {
   return Just<bool>(obj->HasRealNamedCallbackProperty(key));
 }
 
-NAN_INLINE MaybeLocal<v8::Value> GetRealNamedPropertyInPrototypeChain(
+inline MaybeLocal<v8::Value> GetRealNamedPropertyInPrototypeChain(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::String> key) {
   return MaybeLocal<v8::Value>(
       obj->GetRealNamedPropertyInPrototypeChain(key));
 }
 
-NAN_INLINE MaybeLocal<v8::Value> GetRealNamedProperty(
+inline MaybeLocal<v8::Value> GetRealNamedProperty(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::String> key) {
   return MaybeLocal<v8::Value>(obj->GetRealNamedProperty(key));
 }
 
-NAN_INLINE MaybeLocal<v8::Value> CallAsFunction(
+inline MaybeLocal<v8::Value> CallAsFunction(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::Object> recv
   , int argc
@@ -262,37 +262,37 @@ NAN_INLINE MaybeLocal<v8::Value> CallAsFunction(
   return MaybeLocal<v8::Value>(obj->CallAsFunction(recv, argc, argv));
 }
 
-NAN_INLINE MaybeLocal<v8::Value> CallAsConstructor(
+inline MaybeLocal<v8::Value> CallAsConstructor(
     v8::Handle<v8::Object> obj
   , int argc
   , v8::Local<v8::Value> argv[]) {
   return MaybeLocal<v8::Value>(obj->CallAsConstructor(argc, argv));
 }
 
-NAN_INLINE
+inline
 MaybeLocal<v8::String> GetSourceLine(v8::Handle<v8::Message> msg) {
   return MaybeLocal<v8::String>(msg->GetSourceLine());
 }
 
-NAN_INLINE Maybe<int> GetLineNumber(v8::Handle<v8::Message> msg) {
+inline Maybe<int> GetLineNumber(v8::Handle<v8::Message> msg) {
   return Just<int>(msg->GetLineNumber());
 }
 
-NAN_INLINE Maybe<int> GetStartColumn(v8::Handle<v8::Message> msg) {
+inline Maybe<int> GetStartColumn(v8::Handle<v8::Message> msg) {
   return Just<int>(msg->GetStartColumn());
 }
 
-NAN_INLINE Maybe<int> GetEndColumn(v8::Handle<v8::Message> msg) {
+inline Maybe<int> GetEndColumn(v8::Handle<v8::Message> msg) {
   return Just<int>(msg->GetEndColumn());
 }
 
-NAN_INLINE MaybeLocal<v8::Object> CloneElementAt(
+inline MaybeLocal<v8::Object> CloneElementAt(
     v8::Handle<v8::Array> array
   , uint32_t index) {
   return MaybeLocal<v8::Object>(array->CloneElementAt(index));
 }
 
-NAN_INLINE MaybeLocal<v8::Value> Call(
+inline MaybeLocal<v8::Value> Call(
     v8::Local<v8::Function> fun
   , v8::Local<v8::Object> recv
   , int argc

--- a/nan_persistent_12_inl.h
+++ b/nan_persistent_12_inl.h
@@ -12,38 +12,38 @@
 template<typename T, typename M> class Persistent :
     public v8::Persistent<T, M> {
  public:
-  NAN_INLINE Persistent() : v8::Persistent<T, M>() {}
+  inline Persistent() : v8::Persistent<T, M>() {}
 
-  template<typename S> NAN_INLINE Persistent(v8::Local<S> that) :
+  template<typename S> inline Persistent(v8::Local<S> that) :
       v8::Persistent<T, M>(v8::Isolate::GetCurrent(), that) {}
 
   template<typename S, typename M2>
-  NAN_INLINE Persistent(const v8::Persistent<S, M2> &that) :
+  inline Persistent(const v8::Persistent<S, M2> &that) :
       v8::Persistent<T, M2>(v8::Isolate::GetCurrent(), that) {}
 
-  NAN_INLINE void Reset() { v8::PersistentBase<T>::Reset(); }
+  inline void Reset() { v8::PersistentBase<T>::Reset(); }
 
   template <typename S>
-  NAN_INLINE void Reset(const v8::Local<S> &other) {
+  inline void Reset(const v8::Local<S> &other) {
     v8::PersistentBase<T>::Reset(v8::Isolate::GetCurrent(), other);
   }
 
   template <typename S>
-  NAN_INLINE void Reset(const v8::PersistentBase<S> &other) {
+  inline void Reset(const v8::PersistentBase<S> &other) {
     v8::PersistentBase<T>::Reset(v8::Isolate::GetCurrent(), other);
   }
 
   template<typename P>
-  NAN_INLINE void SetWeak(
+  inline void SetWeak(
     P *parameter
     , typename WeakCallbackInfo<P>::Callback callback
     , WeakCallbackType type);
 
  private:
-  NAN_INLINE T *operator*() const { return *PersistentBase<T>::persistent; }
+  inline T *operator*() const { return *PersistentBase<T>::persistent; }
 
   template<typename S, typename M2>
-  NAN_INLINE void Copy(const Persistent<S, M2> &that) {
+  inline void Copy(const Persistent<S, M2> &that) {
     TYPE_CHECK(T, S);
 
     this->Reset();
@@ -60,29 +60,29 @@ template<typename T, typename M> class Persistent :
 template<typename T>
 class Global : public v8::Global<T> {
  public:
-  NAN_INLINE Global() : v8::Global<T>() {}
+  inline Global() : v8::Global<T>() {}
 
-  template<typename S> NAN_INLINE Global(v8::Local<S> that) :
+  template<typename S> inline Global(v8::Local<S> that) :
     v8::Global<T>(v8::Isolate::GetCurrent(), that) {}
 
   template<typename S>
-  NAN_INLINE Global(const v8::PersistentBase<S> &that) :
+  inline Global(const v8::PersistentBase<S> &that) :
       v8::Global<S>(v8::Isolate::GetCurrent(), that) {}
 
-  NAN_INLINE void Reset() { v8::PersistentBase<T>::Reset(); }
+  inline void Reset() { v8::PersistentBase<T>::Reset(); }
 
   template <typename S>
-  NAN_INLINE void Reset(const v8::Local<S> &other) {
+  inline void Reset(const v8::Local<S> &other) {
     v8::PersistentBase<T>::Reset(v8::Isolate::GetCurrent(), other);
   }
 
   template <typename S>
-  NAN_INLINE void Reset(const v8::PersistentBase<S> &other) {
+  inline void Reset(const v8::PersistentBase<S> &other) {
     v8::PersistentBase<T>::Reset(v8::Isolate::GetCurrent(), other);
   }
 
   template<typename P>
-  NAN_INLINE void SetWeak(
+  inline void SetWeak(
     P *parameter
     , typename WeakCallbackInfo<P>::Callback callback
     , WeakCallbackType type) {
@@ -94,29 +94,29 @@ class Global : public v8::Global<T> {
 template<typename T>
 class Global : public v8::UniquePersistent<T> {
  public:
-  NAN_INLINE Global() : v8::UniquePersistent<T>() {}
+  inline Global() : v8::UniquePersistent<T>() {}
 
-  template<typename S> NAN_INLINE Global(v8::Local<S> that) :
+  template<typename S> inline Global(v8::Local<S> that) :
     v8::UniquePersistent<T>(v8::Isolate::GetCurrent(), that) {}
 
   template<typename S>
-  NAN_INLINE Global(const v8::PersistentBase<S> &that) :
+  inline Global(const v8::PersistentBase<S> &that) :
       v8::UniquePersistent<S>(v8::Isolate::GetCurrent(), that) {}
 
-  NAN_INLINE void Reset() { v8::PersistentBase<T>::Reset(); }
+  inline void Reset() { v8::PersistentBase<T>::Reset(); }
 
   template <typename S>
-  NAN_INLINE void Reset(const v8::Local<S> &other) {
+  inline void Reset(const v8::Local<S> &other) {
     v8::PersistentBase<T>::Reset(v8::Isolate::GetCurrent(), other);
   }
 
   template <typename S>
-  NAN_INLINE void Reset(const v8::PersistentBase<S> &other) {
+  inline void Reset(const v8::PersistentBase<S> &other) {
     v8::PersistentBase<T>::Reset(v8::Isolate::GetCurrent(), other);
   }
 
   template<typename P>
-  NAN_INLINE void SetWeak(
+  inline void SetWeak(
     P *parameter
     , typename WeakCallbackInfo<P>::Callback callback
     , WeakCallbackType type) {

--- a/nan_persistent_pre_12_inl.h
+++ b/nan_persistent_pre_12_inl.h
@@ -21,16 +21,16 @@ class PersistentBase {
   template<typename S> friend class ReturnValue;
 
  public:
-  NAN_INLINE PersistentBase() :
+  inline PersistentBase() :
       persistent() {}
 
-  NAN_INLINE void Reset() {
+  inline void Reset() {
     persistent.Dispose();
     persistent.Clear();
   }
 
   template<typename S>
-  NAN_INLINE void Reset(const v8::Local<S> &other) {
+  inline void Reset(const v8::Local<S> &other) {
     TYPE_CHECK(T, S);
 
     if (!persistent.IsEmpty()) {
@@ -45,7 +45,7 @@ class PersistentBase {
   }
 
   template<typename S>
-  NAN_INLINE void Reset(const PersistentBase<S> &other) {
+  inline void Reset(const PersistentBase<S> &other) {
     TYPE_CHECK(T, S);
 
     if (!persistent.IsEmpty()) {
@@ -59,50 +59,50 @@ class PersistentBase {
     }
   }
 
-  NAN_INLINE bool IsEmpty() const { return persistent.IsEmpty(); }
+  inline bool IsEmpty() const { return persistent.IsEmpty(); }
 
-  NAN_INLINE void Empty() { persistent.Clear(); }
+  inline void Empty() { persistent.Clear(); }
 
   template<typename S>
-  NAN_INLINE bool operator==(const PersistentBase<S> &that) {
+  inline bool operator==(const PersistentBase<S> &that) {
     return this->persistent == that.persistent;
   }
 
   template<typename S>
-  NAN_INLINE bool operator==(const v8::Local<S> &that) {
+  inline bool operator==(const v8::Local<S> &that) {
     return this->persistent == that;
   }
 
   template<typename S>
-  NAN_INLINE bool operator!=(const PersistentBase<S> &that) {
+  inline bool operator!=(const PersistentBase<S> &that) {
     return !operator==(that);
   }
 
   template<typename S>
-  NAN_INLINE bool operator!=(const v8::Local<S> &that) {
+  inline bool operator!=(const v8::Local<S> &that) {
     return !operator==(that);
   }
 
   template<typename P>
-  NAN_INLINE void SetWeak(
+  inline void SetWeak(
     P *parameter
     , typename WeakCallbackInfo<P>::Callback callback
     , WeakCallbackType type);
 
-  NAN_INLINE void ClearWeak() { persistent.ClearWeak(); }
+  inline void ClearWeak() { persistent.ClearWeak(); }
 
-  NAN_INLINE void MarkIndependent() { persistent.MarkIndependent(); }
+  inline void MarkIndependent() { persistent.MarkIndependent(); }
 
-  NAN_INLINE bool IsIndependent() const { return persistent.IsIndependent(); }
+  inline bool IsIndependent() const { return persistent.IsIndependent(); }
 
-  NAN_INLINE bool IsNearDeath() const { return persistent.IsNearDeath(); }
+  inline bool IsNearDeath() const { return persistent.IsNearDeath(); }
 
-  NAN_INLINE bool IsWeak() const { return persistent.IsWeak(); }
+  inline bool IsWeak() const { return persistent.IsWeak(); }
 
  private:
-  NAN_INLINE explicit PersistentBase(v8::Persistent<T> that) :
+  inline explicit PersistentBase(v8::Persistent<T> that) :
       persistent(that) { }
-  NAN_INLINE explicit PersistentBase(T *val) : persistent(val) {}
+  inline explicit PersistentBase(T *val) : persistent(val) {}
   template<typename S, typename M> friend class Persistent;
   template<typename S> friend class Global;
   friend class ObjectWrap;
@@ -115,12 +115,12 @@ class NonCopyablePersistentTraits {
       NonCopyablePersistent;
   static const bool kResetInDestructor = false;
   template<typename S, typename M>
-  NAN_INLINE static void Copy(const Persistent<S, M> &source,
+  inline static void Copy(const Persistent<S, M> &source,
                              NonCopyablePersistent *dest) {
     Uncompilable<v8::Object>();
   }
 
-  template<typename O> NAN_INLINE static void Uncompilable() {
+  template<typename O> inline static void Uncompilable() {
     TYPE_CHECK(O, v8::Primitive);
   }
 };
@@ -130,50 +130,50 @@ struct CopyablePersistentTraits {
   typedef Persistent<T, CopyablePersistentTraits<T> > CopyablePersistent;
   static const bool kResetInDestructor = true;
   template<typename S, typename M>
-  static NAN_INLINE void Copy(const Persistent<S, M> &source,
+  static inline void Copy(const Persistent<S, M> &source,
                              CopyablePersistent *dest) {}
 };
 
 template<typename T, typename M> class Persistent :
     public PersistentBase<T> {
  public:
-  NAN_INLINE Persistent() {}
+  inline Persistent() {}
 
-  template<typename S> NAN_INLINE Persistent(v8::Handle<S> that)
+  template<typename S> inline Persistent(v8::Handle<S> that)
       : PersistentBase<T>(v8::Persistent<T>::New(that)) {
     TYPE_CHECK(T, S);
   }
 
-  NAN_INLINE Persistent(const Persistent &that) : PersistentBase<T>() {
+  inline Persistent(const Persistent &that) : PersistentBase<T>() {
     Copy(that);
   }
 
   template<typename S, typename M2>
-  NAN_INLINE Persistent(const Persistent<S, M2> &that) :
+  inline Persistent(const Persistent<S, M2> &that) :
       PersistentBase<T>() {
     Copy(that);
   }
 
-  NAN_INLINE Persistent &operator=(const Persistent &that) {
+  inline Persistent &operator=(const Persistent &that) {
     Copy(that);
     return *this;
   }
 
   template <class S, class M2>
-  NAN_INLINE Persistent &operator=(const Persistent<S, M2> &that) {
+  inline Persistent &operator=(const Persistent<S, M2> &that) {
     Copy(that);
     return *this;
   }
 
-  NAN_INLINE ~Persistent() {
+  inline ~Persistent() {
     if (M::kResetInDestructor) this->Reset();
   }
 
  private:
-  NAN_INLINE T *operator*() const { return *PersistentBase<T>::persistent; }
+  inline T *operator*() const { return *PersistentBase<T>::persistent; }
 
   template<typename S, typename M2>
-  NAN_INLINE void Copy(const Persistent<S, M2> &that) {
+  inline void Copy(const Persistent<S, M2> &that) {
     TYPE_CHECK(T, S);
 
     this->Reset();
@@ -188,37 +188,37 @@ template<typename T, typename M> class Persistent :
 template<typename T>
 class Global : public PersistentBase<T> {
   struct RValue {
-    NAN_INLINE explicit RValue(Global* obj) : object(obj) {}
+    inline explicit RValue(Global* obj) : object(obj) {}
     Global* object;
   };
 
  public:
-  NAN_INLINE Global() : PersistentBase<T>(0) { }
+  inline Global() : PersistentBase<T>(0) { }
 
   template <typename S>
-  NAN_INLINE Global(v8::Local<S> that)
+  inline Global(v8::Local<S> that)
       : PersistentBase<T>(v8::Persistent<T>::New(that)) {
     TYPE_CHECK(T, S);
   }
 
   template <typename S>
-  NAN_INLINE Global(const PersistentBase<S> &that)
+  inline Global(const PersistentBase<S> &that)
     : PersistentBase<T>(that) {
     TYPE_CHECK(T, S);
   }
   /**
    * Move constructor.
    */
-  NAN_INLINE Global(RValue rvalue)
+  inline Global(RValue rvalue)
     : PersistentBase<T>(rvalue.object->persistent) {
     rvalue.object->Reset();
   }
-  NAN_INLINE ~Global() { this->Reset(); }
+  inline ~Global() { this->Reset(); }
   /**
    * Move via assignment.
    */
   template<typename S>
-  NAN_INLINE Global &operator=(Global<S> rhs) {
+  inline Global &operator=(Global<S> rhs) {
     TYPE_CHECK(T, S);
     this->Reset(rhs.persistent);
     rhs.Reset();
@@ -227,7 +227,7 @@ class Global : public PersistentBase<T> {
   /**
    * Cast operator for moves.
    */
-  NAN_INLINE operator RValue() { return RValue(this); }
+  inline operator RValue() { return RValue(this); }
   /**
    * Pass allows returning uniques from functions, etc.
    */

--- a/nan_typedarray_contents.h
+++ b/nan_typedarray_contents.h
@@ -12,7 +12,7 @@
 template<typename T>
 class TypedArrayContents {
  public:
-  NAN_INLINE explicit TypedArrayContents(v8::Local<v8::Value> from) :
+  inline explicit TypedArrayContents(v8::Local<v8::Value> from) :
       length_(0), data_(NULL) {
 
     size_t length = 0;
@@ -69,9 +69,9 @@ class TypedArrayContents {
     data_   = static_cast<T*>(data);
   }
 
-  NAN_INLINE size_t length() const      { return length_; }
-  NAN_INLINE T* operator*()             { return data_;   }
-  NAN_INLINE const T* operator*() const { return data_;   }
+  inline size_t length() const      { return length_; }
+  inline T* operator*()             { return data_;   }
+  inline const T* operator*() const { return data_;   }
 
  private:
   NAN_DISALLOW_ASSIGN_COPY_MOVE(TypedArrayContents)

--- a/nan_weak.h
+++ b/nan_weak.h
@@ -59,9 +59,9 @@ class WeakCallbackInfo {
     internal_fields_[0] = field1;
     internal_fields_[1] = field2;
   }
-  NAN_INLINE v8::Isolate *GetIsolate() const { return isolate_; }
-  NAN_INLINE T *GetParameter() const { return static_cast<T*>(parameter_); }
-  NAN_INLINE void *GetInternalField(int index) const {
+  inline v8::Isolate *GetIsolate() const { return isolate_; }
+  inline T *GetParameter() const { return static_cast<T*>(parameter_); }
+  inline void *GetInternalField(int index) const {
     assert((index == 0 || index == 1) && "internal field index out of bounds");
     if (index == 0) {
       return internal_fields_[0];
@@ -255,7 +255,7 @@ WeakCallbackInfo<T> *WeakCallbackInfo<T>::unwrap(
   (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
 template<typename T, typename M>
 template<typename P>
-NAN_INLINE void Persistent<T, M>::SetWeak(
+inline void Persistent<T, M>::SetWeak(
     P *parameter
   , typename WeakCallbackInfo<P>::Callback callback
   , WeakCallbackType type) {
@@ -293,7 +293,7 @@ NAN_INLINE void Persistent<T, M>::SetWeak(
 #elif NODE_MODULE_VERSION > IOJS_1_1_MODULE_VERSION
 template<typename T, typename M>
 template<typename P>
-NAN_INLINE void Persistent<T, M>::SetWeak(
+inline void Persistent<T, M>::SetWeak(
     P *parameter
   , typename WeakCallbackInfo<P>::Callback callback
   , WeakCallbackType type) {
@@ -331,7 +331,7 @@ NAN_INLINE void Persistent<T, M>::SetWeak(
 #elif NODE_MODULE_VERSION > NODE_0_12_MODULE_VERSION
 template<typename T, typename M>
 template<typename P>
-NAN_INLINE void Persistent<T, M>::SetWeak(
+inline void Persistent<T, M>::SetWeak(
     P *parameter
   , typename WeakCallbackInfo<P>::Callback callback
   , WeakCallbackType type) {
@@ -368,7 +368,7 @@ NAN_INLINE void Persistent<T, M>::SetWeak(
 #elif NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
 template<typename T, typename M>
 template<typename P>
-NAN_INLINE void Persistent<T, M>::SetWeak(
+inline void Persistent<T, M>::SetWeak(
     P *parameter
   , typename WeakCallbackInfo<P>::Callback callback
   , WeakCallbackType type) {
@@ -399,7 +399,7 @@ NAN_INLINE void Persistent<T, M>::SetWeak(
 #else
 template<typename T>
 template<typename P>
-NAN_INLINE void PersistentBase<T>::SetWeak(
+inline void PersistentBase<T>::SetWeak(
     P *parameter
   , typename WeakCallbackInfo<P>::Callback callback
   , WeakCallbackType type) {


### PR DESCRIPTION
There is no reason to mark everything  `__attribute__((always_inline))`,
just use the regular keyword and let the compiler decide.  Avoids code
bloat and build errors when inlining fails due to compiler limitations.

Fixes: https://github.com/nodejs/nan/issues/576