### PR TITLE
Makefile: remove repeated cpp files in LINT_SOURCES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ LINT_SOURCES = \
 	test/cpp/error.cpp \
 	test/cpp/gc.cpp \
 	test/cpp/indexedinterceptors.cpp \
-	test/cpp/isolatedata.cpp \
-	test/cpp/makecallback.cpp \
-	test/cpp/morenews.cpp \
 	test/cpp/converters.cpp \
 	test/cpp/isolatedata.cpp \
 	test/cpp/makecallback.cpp \


### PR DESCRIPTION
remove repeated cpp source files in LINT_SOURCES:

* isolatedata.cpp
* makecallback.cpp
* morenews.cpp

closes https://github.com/nodejs/nan/issues/654