### PR TITLE
removed "HandleScope scope" from private accessors

### DIFF
--- a/nan_private.h
+++ b/nan_private.h
@@ -11,7 +11,6 @@
 
 inline Maybe<bool>
 HasPrivate(v8::Local<v8::Object> object, v8::Local<v8::String> key) {
-  HandleScope scope;
 #if NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION
   v8::Isolate *isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
@@ -24,7 +23,6 @@ HasPrivate(v8::Local<v8::Object> object, v8::Local<v8::String> key) {
 
 inline MaybeLocal<v8::Value>
 GetPrivate(v8::Local<v8::Object> object, v8::Local<v8::String> key) {
-  HandleScope scope;
 #if NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION
   v8::Isolate *isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
@@ -42,7 +40,6 @@ inline Maybe<bool> SetPrivate(
     v8::Local<v8::String> key,
     v8::Local<v8::Value> value) {
 #if NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION
-  HandleScope scope;
   v8::Isolate *isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   v8::Local<v8::Private> private_key = v8::Private::ForApi(isolate, key);

--- a/nan_private.h
+++ b/nan_private.h
@@ -23,15 +23,16 @@ HasPrivate(v8::Local<v8::Object> object, v8::Local<v8::String> key) {
 
 inline MaybeLocal<v8::Value>
 GetPrivate(v8::Local<v8::Object> object, v8::Local<v8::String> key) {
+  EscapableHandleScope scope;
 #if NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION
   v8::Isolate *isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   v8::Local<v8::Private> private_key = v8::Private::ForApi(isolate, key);
-  return object->GetPrivate(context, private_key);
+  return scope.Escape(object->GetPrivate(context, private_key).ToLocalChecked());
 #else
   v8::Local<v8::Value> v = object->GetHiddenValue(key);
   v8::Local<v8::Value> def = Undefined();
-  return MaybeLocal<v8::Value>(v.IsEmpty() ? def : v);
+  return scope.Escape(v.IsEmpty() ? def : v);
 #endif
 }
 

--- a/nan_private.h
+++ b/nan_private.h
@@ -11,6 +11,7 @@
 
 inline Maybe<bool>
 HasPrivate(v8::Local<v8::Object> object, v8::Local<v8::String> key) {
+  HandleScope scope;
 #if NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION
   v8::Isolate *isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
@@ -41,6 +42,7 @@ inline Maybe<bool> SetPrivate(
     v8::Local<v8::String> key,
     v8::Local<v8::Value> value) {
 #if NODE_MODULE_VERSION >= NODE_6_0_MODULE_VERSION
+  HandleScope scope;
   v8::Isolate *isolate = v8::Isolate::GetCurrent();
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   v8::Local<v8::Private> private_key = v8::Private::ForApi(isolate, key);


### PR DESCRIPTION
These `HandleScope scope;` declarations were causing crashes on some node versions, and failed tests on other node versions. Removing them fixed all my problems.