### PR TITLE
abort in delete operators that shouldn't be called

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -351,7 +351,9 @@ class HandleScope {
   HandleScope(const HandleScope &);
   void operator=(const HandleScope &);
   void *operator new(size_t size);
-  void operator delete(void *, size_t);
+  void operator delete(void *, size_t) {
+    abort();
+  }
 };
 
 class EscapableHandleScope {
@@ -392,7 +394,9 @@ class EscapableHandleScope {
   EscapableHandleScope(const EscapableHandleScope &);
   void operator=(const EscapableHandleScope &);
   void *operator new(size_t size);
-  void operator delete(void *, size_t);
+  void operator delete(void *, size_t) {
+    abort();
+  }
 };
 
 //=== TryCatch =================================================================

--- a/nan_typedarray_contents.h
+++ b/nan_typedarray_contents.h
@@ -78,7 +78,9 @@ class TypedArrayContents {
 
   //Disable heap allocation
   void *operator new(size_t size);
-  void operator delete(void *, size_t);
+  void operator delete(void *, size_t) {
+    abort();
+  }
 
   size_t  length_;
   T*      data_;


### PR DESCRIPTION
Section 3.2 of the C++ standard states that destructor definitions
implicitly "use" operator delete functions. Therefore, these operator
delete functions must be defined even if they are never called by
user code explicitly.
http://www.open-std.org/JTC1/SC22/WG21/docs/cwg_defects.html#261

gcc allows them to remain as empty definitions. However, not all
compilers allow this.

This pull request creates definitions which if ever called, result
in an abort.