### PR TITLE
The path string returned when nan is imported in node 6 is wrong in some cases

### DIFF
--- a/include_dirs.js
+++ b/include_dirs.js
@@ -1,1 +1,1 @@
-console.log(require('path').relative('.', __dirname));
+console.log(require('path').resolve(__dirname));


### PR DESCRIPTION
Addressing this: #600

With the old method to get the current directory of 'nan' module, the path isn't got properly when the parent path is in a shared resource:

`vboxsrv\vagrant\NODE_MODULES\nan` (which don't exists)

with the new method the current directory is obtained correctly:
`\\vboxsrv\vagrant\NODE_MODULES\nan`

This change makes that packages like `bufferutil` or `ref` are built correctly as they are able to get the `nan` headers if the working directory is inside a network resource.