### PR TITLE
CHANGELOG.md: fix typo in version stamp for 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **Version 2.6.1: current Node 7.8.0, Node 12: 0.12.18, Node 10: 0.10.48, iojs: 3.3.1**
 
-### 2.6.0 Apr 6 2017
+### 2.6.1 Apr 6 2017
 
   - Bugfix: nan_json.h: fix build breakage in Node 6 ac8d47dc3c10bfbf3f15a6b951633120c0ee6d51
 


### PR DESCRIPTION
This one obviously is not urgent.  I noticed this typo in the changelog for 2.6.1...