### PR TITLE
Fix v8::JSON::Parse() deprecation warning.

### DIFF
--- a/nan_json.h
+++ b/nan_json.h
@@ -77,15 +77,19 @@ class JSON {
 #if NAN_JSON_H_NEED_PARSE
     return scope.Escape(parse(json_string));
 #else
+    Nan::MaybeLocal<v8::Value> result;
+#if NODE_MODULE_VERSION == NODE_0_12_MODULE_VERSION
+    result = v8::JSON::Parse(json_string);
+#else
 #if NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION
-    Nan::MaybeLocal<v8::Value> result =
-      v8::JSON::Parse(Nan::GetCurrentContext(), json_string);
-
+    v8::Local<v8::Context> context_or_isolate = Nan::GetCurrentContext();
+#else
+    v8::Isolate* context_or_isolate = v8::Isolate::GetCurrent();
+#endif  // NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION
+    result = v8::JSON::Parse(context_or_isolate, json_string);
+#endif  // NODE_MODULE_VERSION == NODE_0_12_MODULE_VERSION
     if (result.IsEmpty()) return v8::Local<v8::Value>();
     return scope.Escape(result.ToLocalChecked());
-#else
-    return scope.Escape(v8::JSON::Parse(json_string));
-#endif  // NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION
 #endif  // NAN_JSON_H_NEED_PARSE
   }
 

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -2,6 +2,7 @@
   "target_defaults":
     {
         "cflags" : ["-Wall", "-Wextra", "-Wno-unused-parameter"],
+        "defines": [ "V8_DEPRECATION_WARNINGS=1" ],
         "include_dirs": ["<!(node -e \"require('..')\")"]
     },
   "targets": [

--- a/test/cpp/accessors.cpp
+++ b/test/cpp/accessors.cpp
@@ -70,7 +70,7 @@ v8::Local<v8::Value> SetterGetter::NewInstance () {
   v8::Local<v8::FunctionTemplate> constructorHandle =
       Nan::New(settergetter_constructor);
   v8::Local<v8::Object> instance =
-    constructorHandle->GetFunction()->NewInstance(0, NULL);
+    Nan::NewInstance(constructorHandle->GetFunction()).ToLocalChecked();
   return scope.Escape(instance);
 }
 

--- a/test/cpp/accessors2.cpp
+++ b/test/cpp/accessors2.cpp
@@ -58,7 +58,7 @@ v8::Local<v8::Value> SetterGetter::NewInstance () {
   v8::Local<v8::FunctionTemplate> constructorHandle =
       Nan::New(settergetter_constructor);
   v8::Local<v8::Object> instance =
-    constructorHandle->GetFunction()->NewInstance(0, NULL);
+    Nan::NewInstance(constructorHandle->GetFunction()).ToLocalChecked();
   SetAccessor(
       instance
     , Nan::New("prop1").ToLocalChecked()

--- a/test/cpp/indexedinterceptors.cpp
+++ b/test/cpp/indexedinterceptors.cpp
@@ -59,7 +59,7 @@ v8::Local<v8::Value> IndexedInterceptor::NewInstance () {
   v8::Local<v8::FunctionTemplate> constructorHandle =
       Nan::New(indexedinterceptors_constructor);
   v8::Local<v8::Object> instance =
-    constructorHandle->GetFunction()->NewInstance(0, NULL);
+    Nan::NewInstance(constructorHandle->GetFunction()).ToLocalChecked();
   return scope.Escape(instance);
 }
 

--- a/test/cpp/makecallback.cpp
+++ b/test/cpp/makecallback.cpp
@@ -50,7 +50,7 @@ NAN_METHOD(MyObject::New) {
     info.GetReturnValue().Set(info.This());
   } else {
     v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-    info.GetReturnValue().Set(cons->NewInstance());
+    info.GetReturnValue().Set(Nan::NewInstance(cons).ToLocalChecked());
   }
 }
 

--- a/test/cpp/namedinterceptors.cpp
+++ b/test/cpp/namedinterceptors.cpp
@@ -59,7 +59,7 @@ v8::Local<v8::Value> NamedInterceptor::NewInstance () {
   v8::Local<v8::FunctionTemplate> constructorHandle =
       Nan::New(namedinterceptors_constructor);
   v8::Local<v8::Object> instance =
-    constructorHandle->GetFunction()->NewInstance(0, NULL);
+    Nan::NewInstance(constructorHandle->GetFunction()).ToLocalChecked();
   return scope.Escape(instance);
 }
 

--- a/test/cpp/objectwraphandle.cpp
+++ b/test/cpp/objectwraphandle.cpp
@@ -41,7 +41,8 @@ class MyObject : public ObjectWrap {
       const int argc = 1;
       v8::Local<v8::Value> argv[argc] = {info[0]};
       v8::Local<v8::Function> cons = Nan::New(constructor());
-      info.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      info.GetReturnValue().Set(
+          Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 

--- a/test/cpp/settemplate.cpp
+++ b/test/cpp/settemplate.cpp
@@ -98,7 +98,7 @@ NAN_METHOD(MyObject::New) {
     info.GetReturnValue().Set(info.This());
   } else {
     v8::Local<v8::Function> cons = Nan::New<v8::Function>(constructor);
-    info.GetReturnValue().Set(cons->NewInstance());
+    info.GetReturnValue().Set(Nan::NewInstance(cons).ToLocalChecked());
   }
 }
 


### PR DESCRIPTION
Use the non-deprecated overload that takes a `v8::Isolate` pointer and
returns a `v8::MaybeLocal<v8::Value>` when building against node <= 6.

Fixes: #663