### PR TITLE
REPLACE_INVALID_UTF8 requires node 0.10.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "tap": "~0.7.1",
     "xtend": "~4.0.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "engines": {
+    "node": ">=0.10.29"
+  }
 }


### PR DESCRIPTION
NodeJS introduced `REPLACE_INVALID_UTF8` in 0.10.29. See [here](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V010.md#0.10.29).

Usage [here](https://github.com/nodejs/nan/blob/master/nan.h#L324).

Would be nice to have this dependency because I tried to install some sensors that use this module on a raspberry pi with preinstalled node version from ubuntu repo (<0.10.29).