### PR TITLE
Add getPrivate/setPrivate methods

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -2191,7 +2191,7 @@ inline void SetCallAsFunctionHandler(
 
 //=== HiddenValue/Private ======================================================
 
-v8::Local<v8::Value> GetPrivate(
+inline v8::Local<v8::Value> GetPrivate(
     v8::Local<v8::Object> object,
     v8::Local<v8::String> key) {
 #if (NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION)
@@ -2210,7 +2210,7 @@ v8::Local<v8::Value> GetPrivate(
 #endif
 }
 
-void SetPrivate(
+inline void SetPrivate(
     v8::Local<v8::Object> object,
     v8::Local<v8::String> key,
     v8::Local<v8::Value> value) {

--- a/nan.h
+++ b/nan.h
@@ -2189,6 +2189,42 @@ inline void SetCallAsFunctionHandler(
 
 #include "nan_object_wrap.h"  // NOLINT(build/include)
 
+//=== HiddenValue/Private ======================================================
+
+v8::Local<v8::Value> GetPrivate(
+    v8::Local<v8::Object> object,
+    v8::Local<v8::String> key) {
+#if (NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION)
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Local<v8::Private> privateKey = v8::Private::ForApi(isolate, key);
+  v8::Local<v8::Value> value;
+  v8::Maybe<bool> result = object->HasPrivate(context, privateKey);
+  if (!(result.IsJust() && result.FromJust()))
+    return v8::Local<v8::Value>();
+  if (object->GetPrivate(context, privateKey).ToLocal(&value))
+    return value;
+  return v8::Local<v8::Value>();
+#else
+  return object->GetHiddenValue(key);
+#endif
+}
+
+void SetPrivate(
+    v8::Local<v8::Object> object,
+    v8::Local<v8::String> key,
+    v8::Local<v8::Value> value) {
+#if (NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION)
+  if (value.IsEmpty()) return;
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Local<v8::Private> privateKey = v8::Private::ForApi(isolate, key);
+  object->SetPrivate(context, privateKey, value);
+#else
+  object->SetHiddenValue(key, value);
+#endif
+}
+
 //=== Export ==================================================================
 
 inline

--- a/nan.h
+++ b/nan.h
@@ -2194,7 +2194,7 @@ inline void SetCallAsFunctionHandler(
 inline v8::Local<v8::Value> GetPrivate(
     v8::Local<v8::Object> object,
     v8::Local<v8::String> key) {
-#if (NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION)
+#if (NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION)
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   v8::Local<v8::Private> private_key = v8::Private::ForApi(isolate, key);
@@ -2214,7 +2214,7 @@ inline void SetPrivate(
     v8::Local<v8::Object> object,
     v8::Local<v8::String> key,
     v8::Local<v8::Value> value) {
-#if (NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION)
+#if (NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION)
   if (value.IsEmpty()) return;
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();

--- a/nan.h
+++ b/nan.h
@@ -2197,12 +2197,12 @@ inline v8::Local<v8::Value> GetPrivate(
 #if (NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION)
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  v8::Local<v8::Private> privateKey = v8::Private::ForApi(isolate, key);
+  v8::Local<v8::Private> private_key = v8::Private::ForApi(isolate, key);
   v8::Local<v8::Value> value;
-  v8::Maybe<bool> result = object->HasPrivate(context, privateKey);
-  if (!(result.IsJust() && result.FromJust()))
+  v8::Maybe<bool> result = object->HasPrivate(context, private_key);
+  if (!result.FromMaybe(false))
     return v8::Local<v8::Value>();
-  if (object->GetPrivate(context, privateKey).ToLocal(&value))
+  if (object->GetPrivate(context, private_key).ToLocal(&value))
     return value;
   return v8::Local<v8::Value>();
 #else
@@ -2218,8 +2218,8 @@ inline void SetPrivate(
   if (value.IsEmpty()) return;
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
-  v8::Local<v8::Private> privateKey = v8::Private::ForApi(isolate, key);
-  object->SetPrivate(context, privateKey, value);
+  v8::Local<v8::Private> private_key = v8::Private::ForApi(isolate, key);
+  object->SetPrivate(context, private_key, value);
 #else
   object->SetHiddenValue(key, value);
 #endif


### PR DESCRIPTION
Addressing this: https://github.com/nodejs/nan/issues/587

Of note, I set this to use get/setPrivate on module version 49+, although this should work with older versions as well (I know it does not work in with modules <= 46, but is already marked deprecated in modules 48, I have not tested against 47). 

I've tried to maintain coding standards, although to be totally frank I'm completely unsure that i put this in the correct place in the code at all, and that I handled it properly (some functions seem to be redeclared entirely, while others have a single declaration with different contents).

Regarding testing, I've not added anything to the test suites, but I've been able to build and use nodegit using this change on node 0.12.15, 4.4.7, 6.2.2, 6.3.1, and electron 1.2.8, and 1.3.3, all succesfully (note that building nodegit for node 6.3 wont work on windows for separate reasons). I'd be happy to try to add something to the tests if this is a welcome change.
I've got a commit of nodegit working this way here: https://github.com/nodegit/nodegit/tree/nan-test

I assume some documentation would also need to be added for this. 
