### PR TITLE
nan.h: update NAN contributors copyright header

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -9,6 +9,7 @@
  *   - Brett Lawson <https://github.com/brett19>
  *   - Ben Noordhuis <https://github.com/bnoordhuis>
  *   - David Siegel <https://github.com/agnat>
+ *   - Michael Ira Krufky <https://github.com/mkrufky>
  *
  * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
  *


### PR DESCRIPTION
My original pull request #651 added my name to the contributors block in _package.json_, but I forgot to add it to the top of _nan.h_.  If nobody minds, this PR adds it.  I didn't add myself to _README.md_ because the list in that file is for WG Members.