### PR TITLE
Correct NAN_PROPERTY_SETTER_ARGS_TYPE to match with prototype needed by Nan::SetAccessor().

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1260,7 +1260,7 @@ typedef const PropertyCallbackInfo<v8::Value>&
     NAN_PROPERTY_GETTER_ARGS_TYPE;
 typedef void NAN_PROPERTY_GETTER_RETURN_TYPE;
 
-typedef const PropertyCallbackInfo<v8::Value>&
+typedef const PropertyCallbackInfo<void>&
     NAN_PROPERTY_SETTER_ARGS_TYPE;
 typedef void NAN_PROPERTY_SETTER_RETURN_TYPE;
 


### PR DESCRIPTION
If I use NAN_PROPERTY_SETTER I get compile errors (at least in MSVC) that functions doesn't match to Nan::SetAccessor().
I adapted NAN_PROPERTY_SETTER_ARGS_TYPE to correct this.