### PR TITLE
Fix GitHub rendering the entire changelog with a strikethrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### 2.7.0 Aug 30 2017
 
-  - Feature: Add Nan::To<v8::Function>() overload. b93280670c9f6da42ed4cf6cbf085ffdd87bd65b
-  - Bugfix: Fix ternary in Nan::MaybeLocal<T>::FromMaybe<S>(). 79a26f7d362e756a9524e672a82c3d603b542867
+  - Feature: Add `Nan::To<v8::Function>()` overload. b93280670c9f6da42ed4cf6cbf085ffdd87bd65b
+  - Bugfix: Fix ternary in `Nan::MaybeLocal<T>::FromMaybe<S>()`. 79a26f7d362e756a9524e672a82c3d603b542867
 
 ### 2.6.2 Apr 12 2017
 


### PR DESCRIPTION
Fixes GitHub rendering the entire changelog with a strikethrough because of `<S>` ([see the current changelog](https://github.com/nodejs/nan/blob/5d358f26b34ee86a2a40bdf93c0dd620afad4d37/CHANGELOG.md)).