### PR TITLE
add node version 6.9 to the CI environment test matrices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - TRAVIS_NODE_VERSION="4"
   - TRAVIS_NODE_VERSION="5"
   - TRAVIS_NODE_VERSION="6"
+  - TRAVIS_NODE_VERSION="6.9"
   - TRAVIS_NODE_VERSION="7"
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
     - nodejs_version: "4"
     - nodejs_version: "5"
     - nodejs_version: "6"
+    - nodejs_version: "6.9"
     - nodejs_version: "7"
 
 # Install scripts. (runs after repo cloning)


### PR DESCRIPTION
Apparently the current CI tests for node version `6` pull down node version `6.10.x` , but we've come to the realization last night / this morning that there is an ABI breakage between the `V8` headers used between those versions of node.

Let's try to avoid this in the future by also testing node version `6.9` explicitly on both Travis and Appveyor

closes #661 