### PR TITLE
Add optional data parameter to SetPrototypeMethod

### DIFF
--- a/doc/methods.md
+++ b/doc/methods.md
@@ -492,7 +492,8 @@ Signature:
 ```c++
 void Nan::SetPrototypeMethod(v8::Local<v8::FunctionTemplate> recv,
                              const char* name,
-                             Nan::FunctionCallback callback)
+                             Nan::FunctionCallback callback,
+                             v8::Local<v8::Value> data = v8::Local<v8::Value>())
 ```
 
 <a name="api_nan_set_accessor"></a>

--- a/nan.h
+++ b/nan.h
@@ -1888,11 +1888,12 @@ inline void SetMethod(
 
 inline void SetPrototypeMethod(
     v8::Local<v8::FunctionTemplate> recv
-  , const char* name, FunctionCallback callback) {
+  , const char* name, FunctionCallback callback
+  , v8::Local<v8::Value> data = v8::Local<v8::Value>()) {
   HandleScope scope;
   v8::Local<v8::FunctionTemplate> t = New<v8::FunctionTemplate>(
       callback
-    , v8::Local<v8::Value>()
+    , data
     , New<v8::Signature>(recv));
   v8::Local<v8::String> fn_name = New(name).ToLocalChecked();
   recv->PrototypeTemplate()->Set(fn_name, t);


### PR DESCRIPTION
The `v8::FunctionTemplate` that `Nan::SetPrototypeMethod` creates can take some user data to thread through to the callback, but `SetPrototypeMethod` doesn't currently expose this parameter like some of the other NAN functions. I'm using a patched version of `SetPrototypeMethod` to work around this in my own project, but it's a simple change to upstream and would reduce a little of my future maintenance burden.
