### PR TITLE
nan: add support for JSON::Parse & Stringify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ env:
   - TRAVIS_NODE_VERSION="5"
   - TRAVIS_NODE_VERSION="6"
   - TRAVIS_NODE_VERSION="7"
+notifications:
+  email:
+    - rod@vagg.org
 install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - if [[ $TRAVIS_NODE_VERSION == "0.8" ]]; then npm install npm@2 && node_modules/.bin/npm install npm; else npm install npm; fi

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ LINT_SOURCES = \
 	nan_converters_pre_43_inl.h \
 	nan_implementation_12_inl.h \
 	nan_implementation_pre_12_inl.h \
+	nan_json.h \
 	nan_maybe_43_inl.h \
 	nan_maybe_pre_43_inl.h \
 	nan_new.h \
@@ -49,6 +50,8 @@ LINT_SOURCES = \
 	test/cpp/morenews.cpp \
 	test/cpp/converters.cpp \
 	test/cpp/isolatedata.cpp \
+	test/cpp/json-parse.cpp \
+	test/cpp/json-stringify.cpp \
 	test/cpp/makecallback.cpp \
 	test/cpp/morenews.cpp \
 	test/cpp/multifile1.cpp \
@@ -93,14 +96,14 @@ forcetest:
 docs: README.md doc/.build.sh doc/asyncworker.md doc/buffers.md doc/callback.md \
 		doc/converters.md doc/errors.md doc/maybe_types.md doc/methods.md doc/new.md \
 		doc/node_misc.md doc/persistent.md doc/scopes.md doc/script.md doc/string_bytes.md \
-		doc/v8_internals.md doc/v8_misc.md
+		doc/v8_internals.md doc/json.md doc/v8_misc.md
 	doc/.build.sh
 
 
 $(ADDONS): nan.h nan_new.h nan_implementation_pre_12_inl.h nan_implementation_12_inl.h \
 		nan_callbacks.h nan_callbacks_12_inl.h nan_callbacks_pre_12_inl.h \
 		nan_converters.h nan_converters_43_inl.h nan_converters_pre_43_inl.h \
-		nan_maybe_43_inl.h nan_maybe_pre_43_inl.h \
+		nan_json.h nan_maybe_43_inl.h nan_maybe_pre_43_inl.h \
 		nan_persistent_12_inl.h nan_persistent_pre_12_inl.h nan_private.h \
 		nan_weak.h nan_string_bytes.h test/binding.gyp $(SOURCES)
 	cd test/ && ../node_modules/.bin/node-gyp rebuild

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ NAN provides a `v8::Script` helpers as the API has changed over the supported ve
 
 The _JSON_ object provides the c++ versions of the methods offered by the `JSON` object in javascript. V8 exposes these methods via the `v8::JSON` object.
 
