### PR TITLE
support z/OS ebcdic string types

### DIFF
--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -14,6 +14,13 @@
 
 namespace imp {
 
+#ifdef __MVS__
+char EbcdicToAscii(char c) {
+  __e2a_l(&c, 1);
+  return c;
+}
+#endif
+
 //=== Array ====================================================================
 
 Factory<v8::Array>::return_t
@@ -278,8 +285,14 @@ Factory<v8::String>::New(const char * value, int length) {
 Factory<v8::String>::return_t
 Factory<v8::String>::New(std::string const& value) {
   assert(value.size() <= INT_MAX && "string too long");
+#ifdef __MVS__
+  std::string str;
+  std::transform(value.begin(), value.end(), back_inserter(str), EbcdicToAscii);
+#else
+  std::string const& str = value;
+#endif
   return v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),
-      value.data(), v8::NewStringType::kNormal, static_cast<int>(value.size()));
+      str.data(), v8::NewStringType::kNormal, static_cast<int>(str.size()));
 }
 
 Factory<v8::String>::return_t
@@ -308,9 +321,15 @@ Factory<v8::String>::return_t
 Factory<v8::String>::New(
     std::string const& value) /* NOLINT(build/include_what_you_use) */ {
   assert(value.size() <= INT_MAX && "string too long");
-  return v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), value.data(),
+#ifdef __MVS__
+  std::string str;
+  std::transform(value.begin(), value.end(), back_inserter(str), EbcdicToAscii);
+#else
+  std::string const& str = value;
+#endif
+  return v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), str.data(),
                                  v8::String::kNormalString,
-                                 static_cast<int>(value.size()));
+                                 static_cast<int>(str.size()));
 }
 
 Factory<v8::String>::return_t


### PR DESCRIPTION
This introduces a `NativeString` type which basically is the same as `Utf8String` on all platforms except z/OS where it is `EbcdicString`. 

Previously,
``` 
v8::Handle<v8::String> s;
Nan::Utf8String str(s);
system_library_call(*s);
```

This wouldn't work because the z/OS system doesn't use Utf8 string encoding but Ebcdic encoding.

But now, this will work for all platforms.
```
v8::Handle<v8::String> s
Nan::NativeString str(s);
system_library_call(*s);
```

This is a preliminary attempt to solve this problem but I am open to any other ways of achieving this.
