### PR TITLE
Add New<[typedarray]> methods

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -185,6 +185,17 @@ template<typename T, typename M = NonCopyablePersistentTraits<T> >
 class Persistent;
 #endif  // NODE_MODULE_VERSION
 
+template <typename T> struct TypedArrayCType;
+template<> struct TypedArrayCType<v8::Float32Array> { typedef float type; };
+template<> struct TypedArrayCType<v8::Float64Array> { typedef double type; };
+template<> struct TypedArrayCType<v8::Int8Array> { typedef int8_t type; };
+template<> struct TypedArrayCType<v8::Uint8Array> { typedef uint8_t type; };
+template<> struct TypedArrayCType<v8::Uint8ClampedArray> { typedef uint8_t type; };
+template<> struct TypedArrayCType<v8::Int16Array> { typedef int16_t type; };
+template<> struct TypedArrayCType<v8::Uint16Array> { typedef uint16_t type; };
+template<> struct TypedArrayCType<v8::Int32Array> { typedef int32_t type; };
+template<> struct TypedArrayCType<v8::Uint32Array> { typedef uint32_t type; };
+
 #if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
   (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
 # include "nan_maybe_43_inl.h"  // NOLINT(build/include)

--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -26,6 +26,36 @@ Factory<v8::Array>::New(int length) {
   return v8::Array::New(v8::Isolate::GetCurrent(), length);
 }
 
+//=== TypedArrays ==============================================================
+
+#define TYPED_ARRAY_DECL(T)                                                   \
+  Factory<T>::return_t                                                        \
+  Factory<T>::New(size_t len) {                                               \
+    size_t byteLength = len * sizeof(TypedArrayFactory<T>::value_type);       \
+    v8::Local<v8::ArrayBuffer> buffer = v8::ArrayBuffer::New(                 \
+      v8::Isolate::GetCurrent(), byteLength);                                 \
+    return T::New(buffer, 0, len);                                            \
+  }                                                                           \
+                                                                              \
+  Factory<T>::return_t                                                        \
+  Factory<T>::New(v8::Local<v8::ArrayBuffer> buffer,                          \
+                  size_t offset,                                              \
+                  size_t len) {                                               \
+    return T::New(buffer, offset, len);                                       \
+  }
+
+TYPED_ARRAY_DECL(v8::Float32Array)
+TYPED_ARRAY_DECL(v8::Float64Array)
+TYPED_ARRAY_DECL(v8::Int8Array)
+TYPED_ARRAY_DECL(v8::Uint8Array)
+TYPED_ARRAY_DECL(v8::Uint8ClampedArray)
+TYPED_ARRAY_DECL(v8::Int16Array)
+TYPED_ARRAY_DECL(v8::Uint16Array)
+TYPED_ARRAY_DECL(v8::Int32Array)
+TYPED_ARRAY_DECL(v8::Uint32Array)
+
+#undef TYPED_ARRAY_DECL
+
 //=== Boolean ==================================================================
 
 Factory<v8::Boolean>::return_t

--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -31,7 +31,7 @@ Factory<v8::Array>::New(int length) {
 #define TYPED_ARRAY_DECL(T)                                                   \
   Factory<T>::return_t                                                        \
   Factory<T>::New(size_t len) {                                               \
-    size_t byteLength = len * sizeof(TypedArrayFactory<T>::value_type);       \
+    size_t byteLength = len * sizeof(TypedArrayCType<T>::type);       \
     v8::Local<v8::ArrayBuffer> buffer = v8::ArrayBuffer::New(                 \
       v8::Isolate::GetCurrent(), byteLength);                                 \
     return T::New(buffer, 0, len);                                            \

--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -28,33 +28,22 @@ Factory<v8::Array>::New(int length) {
 
 //=== TypedArrays ==============================================================
 
-#define TYPED_ARRAY_DECL(T)                                                   \
-  Factory<T>::return_t                                                        \
-  Factory<T>::New(size_t len) {                                               \
-    size_t byteLength = len * sizeof(TypedArrayCType<T>::type);       \
-    v8::Local<v8::ArrayBuffer> buffer = v8::ArrayBuffer::New(                 \
-      v8::Isolate::GetCurrent(), byteLength);                                 \
-    return T::New(buffer, 0, len);                                            \
-  }                                                                           \
-                                                                              \
-  Factory<T>::return_t                                                        \
-  Factory<T>::New(v8::Local<v8::ArrayBuffer> buffer,                          \
-                  size_t offset,                                              \
-                  size_t len) {                                               \
-    return T::New(buffer, offset, len);                                       \
-  }
+template <typename T>
+typename TypedArrayFactory<T>::return_t
+TypedArrayFactory<T>::New(size_t len) {
+  size_t byteLength = len * sizeof(TypedArrayCType<T>::type);
+  v8::Local<v8::ArrayBuffer> buffer = v8::ArrayBuffer::New(
+    v8::Isolate::GetCurrent(), byteLength);
+  return T::New(buffer, 0, len);
+}
 
-TYPED_ARRAY_DECL(v8::Float32Array)
-TYPED_ARRAY_DECL(v8::Float64Array)
-TYPED_ARRAY_DECL(v8::Int8Array)
-TYPED_ARRAY_DECL(v8::Uint8Array)
-TYPED_ARRAY_DECL(v8::Uint8ClampedArray)
-TYPED_ARRAY_DECL(v8::Int16Array)
-TYPED_ARRAY_DECL(v8::Uint16Array)
-TYPED_ARRAY_DECL(v8::Int32Array)
-TYPED_ARRAY_DECL(v8::Uint32Array)
-
-#undef TYPED_ARRAY_DECL
+template <typename T>
+typename TypedArrayFactory<T>::return_t
+TypedArrayFactory<T>::New(v8::Local<v8::ArrayBuffer> buffer,
+                size_t offset,
+                size_t len) {
+  return T::New(buffer, offset, len);
+}
 
 //=== Boolean ==================================================================
 

--- a/nan_new.h
+++ b/nan_new.h
@@ -51,26 +51,23 @@ struct Factory<v8::Array> : FactoryBase<v8::Array> {
   static inline return_t New(int length);
 };
 
-#define TYPED_ARRAY_DECL(T)                                                   \
-  template <>                                                                 \
-  struct Factory<T> : FactoryBase<T> {                  \
-    static inline return_t New(size_t length);                                \
-    static inline return_t New(v8::Local<v8::ArrayBuffer> buffer,             \
-                               size_t offset,                                 \
-                               size_t len);                                   \
-  };
+template <typename T>
+struct TypedArrayFactory : FactoryBase<T> {
+  static inline return_t New(size_t length);
+  static inline return_t New(v8::Local<v8::ArrayBuffer> buffer,
+                             size_t offset,
+                             size_t len);
+};
 
-TYPED_ARRAY_DECL(v8::Float32Array)
-TYPED_ARRAY_DECL(v8::Float64Array)
-TYPED_ARRAY_DECL(v8::Int8Array)
-TYPED_ARRAY_DECL(v8::Uint8Array)
-TYPED_ARRAY_DECL(v8::Uint8ClampedArray)
-TYPED_ARRAY_DECL(v8::Int16Array)
-TYPED_ARRAY_DECL(v8::Uint16Array)
-TYPED_ARRAY_DECL(v8::Int32Array)
-TYPED_ARRAY_DECL(v8::Uint32Array)
-
-#undef TYPED_ARRAY_DECL
+template <> struct Factory<v8::Float32Array> : TypedArrayFactory<v8::Float32Array> {};
+template <> struct Factory<v8::Float64Array> : TypedArrayFactory<v8::Float64Array> {};
+template <> struct Factory<v8::Int8Array> : TypedArrayFactory<v8::Int8Array> {};
+template <> struct Factory<v8::Uint8Array> : TypedArrayFactory<v8::Uint8Array> {};
+template <> struct Factory<v8::Uint8ClampedArray> : TypedArrayFactory<v8::Uint8ClampedArray> {};
+template <> struct Factory<v8::Int16Array> : TypedArrayFactory<v8::Int16Array> {};
+template <> struct Factory<v8::Uint16Array> : TypedArrayFactory<v8::Uint16Array> {};
+template <> struct Factory<v8::Int32Array> : TypedArrayFactory<v8::Int32Array> {};
+template <> struct Factory<v8::Uint32Array> : TypedArrayFactory<v8::Uint32Array> {};
 
 template <>
 struct Factory<v8::Boolean> : FactoryBase<v8::Boolean> {

--- a/nan_new.h
+++ b/nan_new.h
@@ -51,20 +51,9 @@ struct Factory<v8::Array> : FactoryBase<v8::Array> {
   static inline return_t New(int length);
 };
 
-template <typename T> struct TypedArrayFactory;
-template<> struct TypedArrayFactory<v8::Float32Array> { typedef float value_type; };
-template<> struct TypedArrayFactory<v8::Float64Array> { typedef double value_type; };
-template<> struct TypedArrayFactory<v8::Int8Array> { typedef int8_t value_type; };
-template<> struct TypedArrayFactory<v8::Uint8Array> { typedef uint8_t value_type; };
-template<> struct TypedArrayFactory<v8::Uint8ClampedArray> { typedef uint8_t value_type; };
-template<> struct TypedArrayFactory<v8::Int16Array> { typedef int16_t value_type; };
-template<> struct TypedArrayFactory<v8::Uint16Array> { typedef uint16_t value_type; };
-template<> struct TypedArrayFactory<v8::Int32Array> { typedef int32_t value_type; };
-template<> struct TypedArrayFactory<v8::Uint32Array> { typedef uint32_t value_type; };
-
 #define TYPED_ARRAY_DECL(T)                                                   \
   template <>                                                                 \
-  struct Factory<T> : TypedArrayFactory<T>, FactoryBase<T> {                  \
+  struct Factory<T> : FactoryBase<T> {                  \
     static inline return_t New(size_t length);                                \
     static inline return_t New(v8::Local<v8::ArrayBuffer> buffer,             \
                                size_t offset,                                 \

--- a/nan_new.h
+++ b/nan_new.h
@@ -51,6 +51,38 @@ struct Factory<v8::Array> : FactoryBase<v8::Array> {
   static inline return_t New(int length);
 };
 
+template <typename T> struct TypedArrayFactory;
+template<> struct TypedArrayFactory<v8::Float32Array> { typedef float value_type; };
+template<> struct TypedArrayFactory<v8::Float64Array> { typedef double value_type; };
+template<> struct TypedArrayFactory<v8::Int8Array> { typedef int8_t value_type; };
+template<> struct TypedArrayFactory<v8::Uint8Array> { typedef uint8_t value_type; };
+template<> struct TypedArrayFactory<v8::Uint8ClampedArray> { typedef uint8_t value_type; };
+template<> struct TypedArrayFactory<v8::Int16Array> { typedef int16_t value_type; };
+template<> struct TypedArrayFactory<v8::Uint16Array> { typedef uint16_t value_type; };
+template<> struct TypedArrayFactory<v8::Int32Array> { typedef int32_t value_type; };
+template<> struct TypedArrayFactory<v8::Uint32Array> { typedef uint32_t value_type; };
+
+#define TYPED_ARRAY_DECL(T)                                                   \
+  template <>                                                                 \
+  struct Factory<T> : TypedArrayFactory<T>, FactoryBase<T> {                  \
+    static inline return_t New(size_t length);                                \
+    static inline return_t New(v8::Local<v8::ArrayBuffer> buffer,             \
+                               size_t offset,                                 \
+                               size_t len);                                   \
+  };
+
+TYPED_ARRAY_DECL(v8::Float32Array)
+TYPED_ARRAY_DECL(v8::Float64Array)
+TYPED_ARRAY_DECL(v8::Int8Array)
+TYPED_ARRAY_DECL(v8::Uint8Array)
+TYPED_ARRAY_DECL(v8::Uint8ClampedArray)
+TYPED_ARRAY_DECL(v8::Int16Array)
+TYPED_ARRAY_DECL(v8::Uint16Array)
+TYPED_ARRAY_DECL(v8::Int32Array)
+TYPED_ARRAY_DECL(v8::Uint32Array)
+
+#undef TYPED_ARRAY_DECL
+
 template <>
 struct Factory<v8::Boolean> : FactoryBase<v8::Boolean> {
   static inline return_t New(bool value);

--- a/test/cpp/typedarrays.cpp
+++ b/test/cpp/typedarrays.cpp
@@ -56,11 +56,50 @@ NAN_METHOD(ReadDouble) {
   info.GetReturnValue().Set(result);
 }
 
+#define NEW_TA(ENAME, T)                                                      \
+  NAN_METHOD(ENAME) {                                                         \
+    v8::Local<T> ta = New<T>(4);                                              \
+    info.GetReturnValue().Set(ta);                                            \
+  }                                                                           \
+  NAN_METHOD(ENAME##FromArrayBuffer) {                                        \
+    /* TODO dummy, because this needs BYTES_PER_ELEMENT, again. */            \
+    v8::Local<T> ta = New<T>(4);                                              \
+    info.GetReturnValue().Set(ta);                                            \
+  }
+
+NEW_TA(NewFloat32Array, v8::Float32Array)
+NEW_TA(NewFloat64Array, v8::Float64Array)
+NEW_TA(NewInt8Array, v8::Int8Array)
+NEW_TA(NewUint8Array, v8::Uint8Array)
+NEW_TA(NewUint8ClampedArray, v8::Uint8ClampedArray)
+NEW_TA(NewInt16Array, v8::Int16Array)
+NEW_TA(NewUint16Array, v8::Uint16Array)
+NEW_TA(NewInt32Array, v8::Int32Array)
+NEW_TA(NewUint32Array, v8::Uint32Array)
+
+#undef NEW_TA
+
 NAN_MODULE_INIT(Init) {
   NAN_EXPORT(target, ReadU8);
   NAN_EXPORT(target, ReadI32);
   NAN_EXPORT(target, ReadFloat);
   NAN_EXPORT(target, ReadDouble);
+
+#define TA_EXPORT(x) \
+  NAN_EXPORT(target, x); \
+  NAN_EXPORT(target, x##FromArrayBuffer);
+
+  TA_EXPORT(NewFloat32Array)
+  TA_EXPORT(NewFloat64Array)
+  TA_EXPORT(NewInt8Array)
+  TA_EXPORT(NewUint8Array)
+  TA_EXPORT(NewUint8ClampedArray)
+  TA_EXPORT(NewInt16Array)
+  TA_EXPORT(NewUint16Array)
+  TA_EXPORT(NewInt32Array)
+  TA_EXPORT(NewUint32Array)
+
+#undef TA_EXPORT
 }
 
 NODE_MODULE(typedarrays, Init)

--- a/test/cpp/typedarrays.cpp
+++ b/test/cpp/typedarrays.cpp
@@ -62,8 +62,10 @@ NAN_METHOD(ReadDouble) {
     info.GetReturnValue().Set(ta);                                            \
   }                                                                           \
   NAN_METHOD(ENAME##FromArrayBuffer) {                                        \
-    /* TODO dummy, because this needs BYTES_PER_ELEMENT, again. */            \
-    v8::Local<T> ta = New<T>(4);                                              \
+    size_t byteLength = 4 * sizeof(TypedArrayCType<T>::type);                 \
+    v8::Local<v8::ArrayBuffer> buffer = v8::ArrayBuffer::New(                 \
+      v8::Isolate::GetCurrent(), byteLength);                                 \
+    v8::Local<T> ta = New<T>(buffer, 0, 4);                                   \
     info.GetReturnValue().Set(ta);                                            \
   }
 

--- a/test/js/typedarrays-test.js
+++ b/test/js/typedarrays-test.js
@@ -80,3 +80,29 @@ test('typedarrays - bad arguments', function (t) {
     t.end();
   }
 });
+
+test('typed arrays - Nan::New<[typedarray]>', function (t) {
+  const types = [
+    {fn: "NewFloat32Array", ctor: Float32Array},
+    {fn: "NewFloat64Array", ctor: Float64Array},
+    {fn: "NewInt8Array", ctor: Int8Array},
+    {fn: "NewUint8Array", ctor: Uint8Array},
+    {fn: "NewUint8ClampedArray", ctor: Uint8ClampedArray},
+    {fn: "NewInt16Array", ctor: Int16Array},
+    {fn: "NewUint16Array", ctor: Uint16Array},
+    {fn: "NewInt32Array", ctor: Int32Array},
+    {fn: "NewUint32Array", ctor: Uint32Array}
+  ];
+
+  t.plan(4 * types.length);
+  types.forEach(function (type) {
+    t.type(bindings[type.fn], 'function');
+    t.same(bindings[type.fn](), new type.ctor([0, 0, 0, 0]));
+
+    // TODO:
+    var fname = type.fn + 'FromArrayBuffer';
+    t.type(bindings[fname], 'function');
+    t.same(bindings[fname](), new type.ctor([0, 0, 0, 0]));
+  });
+  t.end();
+});


### PR DESCRIPTION
This is not ready to merge yet; soliciting feedback first. (At the least, this needs the pre-0.12 implementation (unless NAN is also dropping 0.10 support?) and real tests for the ternary form.)

Adds `Nan::New<[typedarray]>(size_t length)` and `Nan::New<[typedarray]>(v8::Local<v8::ArrayBuffer>, size_t offset, size_t length)` for all of the typed array types.

This is a very repetitive set of functions to add. _I'm open to suggestions for better methods than macros for de-duping._ I struggled for a bit to try to templatize these but couldn't figure out how to specialize `Factory` via another level of templating. As-is, there's not really a reason to have `TypedArrayFactory` in addition to the macros, except that it would dedupe code between the 0.12+ and 0.10 impl (when it's added); if not, the macros could be changed to be `TYPED_ARRAY_DECL(v8::Uint8Array, uint8_t)` for example.

I'm also interested in exposing the C types for the typed array types, since v8 does not do this. That is, make it so you could do something like `NAN_TYPED_ARRAY_CTYPE(v8::Local<v8::Uint8Array>)` and get `uint8_t`. _Is there a better API to offer for this than a macro?_

Thoughts?

Fixes #521.