- - <a href="doc/json.md#api_nan_json_parse"><b><code>Nan::JSON::Parse</code></b></a>
- - <a href="doc/json.md#api_nan_json_stringify"><b><code>Nan::JSON::Stringify</code></b></a>
+ - <a href="doc/json.md#api_nan_json_parse"><b><code>Nan::JSON.Parse</code></b></a>
+ - <a href="doc/json.md#api_nan_json_stringify"><b><code>Nan::JSON.Stringify</code></b></a>
 
 Refer to the V8 JSON object in the [V8 documentation](https://v8docs.nodesource.com/node-7.4/da/d6f/classv8_1_1_j_s_o_n.html) for more information about these methods and their arguments.
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,15 @@ NAN provides a `v8::Script` helpers as the API has changed over the supported ve
  - <a href="doc/script.md#api_nan_run_script"><b><code>Nan::RunScript()</code></b></a>
 
 
+### JSON
+
+The _JSON_ object provides the c++ versions of the methods offered by the `JSON` object in javascript. V8 exposes these methods via the `v8::JSON` object.
+
+ - <a href="doc/json.md#api_nan_json_parse"><b><code>Nan::JSON::Parse</code></b></a>
+ - <a href="doc/json.md#api_nan_json_stringify"><b><code>Nan::JSON::Stringify</code></b></a>
+
+Refer to the V8 JSON object in the [V8 documentation](https://v8docs.nodesource.com/node-7.4/da/d6f/classv8_1_1_j_s_o_n.html) for more information about these methods and their arguments.
+
 ### Errors
 
 NAN includes helpers for creating, throwing and catching Errors as much of this functionality varies across the supported versions of V8 and must be abstracted.

--- a/doc/.build.sh
+++ b/doc/.build.sh
@@ -8,6 +8,7 @@ files="              \
   converters.md      \
   maybe_types.md     \
   script.md          \
+  json.md            \
   errors.md          \
   buffers.md         \
   callback.md        \

--- a/doc/json.md
+++ b/doc/json.md
@@ -47,7 +47,7 @@ Example:
 
 ```c++
 // using `v8::Local<v8::Value> val` from the `JSON::Parse` example
-v8::Local<v8::Object> obj = val->ToObject();
+v8::Local<v8::Object> obj = Nan::To<v8::Object>(val);
 
 v8::Local<v8::String> stringified = Nan::JSON::Stringify(obj).ToLocalChecked();
 ```

--- a/doc/json.md
+++ b/doc/json.md
@@ -16,7 +16,7 @@ A simple wrapper around [`v8::JSON::Parse`](https://v8docs.nodesource.com/node-7
 Definition:
 
 ```c++
-Nan::MaybeLocal<v8::Value> Nan::JSON::Parse(v8::Local<v8::String> jsonString);
+Nan::MaybeLocal<v8::Value> Nan::JSON::Parse(v8::Local<v8::String> json_string);
 ```
 
 Use `JSON.Parse(json_string)` to parse a `v8::String` into a `v8::Value`.
@@ -39,7 +39,7 @@ A simple wrapper around [`v8::JSON::Stringify`](https://v8docs.nodesource.com/no
 Definition:
 
 ```c++
-Nan::MaybeLocal<v8::String> Nan::JSON::Stringify(v8::Local<v8::Object> jsonObject, v8::Local<v8::String> gap = v8::Local<v8::String>());
+Nan::MaybeLocal<v8::String> Nan::JSON::Stringify(v8::Local<v8::Object> json_object, v8::Local<v8::String> gap = v8::Local<v8::String>());
 ```
 
 Use `JSON.Stringify(value)` to convert a `v8::Object` into a `v8::String`.

--- a/doc/json.md
+++ b/doc/json.md
@@ -1,0 +1,54 @@
+## JSON
+
+The _JSON_ object provides the c++ versions of the methods offered by the `JSON` object in javascript. V8 exposes these methods via the `v8::JSON` object.
+
+ - <a href="#api_nan_json_parse"><b><code>Nan::JSON::Parse</code></b></a>
+ - <a href="#api_nan_json_stringify"><b><code>Nan::JSON::Stringify</code></b></a>
+
+Refer to the V8 JSON object in the [V8 documentation](https://v8docs.nodesource.com/node-7.4/da/d6f/classv8_1_1_j_s_o_n.html) for more information about these methods and their arguments.
+
+<a name="api_nan_json_parse"></a>
+
+### Nan::JSON::Parse
+
+A simple wrapper around [`v8::JSON::Parse`](https://v8docs.nodesource.com/node-7.4/da/d6f/classv8_1_1_j_s_o_n.html#a936310d2540fb630ed37d3ee3ffe4504).
+
+Definition:
+
+```c++
+Nan::MaybeLocal<v8::Value> Nan::JSON::Parse(v8::Local<v8::String> jsonString);
+```
+
+Use `JSON::Parse(json_string)` to parse a `v8::String` into a `v8::Value`.
+
+Example:
+
+```c++
+v8::Local<v8::String> json_string = Nan::New("{ \"JSON\": \"object\" }").ToLocalChecked();
+
+v8::Local<v8::Value> val = Nan::JSON::Parse(json_string).ToLocalChecked();
+```
+
+<a name="api_nan_json_stringify"></a>
+
+### Nan::JSON::Stringify
+
+A simple wrapper around [`v8::JSON::Stringify`](https://v8docs.nodesource.com/node-7.4/da/d6f/classv8_1_1_j_s_o_n.html#a44b255c3531489ce43f6110209138860).
+
+Definition:
+
+```c++
+Nan::MaybeLocal<v8::String> Nan::JSON::Stringify(v8::Local<v8::Object> jsonObject, v8::Local<v8::String> gap = v8::Local<v8::String>());
+```
+
+Use `JSON::Stringify(value)` to convert a `v8::Object` into a `v8::String`.
+
+Example:
+
+```c++
+// using `v8::Local<v8::Value> val` from the `JSON::Parse` example
+v8::Local<v8::Object> obj = val->ToObject();
+
+v8::Local<v8::String> stringified = Nan::JSON::Stringify(obj).ToLocalChecked();
+```
+

--- a/doc/json.md
+++ b/doc/json.md
@@ -2,14 +2,14 @@
 
 The _JSON_ object provides the c++ versions of the methods offered by the `JSON` object in javascript. V8 exposes these methods via the `v8::JSON` object.
 
- - <a href="#api_nan_json_parse"><b><code>Nan::JSON::Parse</code></b></a>
- - <a href="#api_nan_json_stringify"><b><code>Nan::JSON::Stringify</code></b></a>
+ - <a href="#api_nan_json_parse"><b><code>Nan::JSON.Parse</code></b></a>
+ - <a href="#api_nan_json_stringify"><b><code>Nan::JSON.Stringify</code></b></a>
 
 Refer to the V8 JSON object in the [V8 documentation](https://v8docs.nodesource.com/node-7.4/da/d6f/classv8_1_1_j_s_o_n.html) for more information about these methods and their arguments.
 
 <a name="api_nan_json_parse"></a>
 
-### Nan::JSON::Parse
+### Nan::JSON.Parse
 
 A simple wrapper around [`v8::JSON::Parse`](https://v8docs.nodesource.com/node-7.4/da/d6f/classv8_1_1_j_s_o_n.html#a936310d2540fb630ed37d3ee3ffe4504).
 
@@ -35,7 +35,7 @@ if (!result.IsEmpty()) {
 
 <a name="api_nan_json_stringify"></a>
 
-### Nan::JSON::Stringify
+### Nan::JSON.Stringify
 
 A simple wrapper around [`v8::JSON::Stringify`](https://v8docs.nodesource.com/node-7.4/da/d6f/classv8_1_1_j_s_o_n.html#a44b255c3531489ce43f6110209138860).
 

--- a/doc/json.md
+++ b/doc/json.md
@@ -27,7 +27,10 @@ Example:
 v8::Local<v8::String> json_string = Nan::New("{ \"JSON\": \"object\" }").ToLocalChecked();
 
 Nan::JSON NanJSON;
-v8::Local<v8::Value> val = NanJSON.Parse(json_string).ToLocalChecked();
+Nan::MaybeLocal<v8::Value> result = NanJSON.Parse(json_string);
+if (!result.IsEmpty()) {
+  v8::Local<v8::Value> val = result.ToLocalChecked();
+}
 ```
 
 <a name="api_nan_json_stringify"></a>
@@ -51,6 +54,9 @@ Example:
 v8::Local<v8::Object> obj = Nan::To<v8::Object>(val).ToLocalChecked();
 
 Nan::JSON NanJSON;
-v8::Local<v8::String> stringified = NanJSON.Stringify(obj).ToLocalChecked();
+Nan::MaybeLocal<v8::String> result = NanJSON.Stringify(obj);
+if (!result.IsEmpty()) {
+  v8::Local<v8::String> stringified = result.ToLocalChecked();
+}
 ```
 

--- a/doc/json.md
+++ b/doc/json.md
@@ -19,7 +19,7 @@ Definition:
 Nan::MaybeLocal<v8::Value> Nan::JSON::Parse(v8::Local<v8::String> json_string);
 ```
 
-Use `JSON.Parse(json_string)` to parse a `v8::String` into a `v8::Value`.
+Use `JSON.Parse(json_string)` to parse a string into a `v8::Value`.
 
 Example:
 
@@ -45,7 +45,7 @@ Definition:
 Nan::MaybeLocal<v8::String> Nan::JSON::Stringify(v8::Local<v8::Object> json_object, v8::Local<v8::String> gap = v8::Local<v8::String>());
 ```
 
-Use `JSON.Stringify(value)` to convert a `v8::Object` into a `v8::String`.
+Use `JSON.Stringify(value)` to stringify a `v8::Object`.
 
 Example:
 

--- a/doc/json.md
+++ b/doc/json.md
@@ -19,14 +19,15 @@ Definition:
 Nan::MaybeLocal<v8::Value> Nan::JSON::Parse(v8::Local<v8::String> jsonString);
 ```
 
-Use `JSON::Parse(json_string)` to parse a `v8::String` into a `v8::Value`.
+Use `JSON.Parse(json_string)` to parse a `v8::String` into a `v8::Value`.
 
 Example:
 
 ```c++
 v8::Local<v8::String> json_string = Nan::New("{ \"JSON\": \"object\" }").ToLocalChecked();
 
-v8::Local<v8::Value> val = Nan::JSON::Parse(json_string).ToLocalChecked();
+Nan::JSON NanJSON;
+v8::Local<v8::Value> val = NanJSON.Parse(json_string).ToLocalChecked();
 ```
 
 <a name="api_nan_json_stringify"></a>
@@ -41,7 +42,7 @@ Definition:
 Nan::MaybeLocal<v8::String> Nan::JSON::Stringify(v8::Local<v8::Object> jsonObject, v8::Local<v8::String> gap = v8::Local<v8::String>());
 ```
 
-Use `JSON::Stringify(value)` to convert a `v8::Object` into a `v8::String`.
+Use `JSON.Stringify(value)` to convert a `v8::Object` into a `v8::String`.
 
 Example:
 
@@ -49,6 +50,7 @@ Example:
 // using `v8::Local<v8::Value> val` from the `JSON::Parse` example
 v8::Local<v8::Object> obj = Nan::To<v8::Object>(val).ToLocalChecked();
 
-v8::Local<v8::String> stringified = Nan::JSON::Stringify(obj).ToLocalChecked();
+Nan::JSON NanJSON;
+v8::Local<v8::String> stringified = NanJSON.Stringify(obj).ToLocalChecked();
 ```
 

--- a/doc/json.md
+++ b/doc/json.md
@@ -47,7 +47,7 @@ Example:
 
 ```c++
 // using `v8::Local<v8::Value> val` from the `JSON::Parse` example
-v8::Local<v8::Object> obj = Nan::To<v8::Object>(val);
+v8::Local<v8::Object> obj = Nan::To<v8::Object>(val).ToLocalChecked();
 
 v8::Local<v8::String> stringified = Nan::JSON::Stringify(obj).ToLocalChecked();
 ```

--- a/nan.h
+++ b/nan.h
@@ -2310,6 +2310,10 @@ MakeMaybe(MaybeMaybe<T> v) {
 
 #include "nan_typedarray_contents.h"  // NOLINT(build/include)
 
+//=== JSON =====================================================================
+
+#include "nan_json.h"  // NOLINT(build/include)
+
 }  // end of namespace Nan
 
 #endif  // NAN_H_

--- a/nan_json.h
+++ b/nan_json.h
@@ -1,0 +1,135 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2017 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_JSON_H_
+#define NAN_JSON_H_
+
+#if ((NODE_MAJOR_VERSION == 0) && (NODE_MINOR_VERSION < 12))
+#define NAN_JSON_H_NEED_PARSE 1
+#else
+#define NAN_JSON_H_NEED_PARSE 0
+#endif
+
+#if (NODE_MAJOR_VERSION >= 7)
+#define NAN_JSON_H_NEED_STRINGIFY 0
+#else
+#define NAN_JSON_H_NEED_STRINGIFY 1
+#endif
+
+class JSON {
+ public:
+  static inline
+  Nan::MaybeLocal<v8::Value> Parse(v8::Local<v8::String> jsonString) {
+#if NAN_JSON_H_NEED_PARSE
+    return instance().parse(jsonString);
+#else
+#if (NODE_MAJOR_VERSION >= 7)
+    return v8::JSON::Parse(Nan::GetCurrentContext(), jsonString);
+#else
+    return v8::JSON::Parse(jsonString);
+#endif
+#endif
+  }
+
+  static inline
+  Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> jsonObject) {
+#if NAN_JSON_H_NEED_STRINGIFY
+    return instance().stringify(jsonObject)->ToString();
+#else
+    return v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject);
+#endif
+  }
+
+  static inline
+  Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> jsonObject,
+    v8::Local<v8::String> gap) {
+#if NAN_JSON_H_NEED_STRINGIFY
+    return instance().stringify(jsonObject, gap)->ToString();
+#else
+    return v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject, gap);
+#endif
+  }
+
+ private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(JSON)
+#if NAN_JSON_H_NEED_PARSE
+  Nan::Callback m_cb_parse;
+#endif
+#if NAN_JSON_H_NEED_STRINGIFY
+  Nan::Callback m_cb_stringify;
+#endif
+
+#if (NAN_JSON_H_NEED_PARSE + NAN_JSON_H_NEED_STRINGIFY)
+  static JSON& instance() {
+    static JSON i;
+    return i;
+  }
+#endif
+
+  JSON() {
+#if (NAN_JSON_H_NEED_PARSE + NAN_JSON_H_NEED_STRINGIFY)
+    v8::Local<v8::Value> globalJSON =
+      Nan::GetCurrentContext()->Global()->Get(
+        Nan::New("JSON").ToLocalChecked()
+      );
+
+    if (globalJSON->IsObject()) {
+#if NAN_JSON_H_NEED_PARSE
+      v8::Local<v8::Value> parseMethod =
+        globalJSON->ToObject()->Get(Nan::New("parse").ToLocalChecked());
+
+      if (!parseMethod.IsEmpty() && parseMethod->IsFunction()) {
+        m_cb_parse.Reset(v8::Local<v8::Function>::Cast(parseMethod));
+      }
+#endif
+
+#if NAN_JSON_H_NEED_STRINGIFY
+      v8::Local<v8::Value> stringifyMethod =
+        globalJSON->ToObject()->Get(Nan::New("stringify").ToLocalChecked());
+
+      if (!stringifyMethod.IsEmpty() && stringifyMethod->IsFunction()) {
+        m_cb_stringify.Reset(v8::Local<v8::Function>::Cast(stringifyMethod));
+      }
+#endif
+    }
+#endif
+  }
+
+  ~JSON() {
+#if NAN_JSON_H_NEED_PARSE
+    m_cb_parse.Reset();
+#endif
+#if NAN_JSON_H_NEED_STRINGIFY
+    m_cb_stringify.Reset();
+#endif
+  }
+
+#if NAN_JSON_H_NEED_PARSE
+  inline v8::Local<v8::Value> parse(v8::Local<v8::Value> arg) {
+    return m_cb_parse.Call(1, &arg);
+  }
+#endif
+
+#if NAN_JSON_H_NEED_STRINGIFY
+  inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg) {
+    return m_cb_stringify.Call(1, &arg);
+  }
+
+  inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg,
+    v8::Local<v8::String> gap) {
+    v8::Local<v8::Value> argv[] = {
+      arg,
+      Nan::Null(),
+      gap
+    };
+    return m_cb_stringify.Call(3, argv);
+  }
+#endif
+};
+
+#endif /* NAN_JSON_H_ */

--- a/nan_json.h
+++ b/nan_json.h
@@ -25,8 +25,8 @@ class JSON {
  public:
   static inline
   Nan::MaybeLocal<v8::Value> Parse(v8::Local<v8::String> jsonString) {
-#if NAN_JSON_H_NEED_PARSE
     Nan::HandleScope scope;
+#if NAN_JSON_H_NEED_PARSE
     return parse(jsonString);
 #else
 #if (NODE_MAJOR_VERSION >= 7)
@@ -39,8 +39,8 @@ class JSON {
 
   static inline
   Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> jsonObject) {
-#if NAN_JSON_H_NEED_STRINGIFY
     Nan::HandleScope scope;
+#if NAN_JSON_H_NEED_STRINGIFY
     return stringify(jsonObject)->ToString();
 #else
     return v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject);
@@ -50,8 +50,8 @@ class JSON {
   static inline
   Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> jsonObject,
     v8::Local<v8::String> gap) {
-#if NAN_JSON_H_NEED_STRINGIFY
     Nan::HandleScope scope;
+#if NAN_JSON_H_NEED_STRINGIFY
     return stringify(jsonObject, gap)->ToString();
 #else
     return v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject, gap);

--- a/nan_json.h
+++ b/nan_json.h
@@ -54,7 +54,7 @@ class JSON {
               parse_cb_.Reset(v8::Local<v8::Function>::Cast(parseMethod));
             }
           }
-#endif
+#endif  // NAN_JSON_H_NEED_PARSE
 
 #if NAN_JSON_H_NEED_STRINGIFY
           Nan::MaybeLocal<v8::Value> maybeStringifyMethod = Nan::Get(
@@ -71,11 +71,11 @@ class JSON {
               );
             }
           }
-#endif
+#endif  // NAN_JSON_H_NEED_STRINGIFY
         }
       }
     }
-#endif
+#endif  // NAN_JSON_H_NEED_PARSE + NAN_JSON_H_NEED_STRINGIFY
   }
 
   inline
@@ -92,8 +92,8 @@ class JSON {
     return scope.Escape(result.ToLocalChecked());
 #else
     return scope.Escape(v8::JSON::Parse(json_string));
-#endif
-#endif
+#endif  // NODE_MAJOR_VERSION >= 7
+#endif  // NAN_JSON_H_NEED_PARSE
   }
 
   inline
@@ -104,7 +104,7 @@ class JSON {
       Nan::To<v8::String>(stringify(json_object));
 #else
       v8::JSON::Stringify(Nan::GetCurrentContext(), json_object);
-#endif
+#endif  // NAN_JSON_H_NEED_STRINGIFY
     if (result.IsEmpty()) return v8::Local<v8::String>();
     return scope.Escape(result.ToLocalChecked());
   }
@@ -118,7 +118,7 @@ class JSON {
       Nan::To<v8::String>(stringify(json_object, gap));
 #else
       v8::JSON::Stringify(Nan::GetCurrentContext(), json_object, gap);
-#endif
+#endif  // NAN_JSON_H_NEED_STRINGIFY
     if (result.IsEmpty()) return v8::Local<v8::String>();
     return scope.Escape(result.ToLocalChecked());
   }
@@ -127,17 +127,17 @@ class JSON {
   NAN_DISALLOW_ASSIGN_COPY_MOVE(JSON)
 #if NAN_JSON_H_NEED_PARSE
   Nan::Callback parse_cb_;
-#endif
+#endif  // NAN_JSON_H_NEED_PARSE
 #if NAN_JSON_H_NEED_STRINGIFY
   Nan::Callback stringify_cb_;
-#endif
+#endif  // NAN_JSON_H_NEED_STRINGIFY
 
 #if NAN_JSON_H_NEED_PARSE
   inline v8::Local<v8::Value> parse(v8::Local<v8::Value> arg) {
     if (parse_cb_.IsEmpty()) return Nan::Undefined();
     return parse_cb_.Call(1, &arg);
   }
-#endif
+#endif  // NAN_JSON_H_NEED_PARSE
 
 #if NAN_JSON_H_NEED_STRINGIFY
   inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg) {
@@ -156,7 +156,7 @@ class JSON {
     };
     return stringify_cb_.Call(3, argv);
   }
-#endif
+#endif  // NAN_JSON_H_NEED_STRINGIFY
 };
 
-#endif /* NAN_JSON_H_ */
+#endif  // NAN_JSON_H_

--- a/nan_json.h
+++ b/nan_json.h
@@ -78,15 +78,6 @@ class JSON {
 #endif
   }
 
-  ~JSON() {
-#if NAN_JSON_H_NEED_PARSE
-    parse_cb_.Reset();
-#endif
-#if NAN_JSON_H_NEED_STRINGIFY
-    stringify_cb_.Reset();
-#endif
-  }
-
   inline
   Nan::MaybeLocal<v8::Value> Parse(v8::Local<v8::String> json_string) {
     Nan::EscapableHandleScope scope;

--- a/nan_json.h
+++ b/nan_json.h
@@ -82,7 +82,7 @@ class JSON {
       return Nan::Undefined();
     }
 
-    v8::MaybeLocal<v8::Object> maybeJson =
+    Nan::MaybeLocal<v8::Object> maybeJson =
       Nan::To<v8::Object>(globalJSON);
 
     if (maybeJson.IsEmpty()) {

--- a/nan_json.h
+++ b/nan_json.h
@@ -88,45 +88,45 @@ class JSON {
   }
 
   inline
-  Nan::MaybeLocal<v8::Value> Parse(v8::Local<v8::String> jsonString) {
+  Nan::MaybeLocal<v8::Value> Parse(v8::Local<v8::String> json_string) {
     Nan::EscapableHandleScope scope;
 #if NAN_JSON_H_NEED_PARSE
-    return scope.Escape(parse(jsonString));
+    return scope.Escape(parse(json_string));
 #else
 #if (NODE_MAJOR_VERSION >= 7)
     Nan::MaybeLocal<v8::Value> result =
-      v8::JSON::Parse(Nan::GetCurrentContext(), jsonString);
+      v8::JSON::Parse(Nan::GetCurrentContext(), json_string);
 
     if (result.IsEmpty()) return v8::Local<v8::Value>();
     return scope.Escape(result.ToLocalChecked());
 #else
-    return scope.Escape(v8::JSON::Parse(jsonString));
+    return scope.Escape(v8::JSON::Parse(json_string));
 #endif
 #endif
   }
 
   inline
-  Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> jsonObject) {
+  Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> json_object) {
     Nan::EscapableHandleScope scope;
     Nan::MaybeLocal<v8::String> result =
 #if NAN_JSON_H_NEED_STRINGIFY
-      Nan::To<v8::String>(stringify(jsonObject));
+      Nan::To<v8::String>(stringify(json_object));
 #else
-      v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject);
+      v8::JSON::Stringify(Nan::GetCurrentContext(), json_object);
 #endif
     if (result.IsEmpty()) return v8::Local<v8::String>();
     return scope.Escape(result.ToLocalChecked());
   }
 
   inline
-  Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> jsonObject,
+  Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> json_object,
     v8::Local<v8::String> gap) {
     Nan::EscapableHandleScope scope;
     Nan::MaybeLocal<v8::String> result =
 #if NAN_JSON_H_NEED_STRINGIFY
-      Nan::To<v8::String>(stringify(jsonObject, gap));
+      Nan::To<v8::String>(stringify(json_object, gap));
 #else
-      v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject, gap);
+      v8::JSON::Stringify(Nan::GetCurrentContext(), json_object, gap);
 #endif
     if (result.IsEmpty()) return v8::Local<v8::String>();
     return scope.Escape(result.ToLocalChecked());

--- a/nan_json.h
+++ b/nan_json.h
@@ -51,7 +51,7 @@ class JSON {
               maybeparse_method.ToLocalChecked();
 
             if (parse_method->IsFunction()) {
-              parse_cb_.Reset(v8::Local<v8::Function>::Cast(parse_method));
+              parse_cb_.Reset(parse_method.As<v8::Function>());
             }
           }
 #endif  // NAN_JSON_H_NEED_PARSE
@@ -66,9 +66,7 @@ class JSON {
               maybestringify_method.ToLocalChecked();
 
             if (stringify_method->IsFunction()) {
-              stringify_cb_.Reset(
-                v8::Local<v8::Function>::Cast(stringify_method)
-              );
+              stringify_cb_.Reset(stringify_method.As<v8::Function>());
             }
           }
 #endif  // NAN_JSON_H_NEED_STRINGIFY

--- a/nan_json.h
+++ b/nan_json.h
@@ -41,7 +41,7 @@ class JSON {
   Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> jsonObject) {
     Nan::HandleScope scope;
 #if NAN_JSON_H_NEED_STRINGIFY
-    return stringify(jsonObject)->ToString();
+    return Nan::To<v8::String>(stringify(jsonObject));
 #else
     return v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject);
 #endif
@@ -52,7 +52,7 @@ class JSON {
     v8::Local<v8::String> gap) {
     Nan::HandleScope scope;
 #if NAN_JSON_H_NEED_STRINGIFY
-    return stringify(jsonObject, gap)->ToString();
+    return Nan::To<v8::String>(stringify(jsonObject, gap));
 #else
     return v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject, gap);
 #endif

--- a/nan_json.h
+++ b/nan_json.h
@@ -23,7 +23,71 @@
 
 class JSON {
  public:
-  static inline
+  JSON() {
+#if (NAN_JSON_H_NEED_PARSE + NAN_JSON_H_NEED_STRINGIFY)
+    Nan::MaybeLocal<v8::Value> maybeGlobalJSON = Nan::Get(
+      Nan::GetCurrentContext()->Global(),
+      Nan::New("JSON").ToLocalChecked()
+    );
+
+    if (!maybeGlobalJSON.IsEmpty()) {
+      v8::Local<v8::Value> valGlobalJSON = maybeGlobalJSON.ToLocalChecked();
+
+      if (valGlobalJSON->IsObject()) {
+        Nan::MaybeLocal<v8::Object> maybeObjGlobalJSON =
+          Nan::To<v8::Object>(valGlobalJSON);
+
+        if (!maybeObjGlobalJSON.IsEmpty()) {
+          v8::Local<v8::Object> globalJSON =
+            maybeObjGlobalJSON.ToLocalChecked();
+
+#if NAN_JSON_H_NEED_PARSE
+          Nan::MaybeLocal<v8::Value> maybeParseMethod = Nan::Get(
+            globalJSON, Nan::New("parse").ToLocalChecked()
+          );
+
+          if (!maybeParseMethod.IsEmpty()) {
+            v8::Local<v8::Value> parseMethod =
+              maybeParseMethod.ToLocalChecked();
+
+            if (parseMethod->IsFunction()) {
+              m_cb_parse.Reset(v8::Local<v8::Function>::Cast(parseMethod));
+            }
+          }
+#endif
+
+#if NAN_JSON_H_NEED_STRINGIFY
+          Nan::MaybeLocal<v8::Value> maybeStringifyMethod = Nan::Get(
+            globalJSON, Nan::New("stringify").ToLocalChecked()
+          );
+
+          if (!maybeStringifyMethod.IsEmpty()) {
+            v8::Local<v8::Value> stringifyMethod =
+              maybeStringifyMethod.ToLocalChecked();
+
+            if (stringifyMethod->IsFunction()) {
+              m_cb_stringify.Reset(
+                v8::Local<v8::Function>::Cast(stringifyMethod)
+              );
+            }
+          }
+#endif
+        }
+      }
+    }
+#endif
+  }
+
+  ~JSON() {
+#if NAN_JSON_H_NEED_PARSE
+    m_cb_parse.Reset();
+#endif
+#if NAN_JSON_H_NEED_STRINGIFY
+    m_cb_stringify.Reset();
+#endif
+  }
+
+  inline
   Nan::MaybeLocal<v8::Value> Parse(v8::Local<v8::String> jsonString) {
 #if NAN_JSON_H_NEED_PARSE
     Nan::HandleScope scope;
@@ -38,7 +102,7 @@ class JSON {
 #endif
   }
 
-  static inline
+  inline
   Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> jsonObject) {
     Nan::HandleScope scope;
 #if NAN_JSON_H_NEED_STRINGIFY
@@ -48,7 +112,7 @@ class JSON {
 #endif
   }
 
-  static inline
+  inline
   Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> jsonObject,
     v8::Local<v8::String> gap) {
     Nan::HandleScope scope;
@@ -61,74 +125,32 @@ class JSON {
 
  private:
   NAN_DISALLOW_ASSIGN_COPY_MOVE(JSON)
-  JSON();
-  ~JSON();
-
-  static v8::Local<v8::Value> Call(const char *method,
-    int argc, v8::Local<v8::Value> *argv) {
-    Nan::MaybeLocal<v8::Value> maybeGlobalJSON =
-      Nan::Get(
-        Nan::GetCurrentContext()->Global(),
-        Nan::New("JSON").ToLocalChecked()
-      );
-
-    if (maybeGlobalJSON.IsEmpty()) {
-      return Nan::Undefined();
-    }
-
-    v8::Local<v8::Value> globalJSON = maybeGlobalJSON.ToLocalChecked();
-
-    if (!globalJSON->IsObject()) {
-      return Nan::Undefined();
-    }
-
-    Nan::MaybeLocal<v8::Object> maybeJson =
-      Nan::To<v8::Object>(globalJSON);
-
-    if (maybeJson.IsEmpty()) {
-      return Nan::Undefined();
-    }
-
-    v8::Local<v8::Object> json = maybeJson.ToLocalChecked();
-
-    Nan::MaybeLocal<v8::Value> maybeThisMethod =
-      Nan::Get(json, Nan::New(method).ToLocalChecked());
-
-    if (maybeThisMethod.IsEmpty()) {
-      return Nan::Undefined();
-    }
-
-    v8::Local<v8::Value> thisMethod = maybeThisMethod.ToLocalChecked();
-
-    if (!thisMethod->IsFunction()) {
-      return Nan::Undefined();
-    }
-
-    v8::Local<v8::Function> methodFunction =
-      v8::Local<v8::Function>::Cast(thisMethod);
-
-    return methodFunction->Call(json, argc, argv);
-  }
+#if NAN_JSON_H_NEED_PARSE
+  Nan::Callback m_cb_parse;
+#endif
+#if NAN_JSON_H_NEED_STRINGIFY
+  Nan::Callback m_cb_stringify;
+#endif
 
 #if NAN_JSON_H_NEED_PARSE
-  static inline v8::Local<v8::Value> parse(v8::Local<v8::Value> arg) {
-    return Call("parse", 1, &arg);
+  inline v8::Local<v8::Value> parse(v8::Local<v8::Value> arg) {
+    return m_cb_parse.Call(1, &arg);
   }
 #endif
 
 #if NAN_JSON_H_NEED_STRINGIFY
-  static inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg) {
-    return Call("stringify", 1, &arg);
+  inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg) {
+    return m_cb_stringify.Call(1, &arg);
   }
 
-  static inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg,
+  inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg,
     v8::Local<v8::String> gap) {
     v8::Local<v8::Value> argv[] = {
       arg,
       Nan::Null(),
       gap
     };
-    return Call("stringify", 3, argv);
+    return m_cb_stringify.Call(3, argv);
   }
 #endif
 };

--- a/nan_json.h
+++ b/nan_json.h
@@ -26,6 +26,7 @@ class JSON {
   static inline
   Nan::MaybeLocal<v8::Value> Parse(v8::Local<v8::String> jsonString) {
 #if NAN_JSON_H_NEED_PARSE
+    Nan::HandleScope scope;
     return instance().parse(jsonString);
 #else
 #if (NODE_MAJOR_VERSION >= 7)
@@ -39,6 +40,7 @@ class JSON {
   static inline
   Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> jsonObject) {
 #if NAN_JSON_H_NEED_STRINGIFY
+    Nan::HandleScope scope;
     return instance().stringify(jsonObject)->ToString();
 #else
     return v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject);
@@ -49,6 +51,7 @@ class JSON {
   Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> jsonObject,
     v8::Local<v8::String> gap) {
 #if NAN_JSON_H_NEED_STRINGIFY
+    Nan::HandleScope scope;
     return instance().stringify(jsonObject, gap)->ToString();
 #else
     return v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject, gap);

--- a/nan_json.h
+++ b/nan_json.h
@@ -66,9 +66,10 @@ class JSON {
   static v8::Local<v8::Value> Call(const char *method,
     int argc, v8::Local<v8::Value> *argv) {
     v8::Local<v8::Value> globalJSON =
-      Nan::GetCurrentContext()->Global()->Get(
+      Nan::Get(
+        Nan::GetCurrentContext()->Global(),
         Nan::New("JSON").ToLocalChecked()
-      );
+      ).ToLocalChecked();
 
     if (!globalJSON->IsObject()) {
       return Nan::Undefined();
@@ -77,7 +78,7 @@ class JSON {
     v8::Local<v8::Object> json = globalJSON->ToObject();
 
     v8::Local<v8::Value> thisMethod =
-      json->Get(Nan::New(method).ToLocalChecked());
+      Nan::Get(json, Nan::New(method).ToLocalChecked()).ToLocalChecked();
 
     if (thisMethod.IsEmpty() || !thisMethod->IsFunction()) {
       return Nan::Undefined();

--- a/nan_json.h
+++ b/nan_json.h
@@ -32,49 +32,45 @@ class JSON {
       Nan::New("JSON").ToLocalChecked()
     );
 
-    if (!maybe_global_json.IsEmpty()) {
-      v8::Local<v8::Value> val_global_json = maybe_global_json.ToLocalChecked();
+    assert(!maybe_global_json.IsEmpty() && "global JSON is empty");
 
-      if (val_global_json->IsObject()) {
-        Nan::MaybeLocal<v8::Object> maybe_obj_global_json =
-          Nan::To<v8::Object>(val_global_json);
+    v8::Local<v8::Value> val_global_json = maybe_global_json.ToLocalChecked();
 
-        if (!maybe_obj_global_json.IsEmpty()) {
-          v8::Local<v8::Object> global_json =
-            maybe_obj_global_json.ToLocalChecked();
+    assert(val_global_json->IsObject() && "global JSON is not an object");
+
+    Nan::MaybeLocal<v8::Object> maybe_obj_global_json =
+      Nan::To<v8::Object>(val_global_json);
+
+    assert(!maybe_obj_global_json.IsEmpty() && "global JSON object is empty");
+
+    v8::Local<v8::Object> global_json = maybe_obj_global_json.ToLocalChecked();
 
 #if NAN_JSON_H_NEED_PARSE
-          Nan::MaybeLocal<v8::Value> maybe_parse_method = Nan::Get(
-            global_json, Nan::New("parse").ToLocalChecked()
-          );
+    Nan::MaybeLocal<v8::Value> maybe_parse_method = Nan::Get(
+      global_json, Nan::New("parse").ToLocalChecked()
+    );
 
-          if (!maybe_parse_method.IsEmpty()) {
-            v8::Local<v8::Value> parse_method =
-              maybe_parse_method.ToLocalChecked();
+    assert(!maybe_parse_method.IsEmpty() && "JSON.parse is empty");
+    v8::Local<v8::Value> parse_method = maybe_parse_method.ToLocalChecked();
 
-            if (parse_method->IsFunction()) {
-              parse_cb_.Reset(parse_method.As<v8::Function>());
-            }
-          }
+    assert(parse_method->IsFunction() && "JSON.parse is not a function");
+    parse_cb_.Reset(parse_method.As<v8::Function>());
 #endif  // NAN_JSON_H_NEED_PARSE
 
 #if NAN_JSON_H_NEED_STRINGIFY
-          Nan::MaybeLocal<v8::Value> maybe_stringify_method = Nan::Get(
-            global_json, Nan::New("stringify").ToLocalChecked()
-          );
+    Nan::MaybeLocal<v8::Value> maybe_stringify_method = Nan::Get(
+      global_json, Nan::New("stringify").ToLocalChecked()
+    );
 
-          if (!maybe_stringify_method.IsEmpty()) {
-            v8::Local<v8::Value> stringify_method =
-              maybe_stringify_method.ToLocalChecked();
+    assert(!maybe_stringify_method.IsEmpty() && "JSON.stringify is empty");
+    v8::Local<v8::Value> stringify_method =
+      maybe_stringify_method.ToLocalChecked();
 
-            if (stringify_method->IsFunction()) {
-              stringify_cb_.Reset(stringify_method.As<v8::Function>());
-            }
-          }
+    assert(
+      stringify_method->IsFunction() && "JSON.stringify is not a function"
+    );
+    stringify_cb_.Reset(stringify_method.As<v8::Function>());
 #endif  // NAN_JSON_H_NEED_STRINGIFY
-        }
-      }
-    }
 #endif  // NAN_JSON_H_NEED_PARSE + NAN_JSON_H_NEED_STRINGIFY
   }
 

--- a/nan_json.h
+++ b/nan_json.h
@@ -143,17 +143,21 @@ class JSON {
 
 #if NAN_JSON_H_NEED_PARSE
   inline v8::Local<v8::Value> parse(v8::Local<v8::Value> arg) {
+    if (m_cb_parse.IsEmpty()) return Nan::Undefined();
     return m_cb_parse.Call(1, &arg);
   }
 #endif
 
 #if NAN_JSON_H_NEED_STRINGIFY
   inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg) {
+    if (m_cb_stringify.IsEmpty()) return Nan::Undefined();
     return m_cb_stringify.Call(1, &arg);
   }
 
   inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg,
     v8::Local<v8::String> gap) {
+    if (m_cb_stringify.IsEmpty()) return Nan::Undefined();
+
     v8::Local<v8::Value> argv[] = {
       arg,
       Nan::Null(),

--- a/nan_json.h
+++ b/nan_json.h
@@ -33,16 +33,13 @@ class JSON {
     );
 
     assert(!maybe_global_json.IsEmpty() && "global JSON is empty");
-
     v8::Local<v8::Value> val_global_json = maybe_global_json.ToLocalChecked();
 
     assert(val_global_json->IsObject() && "global JSON is not an object");
-
     Nan::MaybeLocal<v8::Object> maybe_obj_global_json =
       Nan::To<v8::Object>(val_global_json);
 
     assert(!maybe_obj_global_json.IsEmpty() && "global JSON object is empty");
-
     v8::Local<v8::Object> global_json = maybe_obj_global_json.ToLocalChecked();
 
 #if NAN_JSON_H_NEED_PARSE

--- a/nan_json.h
+++ b/nan_json.h
@@ -130,20 +130,20 @@ class JSON {
 
 #if NAN_JSON_H_NEED_PARSE
   inline v8::Local<v8::Value> parse(v8::Local<v8::Value> arg) {
-    if (parse_cb_.IsEmpty()) return Nan::Undefined();
+    assert(!parse_cb_.IsEmpty() && "parse_cb_ is empty");
     return parse_cb_.Call(1, &arg);
   }
 #endif  // NAN_JSON_H_NEED_PARSE
 
 #if NAN_JSON_H_NEED_STRINGIFY
   inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg) {
-    if (stringify_cb_.IsEmpty()) return Nan::Undefined();
+    assert(!stringify_cb_.IsEmpty() && "stringify_cb_ is empty");
     return stringify_cb_.Call(1, &arg);
   }
 
   inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg,
     v8::Local<v8::String> gap) {
-    if (stringify_cb_.IsEmpty()) return Nan::Undefined();
+    assert(!stringify_cb_.IsEmpty() && "stringify_cb_ is empty");
 
     v8::Local<v8::Value> argv[] = {
       arg,

--- a/nan_json.h
+++ b/nan_json.h
@@ -9,13 +9,13 @@
 #ifndef NAN_JSON_H_
 #define NAN_JSON_H_
 
-#if ((NODE_MAJOR_VERSION == 0) && (NODE_MINOR_VERSION < 12))
+#if NODE_MAJOR_VERSION == 0 && NODE_MINOR_VERSION < 12
 #define NAN_JSON_H_NEED_PARSE 1
 #else
 #define NAN_JSON_H_NEED_PARSE 0
 #endif
 
-#if (NODE_MAJOR_VERSION >= 7)
+#if NODE_MAJOR_VERSION >= 7
 #define NAN_JSON_H_NEED_STRINGIFY 0
 #else
 #define NAN_JSON_H_NEED_STRINGIFY 1
@@ -24,7 +24,7 @@
 class JSON {
  public:
   JSON() {
-#if (NAN_JSON_H_NEED_PARSE + NAN_JSON_H_NEED_STRINGIFY)
+#if NAN_JSON_H_NEED_PARSE + NAN_JSON_H_NEED_STRINGIFY
     Nan::MaybeLocal<v8::Value> maybe_global_json = Nan::Get(
       Nan::GetCurrentContext()->Global(),
       Nan::New("JSON").ToLocalChecked()
@@ -82,7 +82,7 @@ class JSON {
 #if NAN_JSON_H_NEED_PARSE
     return scope.Escape(parse(json_string));
 #else
-#if (NODE_MAJOR_VERSION >= 7)
+#if NODE_MAJOR_VERSION >= 7
     Nan::MaybeLocal<v8::Value> result =
       v8::JSON::Parse(Nan::GetCurrentContext(), json_string);
 

--- a/nan_json.h
+++ b/nan_json.h
@@ -66,7 +66,7 @@ class JSON {
 
   static v8::Local<v8::Value> Call(const char *method,
     int argc, v8::Local<v8::Value> *argv) {
-    v8::MaybeLocal<v8::Value> maybeGlobalJSON =
+    Nan::MaybeLocal<v8::Value> maybeGlobalJSON =
       Nan::Get(
         Nan::GetCurrentContext()->Global(),
         Nan::New("JSON").ToLocalChecked()
@@ -85,7 +85,7 @@ class JSON {
     v8::Local<v8::Object> json =
       Nan::To<v8::Object>(globalJSON).ToLocalChecked();
 
-    v8::MaybeLocal<v8::Value> maybeThisMethod =
+    Nan::MaybeLocal<v8::Value> maybeThisMethod =
       Nan::Get(json, Nan::New(method).ToLocalChecked());
 
     if (maybeThisMethod.IsEmpty()) {

--- a/nan_json.h
+++ b/nan_json.h
@@ -25,6 +25,8 @@ class JSON {
  public:
   JSON() {
 #if NAN_JSON_H_NEED_PARSE + NAN_JSON_H_NEED_STRINGIFY
+    Nan::HandleScope scope;
+
     Nan::MaybeLocal<v8::Value> maybe_global_json = Nan::Get(
       Nan::GetCurrentContext()->Global(),
       Nan::New("JSON").ToLocalChecked()

--- a/nan_json.h
+++ b/nan_json.h
@@ -25,30 +25,30 @@ class JSON {
  public:
   JSON() {
 #if (NAN_JSON_H_NEED_PARSE + NAN_JSON_H_NEED_STRINGIFY)
-    Nan::MaybeLocal<v8::Value> maybeGlobalJSON = Nan::Get(
+    Nan::MaybeLocal<v8::Value> maybe_global_json = Nan::Get(
       Nan::GetCurrentContext()->Global(),
       Nan::New("JSON").ToLocalChecked()
     );
 
-    if (!maybeGlobalJSON.IsEmpty()) {
-      v8::Local<v8::Value> valGlobalJSON = maybeGlobalJSON.ToLocalChecked();
+    if (!maybe_global_json.IsEmpty()) {
+      v8::Local<v8::Value> val_global_json = maybe_global_json.ToLocalChecked();
 
-      if (valGlobalJSON->IsObject()) {
-        Nan::MaybeLocal<v8::Object> maybeObjGlobalJSON =
-          Nan::To<v8::Object>(valGlobalJSON);
+      if (val_global_json->IsObject()) {
+        Nan::MaybeLocal<v8::Object> maybe_obj_global_json =
+          Nan::To<v8::Object>(val_global_json);
 
-        if (!maybeObjGlobalJSON.IsEmpty()) {
-          v8::Local<v8::Object> globalJSON =
-            maybeObjGlobalJSON.ToLocalChecked();
+        if (!maybe_obj_global_json.IsEmpty()) {
+          v8::Local<v8::Object> global_json =
+            maybe_obj_global_json.ToLocalChecked();
 
 #if NAN_JSON_H_NEED_PARSE
-          Nan::MaybeLocal<v8::Value> maybeparse_method = Nan::Get(
-            globalJSON, Nan::New("parse").ToLocalChecked()
+          Nan::MaybeLocal<v8::Value> maybe_parse_method = Nan::Get(
+            global_json, Nan::New("parse").ToLocalChecked()
           );
 
-          if (!maybeparse_method.IsEmpty()) {
+          if (!maybe_parse_method.IsEmpty()) {
             v8::Local<v8::Value> parse_method =
-              maybeparse_method.ToLocalChecked();
+              maybe_parse_method.ToLocalChecked();
 
             if (parse_method->IsFunction()) {
               parse_cb_.Reset(parse_method.As<v8::Function>());
@@ -57,13 +57,13 @@ class JSON {
 #endif  // NAN_JSON_H_NEED_PARSE
 
 #if NAN_JSON_H_NEED_STRINGIFY
-          Nan::MaybeLocal<v8::Value> maybestringify_method = Nan::Get(
-            globalJSON, Nan::New("stringify").ToLocalChecked()
+          Nan::MaybeLocal<v8::Value> maybe_stringify_method = Nan::Get(
+            global_json, Nan::New("stringify").ToLocalChecked()
           );
 
-          if (!maybestringify_method.IsEmpty()) {
+          if (!maybe_stringify_method.IsEmpty()) {
             v8::Local<v8::Value> stringify_method =
-              maybestringify_method.ToLocalChecked();
+              maybe_stringify_method.ToLocalChecked();
 
             if (stringify_method->IsFunction()) {
               stringify_cb_.Reset(stringify_method.As<v8::Function>());

--- a/nan_json.h
+++ b/nan_json.h
@@ -82,8 +82,14 @@ class JSON {
       return Nan::Undefined();
     }
 
-    v8::Local<v8::Object> json =
-      Nan::To<v8::Object>(globalJSON).ToLocalChecked();
+    v8::MaybeLocal<v8::Object> maybeJson =
+      Nan::To<v8::Object>(globalJSON);
+
+    if (maybeJson.IsEmpty()) {
+      return Nan::Undefined();
+    }
+
+    v8::Local<v8::Object> json = maybeJson.ToLocalChecked();
 
     Nan::MaybeLocal<v8::Value> maybeThisMethod =
       Nan::Get(json, Nan::New(method).ToLocalChecked());

--- a/nan_json.h
+++ b/nan_json.h
@@ -66,11 +66,17 @@ class JSON {
 
   static v8::Local<v8::Value> Call(const char *method,
     int argc, v8::Local<v8::Value> *argv) {
-    v8::Local<v8::Value> globalJSON =
+    v8::MaybeLocal<v8::Value> maybeGlobalJSON =
       Nan::Get(
         Nan::GetCurrentContext()->Global(),
         Nan::New("JSON").ToLocalChecked()
-      ).ToLocalChecked();
+      );
+
+    if (maybeGlobalJSON.IsEmpty()) {
+      return Nan::Undefined();
+    }
+
+    v8::Local<v8::Value> globalJSON = maybeGlobalJSON.ToLocalChecked();
 
     if (!globalJSON->IsObject()) {
       return Nan::Undefined();
@@ -79,10 +85,16 @@ class JSON {
     v8::Local<v8::Object> json =
       Nan::To<v8::Object>(globalJSON).ToLocalChecked();
 
-    v8::Local<v8::Value> thisMethod =
-      Nan::Get(json, Nan::New(method).ToLocalChecked()).ToLocalChecked();
+    v8::MaybeLocal<v8::Value> maybeThisMethod =
+      Nan::Get(json, Nan::New(method).ToLocalChecked());
 
-    if (thisMethod.IsEmpty() || !thisMethod->IsFunction()) {
+    if (maybeThisMethod.IsEmpty()) {
+      return Nan::Undefined();
+    }
+
+    v8::Local<v8::Value> thisMethod = maybeThisMethod.ToLocalChecked();
+
+    if (!thisMethod->IsFunction()) {
       return Nan::Undefined();
     }
 

--- a/nan_json.h
+++ b/nan_json.h
@@ -93,14 +93,15 @@ class JSON {
 #if NAN_JSON_H_NEED_PARSE
     return scope.Escape(parse(jsonString));
 #else
-    Nan::MaybeLocal<v8::Value> result =
 #if (NODE_MAJOR_VERSION >= 7)
+    Nan::MaybeLocal<v8::Value> result =
       v8::JSON::Parse(Nan::GetCurrentContext(), jsonString);
-#else
-      v8::JSON::Parse(jsonString);
-#endif
+
     if (result.IsEmpty()) return v8::Local<v8::Value>();
     return scope.Escape(result.ToLocalChecked());
+#else
+    return scope.Escape(v8::JSON::Parse(jsonString));
+#endif
 #endif
   }
 

--- a/nan_json.h
+++ b/nan_json.h
@@ -42,32 +42,32 @@ class JSON {
             maybeObjGlobalJSON.ToLocalChecked();
 
 #if NAN_JSON_H_NEED_PARSE
-          Nan::MaybeLocal<v8::Value> maybeParseMethod = Nan::Get(
+          Nan::MaybeLocal<v8::Value> maybeparse_method = Nan::Get(
             globalJSON, Nan::New("parse").ToLocalChecked()
           );
 
-          if (!maybeParseMethod.IsEmpty()) {
-            v8::Local<v8::Value> parseMethod =
-              maybeParseMethod.ToLocalChecked();
+          if (!maybeparse_method.IsEmpty()) {
+            v8::Local<v8::Value> parse_method =
+              maybeparse_method.ToLocalChecked();
 
-            if (parseMethod->IsFunction()) {
-              parse_cb_.Reset(v8::Local<v8::Function>::Cast(parseMethod));
+            if (parse_method->IsFunction()) {
+              parse_cb_.Reset(v8::Local<v8::Function>::Cast(parse_method));
             }
           }
 #endif  // NAN_JSON_H_NEED_PARSE
 
 #if NAN_JSON_H_NEED_STRINGIFY
-          Nan::MaybeLocal<v8::Value> maybeStringifyMethod = Nan::Get(
+          Nan::MaybeLocal<v8::Value> maybestringify_method = Nan::Get(
             globalJSON, Nan::New("stringify").ToLocalChecked()
           );
 
-          if (!maybeStringifyMethod.IsEmpty()) {
-            v8::Local<v8::Value> stringifyMethod =
-              maybeStringifyMethod.ToLocalChecked();
+          if (!maybestringify_method.IsEmpty()) {
+            v8::Local<v8::Value> stringify_method =
+              maybestringify_method.ToLocalChecked();
 
-            if (stringifyMethod->IsFunction()) {
+            if (stringify_method->IsFunction()) {
               stringify_cb_.Reset(
-                v8::Local<v8::Function>::Cast(stringifyMethod)
+                v8::Local<v8::Function>::Cast(stringify_method)
               );
             }
           }

--- a/nan_json.h
+++ b/nan_json.h
@@ -89,38 +89,46 @@ class JSON {
 
   inline
   Nan::MaybeLocal<v8::Value> Parse(v8::Local<v8::String> jsonString) {
+    Nan::EscapableHandleScope scope;
 #if NAN_JSON_H_NEED_PARSE
-    Nan::HandleScope scope;
-    return parse(jsonString);
+    return scope.Escape(parse(jsonString));
 #else
+    Nan::MaybeLocal<v8::Value> result =
 #if (NODE_MAJOR_VERSION >= 7)
-    Nan::HandleScope scope;
-    return v8::JSON::Parse(Nan::GetCurrentContext(), jsonString);
+      v8::JSON::Parse(Nan::GetCurrentContext(), jsonString);
 #else
-    return v8::JSON::Parse(jsonString);
+      v8::JSON::Parse(jsonString);
 #endif
+    if (result.IsEmpty()) return v8::Local<v8::Value>();
+    return scope.Escape(result.ToLocalChecked());
 #endif
   }
 
   inline
   Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> jsonObject) {
-    Nan::HandleScope scope;
+    Nan::EscapableHandleScope scope;
+    Nan::MaybeLocal<v8::String> result =
 #if NAN_JSON_H_NEED_STRINGIFY
-    return Nan::To<v8::String>(stringify(jsonObject));
+      Nan::To<v8::String>(stringify(jsonObject));
 #else
-    return v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject);
+      v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject);
 #endif
+    if (result.IsEmpty()) return v8::Local<v8::String>();
+    return scope.Escape(result.ToLocalChecked());
   }
 
   inline
   Nan::MaybeLocal<v8::String> Stringify(v8::Local<v8::Object> jsonObject,
     v8::Local<v8::String> gap) {
-    Nan::HandleScope scope;
+    Nan::EscapableHandleScope scope;
+    Nan::MaybeLocal<v8::String> result =
 #if NAN_JSON_H_NEED_STRINGIFY
-    return Nan::To<v8::String>(stringify(jsonObject, gap));
+      Nan::To<v8::String>(stringify(jsonObject, gap));
 #else
-    return v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject, gap);
+      v8::JSON::Stringify(Nan::GetCurrentContext(), jsonObject, gap);
 #endif
+    if (result.IsEmpty()) return v8::Local<v8::String>();
+    return scope.Escape(result.ToLocalChecked());
   }
 
  private:

--- a/nan_json.h
+++ b/nan_json.h
@@ -25,11 +25,12 @@ class JSON {
  public:
   static inline
   Nan::MaybeLocal<v8::Value> Parse(v8::Local<v8::String> jsonString) {
-    Nan::HandleScope scope;
 #if NAN_JSON_H_NEED_PARSE
+    Nan::HandleScope scope;
     return parse(jsonString);
 #else
 #if (NODE_MAJOR_VERSION >= 7)
+    Nan::HandleScope scope;
     return v8::JSON::Parse(Nan::GetCurrentContext(), jsonString);
 #else
     return v8::JSON::Parse(jsonString);

--- a/nan_json.h
+++ b/nan_json.h
@@ -51,7 +51,7 @@ class JSON {
               maybeParseMethod.ToLocalChecked();
 
             if (parseMethod->IsFunction()) {
-              m_cb_parse.Reset(v8::Local<v8::Function>::Cast(parseMethod));
+              parse_cb_.Reset(v8::Local<v8::Function>::Cast(parseMethod));
             }
           }
 #endif
@@ -66,7 +66,7 @@ class JSON {
               maybeStringifyMethod.ToLocalChecked();
 
             if (stringifyMethod->IsFunction()) {
-              m_cb_stringify.Reset(
+              stringify_cb_.Reset(
                 v8::Local<v8::Function>::Cast(stringifyMethod)
               );
             }
@@ -80,10 +80,10 @@ class JSON {
 
   ~JSON() {
 #if NAN_JSON_H_NEED_PARSE
-    m_cb_parse.Reset();
+    parse_cb_.Reset();
 #endif
 #if NAN_JSON_H_NEED_STRINGIFY
-    m_cb_stringify.Reset();
+    stringify_cb_.Reset();
 #endif
   }
 
@@ -135,35 +135,35 @@ class JSON {
  private:
   NAN_DISALLOW_ASSIGN_COPY_MOVE(JSON)
 #if NAN_JSON_H_NEED_PARSE
-  Nan::Callback m_cb_parse;
+  Nan::Callback parse_cb_;
 #endif
 #if NAN_JSON_H_NEED_STRINGIFY
-  Nan::Callback m_cb_stringify;
+  Nan::Callback stringify_cb_;
 #endif
 
 #if NAN_JSON_H_NEED_PARSE
   inline v8::Local<v8::Value> parse(v8::Local<v8::Value> arg) {
-    if (m_cb_parse.IsEmpty()) return Nan::Undefined();
-    return m_cb_parse.Call(1, &arg);
+    if (parse_cb_.IsEmpty()) return Nan::Undefined();
+    return parse_cb_.Call(1, &arg);
   }
 #endif
 
 #if NAN_JSON_H_NEED_STRINGIFY
   inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg) {
-    if (m_cb_stringify.IsEmpty()) return Nan::Undefined();
-    return m_cb_stringify.Call(1, &arg);
+    if (stringify_cb_.IsEmpty()) return Nan::Undefined();
+    return stringify_cb_.Call(1, &arg);
   }
 
   inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg,
     v8::Local<v8::String> gap) {
-    if (m_cb_stringify.IsEmpty()) return Nan::Undefined();
+    if (stringify_cb_.IsEmpty()) return Nan::Undefined();
 
     v8::Local<v8::Value> argv[] = {
       arg,
       Nan::Null(),
       gap
     };
-    return m_cb_stringify.Call(3, argv);
+    return stringify_cb_.Call(3, argv);
   }
 #endif
 };

--- a/nan_json.h
+++ b/nan_json.h
@@ -9,17 +9,17 @@
 #ifndef NAN_JSON_H_
 #define NAN_JSON_H_
 
-#if NODE_MAJOR_VERSION == 0 && NODE_MINOR_VERSION < 12
+#if NODE_MODULE_VERSION < NODE_0_12_MODULE_VERSION
 #define NAN_JSON_H_NEED_PARSE 1
 #else
 #define NAN_JSON_H_NEED_PARSE 0
-#endif
+#endif  // NODE_MODULE_VERSION < NODE_0_12_MODULE_VERSION
 
-#if NODE_MAJOR_VERSION >= 7
+#if NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION
 #define NAN_JSON_H_NEED_STRINGIFY 0
 #else
 #define NAN_JSON_H_NEED_STRINGIFY 1
-#endif
+#endif  // NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION
 
 class JSON {
  public:
@@ -82,7 +82,7 @@ class JSON {
 #if NAN_JSON_H_NEED_PARSE
     return scope.Escape(parse(json_string));
 #else
-#if NODE_MAJOR_VERSION >= 7
+#if NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION
     Nan::MaybeLocal<v8::Value> result =
       v8::JSON::Parse(Nan::GetCurrentContext(), json_string);
 
@@ -90,7 +90,7 @@ class JSON {
     return scope.Escape(result.ToLocalChecked());
 #else
     return scope.Escape(v8::JSON::Parse(json_string));
-#endif  // NODE_MAJOR_VERSION >= 7
+#endif  // NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION
 #endif  // NAN_JSON_H_NEED_PARSE
   }
 

--- a/nan_json.h
+++ b/nan_json.h
@@ -75,7 +75,8 @@ class JSON {
       return Nan::Undefined();
     }
 
-    v8::Local<v8::Object> json = globalJSON->ToObject();
+    v8::Local<v8::Object> json =
+      Nan::To<v8::Object>(globalJSON).ToLocalChecked();
 
     v8::Local<v8::Value> thisMethod =
       Nan::Get(json, Nan::New(method).ToLocalChecked()).ToLocalChecked();

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "Nathan Rajlich <nathan@tootallnate.net> (https://github.com/TooTallNate)",
     "Brett Lawson <brett19@gmail.com> (https://github.com/brett19)",
     "Ben Noordhuis <info@bnoordhuis.nl> (https://github.com/bnoordhuis)",
-    "David Siegel <david@artcom.de> (https://github.com/agnat)"
+    "David Siegel <david@artcom.de> (https://github.com/agnat)",
+    "Michael Ira Krufky <mkrufky@gmail.com> (https://github.com/mkrufky)"
   ],
   "devDependencies": {
     "bindings": "~1.2.1",

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -156,4 +156,12 @@
         "target_name" : "private"
       , "sources"     : [ "cpp/private.cpp" ]
     }
+    , {
+        "target_name" : "parse"
+      , "sources"     : [ "cpp/json-parse.cpp" ]
+    }
+    , {
+        "target_name" : "stringify"
+      , "sources"     : [ "cpp/json-stringify.cpp" ]
+    }
 ]}

--- a/test/cpp/json-parse.cpp
+++ b/test/cpp/json-parse.cpp
@@ -10,7 +10,7 @@
 
 NAN_METHOD(Parse) {
   info.GetReturnValue().Set(
-    Nan::JSON::Parse(
+    (new Nan::JSON)->Parse(
       Nan::To<v8::String>(info[0]).ToLocalChecked()
     ).ToLocalChecked()
   );

--- a/test/cpp/json-parse.cpp
+++ b/test/cpp/json-parse.cpp
@@ -13,16 +13,12 @@ NAN_METHOD(Parse) {
 
   Nan::MaybeLocal<v8::String> inp = Nan::To<v8::String>(info[0]);
 
-  if (inp.IsEmpty()) {
-    info.GetReturnValue().SetUndefined();
-  } else {
+  if (!inp.IsEmpty()) {
     Nan::MaybeLocal<v8::Value> result = NanJSON.Parse(
       inp.ToLocalChecked()
     );
 
-    if (result.IsEmpty()) {
-      info.GetReturnValue().SetUndefined();
-    } else {
+    if (!result.IsEmpty()) {
       info.GetReturnValue().Set(result.ToLocalChecked());
     }
   }

--- a/test/cpp/json-parse.cpp
+++ b/test/cpp/json-parse.cpp
@@ -10,7 +10,9 @@
 
 NAN_METHOD(Parse) {
   info.GetReturnValue().Set(
-    Nan::JSON::Parse(info[0]->ToString()).ToLocalChecked()
+    Nan::JSON::Parse(
+      Nan::To<v8::String>(info[0]).ToLocalChecked()
+    ).ToLocalChecked()
   );
 }
 

--- a/test/cpp/json-parse.cpp
+++ b/test/cpp/json-parse.cpp
@@ -14,14 +14,14 @@ NAN_METHOD(Parse) {
   Nan::MaybeLocal<v8::String> inp = Nan::To<v8::String>(info[0]);
 
   if (inp.IsEmpty()) {
-    info.GetReturnValue().Set(Nan::Undefined());
+    info.GetReturnValue().SetUndefined();
   } else {
     Nan::MaybeLocal<v8::Value> result = NanJSON.Parse(
       inp.ToLocalChecked()
     );
 
     if (result.IsEmpty()) {
-      info.GetReturnValue().Set(Nan::Undefined());
+      info.GetReturnValue().SetUndefined();
     } else {
       info.GetReturnValue().Set(result.ToLocalChecked());
     }

--- a/test/cpp/json-parse.cpp
+++ b/test/cpp/json-parse.cpp
@@ -1,0 +1,24 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2017 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#include <nan.h>
+
+NAN_METHOD(Parse) {
+  info.GetReturnValue().Set(
+    Nan::JSON::Parse(info[0]->ToString()).ToLocalChecked()
+  );
+}
+
+NAN_MODULE_INIT(Init) {
+  Nan::Set(target
+    , Nan::New<v8::String>("parse").ToLocalChecked()
+    , Nan::New<v8::FunctionTemplate>(Parse)->GetFunction()
+  );
+}
+
+NODE_MODULE(parse, Init)

--- a/test/cpp/json-parse.cpp
+++ b/test/cpp/json-parse.cpp
@@ -9,8 +9,9 @@
 #include <nan.h>
 
 NAN_METHOD(Parse) {
+  Nan::JSON NanJSON;
   info.GetReturnValue().Set(
-    (new Nan::JSON)->Parse(
+    NanJSON.Parse(
       Nan::To<v8::String>(info[0]).ToLocalChecked()
     ).ToLocalChecked()
   );

--- a/test/cpp/json-parse.cpp
+++ b/test/cpp/json-parse.cpp
@@ -14,14 +14,14 @@ NAN_METHOD(Parse) {
   Nan::MaybeLocal<v8::String> inp = Nan::To<v8::String>(info[0]);
 
   if (inp.IsEmpty()) {
-    info.GetReturnValue().Set(v8::Local<v8::Value>());
+    info.GetReturnValue().Set(Nan::Undefined());
   } else {
     Nan::MaybeLocal<v8::Value> result = NanJSON.Parse(
       inp.ToLocalChecked()
     );
 
     if (result.IsEmpty()) {
-      info.GetReturnValue().Set(v8::Local<v8::Value>());
+      info.GetReturnValue().Set(Nan::Undefined());
     } else {
       info.GetReturnValue().Set(result.ToLocalChecked());
     }

--- a/test/cpp/json-parse.cpp
+++ b/test/cpp/json-parse.cpp
@@ -10,11 +10,22 @@
 
 NAN_METHOD(Parse) {
   Nan::JSON NanJSON;
-  info.GetReturnValue().Set(
-    NanJSON.Parse(
-      Nan::To<v8::String>(info[0]).ToLocalChecked()
-    ).ToLocalChecked()
-  );
+
+  Nan::MaybeLocal<v8::String> inp = Nan::To<v8::String>(info[0]);
+
+  if (inp.IsEmpty()) {
+    info.GetReturnValue().Set(v8::Local<v8::Value>());
+  } else {
+    Nan::MaybeLocal<v8::Value> result = NanJSON.Parse(
+      inp.ToLocalChecked()
+    );
+
+    if (result.IsEmpty()) {
+      info.GetReturnValue().Set(v8::Local<v8::Value>());
+    } else {
+      info.GetReturnValue().Set(result.ToLocalChecked());
+    }
+  }
 }
 
 NAN_MODULE_INIT(Init) {

--- a/test/cpp/json-stringify.cpp
+++ b/test/cpp/json-stringify.cpp
@@ -18,22 +18,29 @@ NAN_METHOD(Stringify) {
       v8::Local<v8::String> gap =
         Nan::New<v8::String>(std::string(len, ' ')).ToLocalChecked();
       info.GetReturnValue().Set(
-        Nan::JSON::Stringify(info[0]->ToObject(), gap).ToLocalChecked()
+        Nan::JSON::Stringify(
+          Nan::To<v8::Object>(info[0]).ToLocalChecked(), gap
+        ).ToLocalChecked()
       );
     } else if (info[2]->IsString()) {
       info.GetReturnValue().Set(
-        Nan::JSON::Stringify(info[0]->ToObject(),
+        Nan::JSON::Stringify(
+          Nan::To<v8::Object>(info[0]).ToLocalChecked(),
           Nan::To<v8::String>(info[2]).ToLocalChecked()
         ).ToLocalChecked()
       );
     } else {
       info.GetReturnValue().Set(
-        Nan::JSON::Stringify(info[0]->ToObject()).ToLocalChecked()
+        Nan::JSON::Stringify(
+          Nan::To<v8::Object>(info[0]).ToLocalChecked()
+        ).ToLocalChecked()
       );
     }
   } else {
     info.GetReturnValue().Set(
-      Nan::JSON::Stringify(info[0]->ToObject()).ToLocalChecked()
+      Nan::JSON::Stringify(
+        Nan::To<v8::Object>(info[0]).ToLocalChecked()
+      ).ToLocalChecked()
     );
   }
 }

--- a/test/cpp/json-stringify.cpp
+++ b/test/cpp/json-stringify.cpp
@@ -10,6 +10,8 @@
 #include <string>
 
 NAN_METHOD(Stringify) {
+  Nan::JSON NanJSON;
+
   if (3 == info.Length()) {
     if (info[2]->IsNumber()) {
       int len = info[2]->IntegerValue();
@@ -18,27 +20,27 @@ NAN_METHOD(Stringify) {
       v8::Local<v8::String> gap =
         Nan::New<v8::String>(std::string(len, ' ')).ToLocalChecked();
       info.GetReturnValue().Set(
-        Nan::JSON::Stringify(
+        NanJSON.Stringify(
           Nan::To<v8::Object>(info[0]).ToLocalChecked(), gap
         ).ToLocalChecked()
       );
     } else if (info[2]->IsString()) {
       info.GetReturnValue().Set(
-        Nan::JSON::Stringify(
+        NanJSON.Stringify(
           Nan::To<v8::Object>(info[0]).ToLocalChecked(),
           Nan::To<v8::String>(info[2]).ToLocalChecked()
         ).ToLocalChecked()
       );
     } else {
       info.GetReturnValue().Set(
-        Nan::JSON::Stringify(
+        NanJSON.Stringify(
           Nan::To<v8::Object>(info[0]).ToLocalChecked()
         ).ToLocalChecked()
       );
     }
   } else {
     info.GetReturnValue().Set(
-      Nan::JSON::Stringify(
+      NanJSON.Stringify(
         Nan::To<v8::Object>(info[0]).ToLocalChecked()
       ).ToLocalChecked()
     );

--- a/test/cpp/json-stringify.cpp
+++ b/test/cpp/json-stringify.cpp
@@ -25,16 +25,22 @@ NAN_METHOD(Stringify) {
           int len = info[2]->IntegerValue();
           len = (len > 10) ? 10 : len;
           len = (len < 0) ? 0 : len;
-          v8::Local<v8::String> gap =
-            Nan::New<v8::String>(std::string(len, ' ')).ToLocalChecked();
+          v8::MaybeLocal<v8::String> maybe_gap =
+            Nan::New<v8::String>(std::string(len, ' '));
 
-          Nan::MaybeLocal<v8::String> result =
-            NanJSON.Stringify(obj, gap);
-
-          if (result.IsEmpty()) {
+          if (maybe_gap.IsEmpty()) {
             info.GetReturnValue().Set(Nan::Undefined());
           } else {
-            info.GetReturnValue().Set(result.ToLocalChecked());
+            v8::Local<v8::String> gap = maybe_gap.ToLocalChecked();
+
+            Nan::MaybeLocal<v8::String> result =
+              NanJSON.Stringify(obj, gap);
+
+            if (result.IsEmpty()) {
+              info.GetReturnValue().Set(Nan::Undefined());
+            } else {
+              info.GetReturnValue().Set(result.ToLocalChecked());
+            }
           }
         } else if (info[2]->IsString()) {
           Nan::MaybeLocal<v8::String> result = NanJSON.Stringify(

--- a/test/cpp/json-stringify.cpp
+++ b/test/cpp/json-stringify.cpp
@@ -1,0 +1,47 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2017 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#include <nan.h>
+#include <string>
+
+NAN_METHOD(Stringify) {
+  if (3 == info.Length()) {
+    if (info[2]->IsNumber()) {
+      int len = info[2]->IntegerValue();
+      len = (len > 10) ? 10 : len;
+      len = (len < 0) ? 0 : len;
+      v8::Local<v8::String> gap =
+        Nan::New<v8::String>(std::string(len, ' ')).ToLocalChecked();
+      info.GetReturnValue().Set(
+        Nan::JSON::Stringify(info[0]->ToObject(), gap).ToLocalChecked()
+      );
+    } else if (info[2]->IsString()) {
+      info.GetReturnValue().Set(
+        Nan::JSON::Stringify(info[0]->ToObject(),
+          info[2]->ToString()).ToLocalChecked()
+      );
+    } else {
+      info.GetReturnValue().Set(
+        Nan::JSON::Stringify(info[0]->ToObject()).ToLocalChecked()
+      );
+    }
+  } else {
+    info.GetReturnValue().Set(
+      Nan::JSON::Stringify(info[0]->ToObject()).ToLocalChecked()
+    );
+  }
+}
+
+NAN_MODULE_INIT(Init) {
+  Nan::Set(target
+    , Nan::New<v8::String>("stringify").ToLocalChecked()
+    , Nan::New<v8::FunctionTemplate>(Stringify)->GetFunction()
+  );
+}
+
+NODE_MODULE(stringify, Init)

--- a/test/cpp/json-stringify.cpp
+++ b/test/cpp/json-stringify.cpp
@@ -25,7 +25,7 @@ NAN_METHOD(Stringify) {
           int len = info[2]->IntegerValue();
           len = (len > 10) ? 10 : len;
           len = (len < 0) ? 0 : len;
-          v8::MaybeLocal<v8::String> maybe_gap =
+          Nan::MaybeLocal<v8::String> maybe_gap =
             Nan::New<v8::String>(std::string(len, ' '));
 
           if (maybe_gap.IsEmpty()) {

--- a/test/cpp/json-stringify.cpp
+++ b/test/cpp/json-stringify.cpp
@@ -23,7 +23,8 @@ NAN_METHOD(Stringify) {
     } else if (info[2]->IsString()) {
       info.GetReturnValue().Set(
         Nan::JSON::Stringify(info[0]->ToObject(),
-          info[2]->ToString()).ToLocalChecked()
+          Nan::To<v8::String>(info[2]).ToLocalChecked()
+        ).ToLocalChecked()
       );
     } else {
       info.GetReturnValue().Set(

--- a/test/cpp/json-stringify.cpp
+++ b/test/cpp/json-stringify.cpp
@@ -10,40 +10,44 @@
 #include <string>
 
 NAN_METHOD(Stringify) {
-  Nan::JSON NanJSON;
-
-  if (3 == info.Length()) {
-    if (info[2]->IsNumber()) {
-      int len = info[2]->IntegerValue();
-      len = (len > 10) ? 10 : len;
-      len = (len < 0) ? 0 : len;
-      v8::Local<v8::String> gap =
-        Nan::New<v8::String>(std::string(len, ' ')).ToLocalChecked();
-      info.GetReturnValue().Set(
-        NanJSON.Stringify(
-          Nan::To<v8::Object>(info[0]).ToLocalChecked(), gap
-        ).ToLocalChecked()
-      );
-    } else if (info[2]->IsString()) {
-      info.GetReturnValue().Set(
-        NanJSON.Stringify(
-          Nan::To<v8::Object>(info[0]).ToLocalChecked(),
-          Nan::To<v8::String>(info[2]).ToLocalChecked()
-        ).ToLocalChecked()
-      );
-    } else {
-      info.GetReturnValue().Set(
-        NanJSON.Stringify(
-          Nan::To<v8::Object>(info[0]).ToLocalChecked()
-        ).ToLocalChecked()
-      );
-    }
+  if (0 == info.Length()) {
+    info.GetReturnValue().Set(v8::Local<v8::Value>());
   } else {
-    info.GetReturnValue().Set(
-      NanJSON.Stringify(
-        Nan::To<v8::Object>(info[0]).ToLocalChecked()
-      ).ToLocalChecked()
-    );
+    Nan::MaybeLocal<v8::Object> maybe_obj = Nan::To<v8::Object>(info[0]);
+    if (maybe_obj.IsEmpty()) {
+      info.GetReturnValue().Set(v8::Local<v8::Value>());
+    } else {
+      Nan::JSON NanJSON;
+      v8::Local<v8::Object> obj = maybe_obj.ToLocalChecked();
+
+      if (3 == info.Length()) {
+        if (info[2]->IsNumber()) {
+          int len = info[2]->IntegerValue();
+          len = (len > 10) ? 10 : len;
+          len = (len < 0) ? 0 : len;
+          v8::Local<v8::String> gap =
+            Nan::New<v8::String>(std::string(len, ' ')).ToLocalChecked();
+          info.GetReturnValue().Set(
+            NanJSON.Stringify(obj, gap).ToLocalChecked()
+          );
+        } else if (info[2]->IsString()) {
+          info.GetReturnValue().Set(
+            NanJSON.Stringify(
+              obj,
+              Nan::To<v8::String>(info[2]).ToLocalChecked()
+            ).ToLocalChecked()
+          );
+        } else {
+          info.GetReturnValue().Set(
+            NanJSON.Stringify(obj).ToLocalChecked()
+          );
+        }
+      } else {
+        info.GetReturnValue().Set(
+          NanJSON.Stringify(obj).ToLocalChecked()
+        );
+      }
+    }
   }
 }
 

--- a/test/cpp/json-stringify.cpp
+++ b/test/cpp/json-stringify.cpp
@@ -27,25 +27,43 @@ NAN_METHOD(Stringify) {
           len = (len < 0) ? 0 : len;
           v8::Local<v8::String> gap =
             Nan::New<v8::String>(std::string(len, ' ')).ToLocalChecked();
-          info.GetReturnValue().Set(
-            NanJSON.Stringify(obj, gap).ToLocalChecked()
-          );
+
+          Nan::MaybeLocal<v8::String> result =
+            NanJSON.Stringify(obj, gap);
+
+          if (result.IsEmpty()) {
+            info.GetReturnValue().Set(v8::Local<v8::String>());
+          } else {
+            info.GetReturnValue().Set(result.ToLocalChecked());
+          }
         } else if (info[2]->IsString()) {
-          info.GetReturnValue().Set(
-            NanJSON.Stringify(
-              obj,
-              Nan::To<v8::String>(info[2]).ToLocalChecked()
-            ).ToLocalChecked()
+          Nan::MaybeLocal<v8::String> result = NanJSON.Stringify(
+            obj,
+            Nan::To<v8::String>(info[2]).ToLocalChecked()
           );
+
+          if (result.IsEmpty()) {
+            info.GetReturnValue().Set(v8::Local<v8::String>());
+          } else {
+            info.GetReturnValue().Set(result.ToLocalChecked());
+          }
         } else {
-          info.GetReturnValue().Set(
-            NanJSON.Stringify(obj).ToLocalChecked()
-          );
+          Nan::MaybeLocal<v8::String> result = NanJSON.Stringify(obj);
+
+          if (result.IsEmpty()) {
+            info.GetReturnValue().Set(v8::Local<v8::String>());
+          } else {
+            info.GetReturnValue().Set(result.ToLocalChecked());
+          }
         }
       } else {
-        info.GetReturnValue().Set(
-          NanJSON.Stringify(obj).ToLocalChecked()
-        );
+        Nan::MaybeLocal<v8::String> result = NanJSON.Stringify(obj);
+
+        if (result.IsEmpty()) {
+          info.GetReturnValue().Set(v8::Local<v8::String>());
+        } else {
+          info.GetReturnValue().Set(result.ToLocalChecked());
+        }
       }
     }
   }

--- a/test/cpp/json-stringify.cpp
+++ b/test/cpp/json-stringify.cpp
@@ -10,13 +10,9 @@
 #include <string>
 
 NAN_METHOD(Stringify) {
-  if (0 == info.Length()) {
-    info.GetReturnValue().SetUndefined();
-  } else {
+  if (info.Length() > 0) {
     Nan::MaybeLocal<v8::Object> maybe_obj = Nan::To<v8::Object>(info[0]);
-    if (maybe_obj.IsEmpty()) {
-      info.GetReturnValue().SetUndefined();
-    } else {
+    if (!maybe_obj.IsEmpty()) {
       Nan::JSON NanJSON;
       v8::Local<v8::Object> obj = maybe_obj.ToLocalChecked();
 
@@ -28,17 +24,13 @@ NAN_METHOD(Stringify) {
           Nan::MaybeLocal<v8::String> maybe_gap =
             Nan::New<v8::String>(std::string(len, ' '));
 
-          if (maybe_gap.IsEmpty()) {
-            info.GetReturnValue().SetUndefined();
-          } else {
+          if (!maybe_gap.IsEmpty()) {
             v8::Local<v8::String> gap = maybe_gap.ToLocalChecked();
 
             Nan::MaybeLocal<v8::String> result =
               NanJSON.Stringify(obj, gap);
 
-            if (result.IsEmpty()) {
-              info.GetReturnValue().SetUndefined();
-            } else {
+            if (!result.IsEmpty()) {
               info.GetReturnValue().Set(result.ToLocalChecked());
             }
           }
@@ -48,26 +40,20 @@ NAN_METHOD(Stringify) {
             Nan::To<v8::String>(info[2]).ToLocalChecked()
           );
 
-          if (result.IsEmpty()) {
-            info.GetReturnValue().SetUndefined();
-          } else {
+          if (!result.IsEmpty()) {
             info.GetReturnValue().Set(result.ToLocalChecked());
           }
         } else {
           Nan::MaybeLocal<v8::String> result = NanJSON.Stringify(obj);
 
-          if (result.IsEmpty()) {
-            info.GetReturnValue().SetUndefined();
-          } else {
+          if (!result.IsEmpty()) {
             info.GetReturnValue().Set(result.ToLocalChecked());
           }
         }
       } else {
         Nan::MaybeLocal<v8::String> result = NanJSON.Stringify(obj);
 
-        if (result.IsEmpty()) {
-          info.GetReturnValue().SetUndefined();
-        } else {
+        if (!result.IsEmpty()) {
           info.GetReturnValue().Set(result.ToLocalChecked());
         }
       }

--- a/test/cpp/json-stringify.cpp
+++ b/test/cpp/json-stringify.cpp
@@ -11,11 +11,11 @@
 
 NAN_METHOD(Stringify) {
   if (0 == info.Length()) {
-    info.GetReturnValue().Set(v8::Local<v8::Value>());
+    info.GetReturnValue().Set(Nan::Undefined());
   } else {
     Nan::MaybeLocal<v8::Object> maybe_obj = Nan::To<v8::Object>(info[0]);
     if (maybe_obj.IsEmpty()) {
-      info.GetReturnValue().Set(v8::Local<v8::Value>());
+      info.GetReturnValue().Set(Nan::Undefined());
     } else {
       Nan::JSON NanJSON;
       v8::Local<v8::Object> obj = maybe_obj.ToLocalChecked();
@@ -32,7 +32,7 @@ NAN_METHOD(Stringify) {
             NanJSON.Stringify(obj, gap);
 
           if (result.IsEmpty()) {
-            info.GetReturnValue().Set(v8::Local<v8::String>());
+            info.GetReturnValue().Set(Nan::Undefined());
           } else {
             info.GetReturnValue().Set(result.ToLocalChecked());
           }
@@ -43,7 +43,7 @@ NAN_METHOD(Stringify) {
           );
 
           if (result.IsEmpty()) {
-            info.GetReturnValue().Set(v8::Local<v8::String>());
+            info.GetReturnValue().Set(Nan::Undefined());
           } else {
             info.GetReturnValue().Set(result.ToLocalChecked());
           }
@@ -51,7 +51,7 @@ NAN_METHOD(Stringify) {
           Nan::MaybeLocal<v8::String> result = NanJSON.Stringify(obj);
 
           if (result.IsEmpty()) {
-            info.GetReturnValue().Set(v8::Local<v8::String>());
+            info.GetReturnValue().Set(Nan::Undefined());
           } else {
             info.GetReturnValue().Set(result.ToLocalChecked());
           }
@@ -60,7 +60,7 @@ NAN_METHOD(Stringify) {
         Nan::MaybeLocal<v8::String> result = NanJSON.Stringify(obj);
 
         if (result.IsEmpty()) {
-          info.GetReturnValue().Set(v8::Local<v8::String>());
+          info.GetReturnValue().Set(Nan::Undefined());
         } else {
           info.GetReturnValue().Set(result.ToLocalChecked());
         }

--- a/test/cpp/json-stringify.cpp
+++ b/test/cpp/json-stringify.cpp
@@ -11,11 +11,11 @@
 
 NAN_METHOD(Stringify) {
   if (0 == info.Length()) {
-    info.GetReturnValue().Set(Nan::Undefined());
+    info.GetReturnValue().SetUndefined();
   } else {
     Nan::MaybeLocal<v8::Object> maybe_obj = Nan::To<v8::Object>(info[0]);
     if (maybe_obj.IsEmpty()) {
-      info.GetReturnValue().Set(Nan::Undefined());
+      info.GetReturnValue().SetUndefined();
     } else {
       Nan::JSON NanJSON;
       v8::Local<v8::Object> obj = maybe_obj.ToLocalChecked();
@@ -29,7 +29,7 @@ NAN_METHOD(Stringify) {
             Nan::New<v8::String>(std::string(len, ' '));
 
           if (maybe_gap.IsEmpty()) {
-            info.GetReturnValue().Set(Nan::Undefined());
+            info.GetReturnValue().SetUndefined();
           } else {
             v8::Local<v8::String> gap = maybe_gap.ToLocalChecked();
 
@@ -37,7 +37,7 @@ NAN_METHOD(Stringify) {
               NanJSON.Stringify(obj, gap);
 
             if (result.IsEmpty()) {
-              info.GetReturnValue().Set(Nan::Undefined());
+              info.GetReturnValue().SetUndefined();
             } else {
               info.GetReturnValue().Set(result.ToLocalChecked());
             }
@@ -49,7 +49,7 @@ NAN_METHOD(Stringify) {
           );
 
           if (result.IsEmpty()) {
-            info.GetReturnValue().Set(Nan::Undefined());
+            info.GetReturnValue().SetUndefined();
           } else {
             info.GetReturnValue().Set(result.ToLocalChecked());
           }
@@ -57,7 +57,7 @@ NAN_METHOD(Stringify) {
           Nan::MaybeLocal<v8::String> result = NanJSON.Stringify(obj);
 
           if (result.IsEmpty()) {
-            info.GetReturnValue().Set(Nan::Undefined());
+            info.GetReturnValue().SetUndefined();
           } else {
             info.GetReturnValue().Set(result.ToLocalChecked());
           }
@@ -66,7 +66,7 @@ NAN_METHOD(Stringify) {
         Nan::MaybeLocal<v8::String> result = NanJSON.Stringify(obj);
 
         if (result.IsEmpty()) {
-          info.GetReturnValue().Set(Nan::Undefined());
+          info.GetReturnValue().SetUndefined();
         } else {
           info.GetReturnValue().Set(result.ToLocalChecked());
         }

--- a/test/js/json-parse-test.js
+++ b/test/js/json-parse-test.js
@@ -1,0 +1,12 @@
+const test     = require('tap').test
+    , testRoot = require('path').resolve(__dirname, '..')
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'parse' });
+
+test('parse', function (t) {
+  t.plan(2);
+  t.type(bindings.parse, 'function');
+  t.deepEqual(
+    bindings.parse('{ "a": "JSON", "string": "value" }'),
+    JSON.parse('{ "a": "JSON", "string": "value" }')
+  );
+});

--- a/test/js/json-parse-test.js
+++ b/test/js/json-parse-test.js
@@ -3,10 +3,34 @@ const test     = require('tap').test
     , bindings = require('bindings')({ module_root: testRoot, bindings: 'parse' });
 
 test('parse', function (t) {
-  t.plan(2);
+  t.plan(8);
   t.type(bindings.parse, 'function');
   t.deepEqual(
     bindings.parse('{ "a": "JSON", "string": "value" }'),
     JSON.parse('{ "a": "JSON", "string": "value" }')
+  );
+  t.deepEqual(
+    bindings.parse('[1, 2, 3]'),
+    JSON.parse('[1, 2, 3]')
+  );
+  t.equal(
+    bindings.parse('57'),
+    JSON.parse('57')
+  );
+  t.equal(
+    bindings.parse('3.14159'),
+    JSON.parse('3.14159')
+  );
+  t.equal(
+    bindings.parse('true'),
+    JSON.parse('true')
+  );
+  t.equal(
+    bindings.parse('false'),
+    JSON.parse('false')
+  );
+  t.equal(
+    bindings.parse('"some string"'),
+    JSON.parse('"some string"')
   );
 });

--- a/test/js/json-parse-test.js
+++ b/test/js/json-parse-test.js
@@ -10,8 +10,8 @@ test('parse', function (t) {
     JSON.parse('{ "a": "JSON", "string": "value" }')
   );
   t.deepEqual(
-    bindings.parse('[1, 2, 3]'),
-    JSON.parse('[1, 2, 3]')
+    bindings.parse('[ 1, 2, 3 ]'),
+    JSON.parse('[ 1, 2, 3 ]')
   );
   t.equal(
     bindings.parse('57'),

--- a/test/js/json-stringify-test.js
+++ b/test/js/json-stringify-test.js
@@ -3,7 +3,7 @@ const test     = require('tap').test
     , bindings = require('bindings')({ module_root: testRoot, bindings: 'stringify' });
 
 test('stringify', function (t) {
-  t.plan(4);
+  t.plan(22);
   t.type(bindings.stringify, 'function');
   t.equal(
     bindings.stringify({ "a": "JSON", "object": "value" }),
@@ -16,5 +16,77 @@ test('stringify', function (t) {
   t.equal(
     bindings.stringify({ "a": "JSON", "object": "value" }, null, '++'),
     JSON.stringify({ "a": "JSON", "object": "value" }, null, '++')
+  );
+  t.equal(
+    bindings.stringify([ 1, 2, 3 ]),
+    JSON.stringify([ 1, 2, 3 ])
+  );
+  t.equal(
+    bindings.stringify([ 1, 2, 3 ], null, 2),
+    JSON.stringify([ 1, 2, 3 ], null, 2)
+  );
+  t.equal(
+    bindings.stringify([ 1, 2, 3 ], null, '++'),
+    JSON.stringify([ 1, 2, 3 ], null, '++')
+  );
+  t.equal(
+    bindings.stringify("a string"),
+    JSON.stringify("a string")
+  );
+  t.equal(
+    bindings.stringify("a string", null, 2),
+    JSON.stringify("a string", null, 2)
+  );
+  t.equal(
+    bindings.stringify("a string", null, '++'),
+    JSON.stringify("a string", null, '++')
+  );
+  t.equal(
+    bindings.stringify(3.14159),
+    JSON.stringify(3.14159)
+  );
+  t.equal(
+    bindings.stringify(3.14159, null, 2),
+    JSON.stringify(3.14159, null, 2)
+  );
+  t.equal(
+    bindings.stringify(3.14159, null, '++'),
+    JSON.stringify(3.14159, null, '++')
+  );
+  t.equal(
+    bindings.stringify(-31),
+    JSON.stringify(-31)
+  );
+  t.equal(
+    bindings.stringify(-31, null, 2),
+    JSON.stringify(-31, null, 2)
+  );
+  t.equal(
+    bindings.stringify(-31, null, '++'),
+    JSON.stringify(-31, null, '++')
+  );
+  t.equal(
+    bindings.stringify(true),
+    JSON.stringify(true)
+  );
+  t.equal(
+    bindings.stringify(true, null, 2),
+    JSON.stringify(true, null, 2)
+  );
+  t.equal(
+    bindings.stringify(true, null, '++'),
+    JSON.stringify(true, null, '++')
+  );
+  t.equal(
+    bindings.stringify(false),
+    JSON.stringify(false)
+  );
+  t.equal(
+    bindings.stringify(false, null, 2),
+    JSON.stringify(false, null, 2)
+  );
+  t.equal(
+    bindings.stringify(false, null, '++'),
+    JSON.stringify(false, null, '++')
   );
 });

--- a/test/js/json-stringify-test.js
+++ b/test/js/json-stringify-test.js
@@ -1,0 +1,20 @@
+const test     = require('tap').test
+    , testRoot = require('path').resolve(__dirname, '..')
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'stringify' });
+
+test('stringify', function (t) {
+  t.plan(4);
+  t.type(bindings.stringify, 'function');
+  t.equal(
+    bindings.stringify({ "a": "JSON", "object": "value" }),
+    JSON.stringify({ "a": "JSON", "object": "value" })
+  );
+  t.equal(
+    bindings.stringify({ "a": "JSON", "object": "value" }, null, 2),
+    JSON.stringify({ "a": "JSON", "object": "value" }, null, 2)
+  );
+  t.equal(
+    bindings.stringify({ "a": "JSON", "object": "value" }, null, '++'),
+    JSON.stringify({ "a": "JSON", "object": "value" }, null, '++')
+  );
+});


### PR DESCRIPTION
As the V8 API for the `JSON` object has changed over the versions of V8 used in node, it makes good sense to add a helper for it, especially now that the `Stringify` method has been made available in node 7.

`v8::JSON` has two methods, `Parse` and `Stringify` ...  For a link to the v8 docs used in node 7, see [v8::JSON Class Reference](https://v8docs.nodesource.com/node-7.4/da/d6f/classv8_1_1_j_s_o_n.html)

As for the changes in `v8::JSON` in the versions of node supported by _NAN_:

`v8::JSON::Parse` was first available in node version 0.12.x - it is *not* otherwise available in versions 0.8 or 0.10.x
`v8::JSON::Stringify` was first available in node version 7 - it is *not* otherwise available in earlier versions

closes https://github.com/nodejs/nan/issues/650