### PR TITLE
add AsyncProgressQueueWorker to queue and deliver all events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ LINT_SOURCES = \
 	test/cpp/asyncprogressworker.cpp \
 	test/cpp/asyncprogressworkerstream.cpp \
 	test/cpp/asyncprogressworkersignal.cpp \
+	test/cpp/asyncprogressqueueworker.cpp \
 	test/cpp/asyncworkererror.cpp \
 	test/cpp/buffer.cpp \
 	test/cpp/bufferworkerpersistent.cpp \

--- a/README.md
+++ b/README.md
@@ -258,10 +258,11 @@ NAN's `node::Buffer` helpers exist as the API has changed across supported Node 
 
 ### Asynchronous work helpers
 
-`Nan::AsyncWorker` and `Nan::AsyncProgressWorker` are helper classes that make working with asynchronous code easier.
+`Nan::AsyncWorker`, `Nan::AsyncProgressWorker` and `Nan::AsyncProgressQueueWorker` are helper classes that make working with asynchronous code easier.
 
  - <a href="doc/asyncworker.md#api_nan_async_worker"><b><code>Nan::AsyncWorker</code></b></a>
  - <a href="doc/asyncworker.md#api_nan_async_progress_worker"><b><code>Nan::AsyncProgressWorkerBase &amp; Nan::AsyncProgressWorker</code></b></a>
+ - <a href="doc/asyncworker.md#api_nan_async_progress_queue_worker"><b><code>Nan::AsyncProgressQueueWorker</code></b></a>
  - <a href="doc/asyncworker.md#api_nan_async_queue_worker"><b><code>Nan::AsyncQueueWorker</code></b></a>
 
 ### Strings & Bytes

--- a/doc/asyncworker.md
+++ b/doc/asyncworker.md
@@ -1,9 +1,10 @@
 ## Asynchronous work helpers
 
-`Nan::AsyncWorker` and `Nan::AsyncProgressWorker` are helper classes that make working with asynchronous code easier.
+`Nan::AsyncWorker`, `Nan::AsyncProgressWorker` and `Nan::AsyncProgressQueueWorker` are helper classes that make working with asynchronous code easier.
 
  - <a href="#api_nan_async_worker"><b><code>Nan::AsyncWorker</code></b></a>
  - <a href="#api_nan_async_progress_worker"><b><code>Nan::AsyncProgressWorkerBase &amp; Nan::AsyncProgressWorker</code></b></a>
+ - <a href="#api_nan_async_progress_queue_worker"><b><code>Nan::AsyncProgressQueueWorker</code></b></a>
  - <a href="#api_nan_async_queue_worker"><b><code>Nan::AsyncQueueWorker</code></b></a>
 
 <a name="api_nan_async_worker"></a>
@@ -64,6 +65,8 @@ class AsyncWorker {
 
 Previously the definiton of `Nan::AsyncProgressWorker` only allowed sending `const char` data. Now extending `Nan::AsyncProgressWorker` will yield an instance of the implicit `Nan::AsyncProgressWorkerBase` template with type `<char>` for compatibility.
 
+`Nan::AsyncProgressWorkerBase` &amp; `Nan::AsyncProgressWorker` is intended for best-effort delivery of nonessential progress messages, e.g. a progress bar.  The last event sent before the main thread is woken will be delivered.
+
 Definition:
 
 ```c++
@@ -90,6 +93,39 @@ class AsyncProgressWorkerBase<T> : public AsyncWorker {
 };
 
 typedef AsyncProgressWorkerBase<T> AsyncProgressWorker;
+```
+
+<a name="api_nan_async_progress_queue_worker"></a>
+### Nan::AsyncProgressQueueWorker
+
+`Nan::AsyncProgressQueueWorker` is an _abstract_ class template that extends `Nan::AsyncWorker` and adds additional progress reporting callbacks that can be used during the asynchronous work execution to provide progress data back to JavaScript.
+
+`Nan::AsyncProgressQueueWorker` behaves exactly the same as `Nan::AsyncProgressWorker`, except all events are queued and delivered to the main thread.
+
+Definition:
+
+```c++
+template<class T>
+class AsyncProgressQueueWorker<T> : public AsyncWorker {
+ public:
+  explicit AsyncProgressQueueWorker(Callback *callback_);
+
+  virtual ~AsyncProgressQueueWorker();
+
+  void WorkProgress();
+
+  class ExecutionProgress {
+   public:
+    void Signal() const;
+    void Send(const T* data, size_t count) const;
+  };
+
+  virtual void Execute(const ExecutionProgress& progress) = 0;
+
+  virtual void HandleProgressCallback(const T *data, size_t count) = 0;
+
+  virtual void Destroy();
+};
 ```
 
 <a name="api_nan_async_queue_worker"></a>

--- a/nan.h
+++ b/nan.h
@@ -1606,12 +1606,11 @@ class Callback {
   char *errmsg_;
 };
 
-
 template<class T>
-/* abstract */ class AsyncProgressWorkerBase : public AsyncWorker {
+/* abstract */ class AsyncBareProgressWorker : public AsyncWorker {
  public:
-  explicit AsyncProgressWorkerBase(Callback *callback_)
-      : AsyncWorker(callback_), asyncdata_(NULL), asyncsize_(0) {
+  explicit AsyncBareProgressWorker(Callback *callback_)
+      : AsyncWorker(callback_) {
     async = new uv_async_t;
     uv_async_init(
         uv_default_loop()
@@ -1619,7 +1618,68 @@ template<class T>
       , AsyncProgress_
     );
     async->data = this;
+  }
 
+  virtual ~AsyncBareProgressWorker() {
+  }
+
+  virtual void WorkProgress() = 0;
+
+  class ExecutionProgress {
+    friend class AsyncBareProgressWorker;
+   public:
+    void Signal() const {
+        uv_async_send(that_->async);
+    }
+
+    void Send(const T* data, size_t count) const {
+        that_->SendProgress_(data, count);
+    }
+
+   private:
+    explicit ExecutionProgress(AsyncBareProgressWorker *that) : that_(that) {}
+    NAN_DISALLOW_ASSIGN_COPY_MOVE(ExecutionProgress)
+    AsyncBareProgressWorker* const that_;
+  };
+
+  virtual void Execute(const ExecutionProgress& progress) = 0;
+  virtual void HandleProgressCallback(const T *data, size_t size) = 0;
+
+  virtual void Destroy() {
+      uv_close(reinterpret_cast<uv_handle_t*>(async), AsyncClose_);
+  }
+
+ private:
+  void Execute() /*final override*/ {
+      ExecutionProgress progress(this);
+      Execute(progress);
+  }
+
+  virtual void SendProgress_(const T *data, size_t count) = 0;
+
+  inline static NAUV_WORK_CB(AsyncProgress_) {
+    AsyncBareProgressWorker *worker =
+            static_cast<AsyncBareProgressWorker*>(async->data);
+    worker->WorkProgress();
+  }
+
+  inline static void AsyncClose_(uv_handle_t* handle) {
+    AsyncBareProgressWorker *worker =
+            static_cast<AsyncBareProgressWorker*>(handle->data);
+    delete reinterpret_cast<uv_async_t*>(handle);
+    delete worker;
+  }
+
+ protected:
+  uv_async_t *async;
+};
+
+template<class T>
+/* abstract */
+class AsyncProgressWorkerBase : public AsyncBareProgressWorker<T> {
+ public:
+  explicit AsyncProgressWorkerBase(Callback *callback_)
+      : AsyncBareProgressWorker<T>(callback_), asyncdata_(NULL), asyncsize_(0) {
     uv_mutex_init(&async_lock);
   }
 
@@ -1637,42 +1697,13 @@ template<class T>
     uv_mutex_unlock(&async_lock);
 
     // Don't send progress events after we've already completed.
-    if (callback) {
-        HandleProgressCallback(data, size);
+    if (this->callback) {
+        this->HandleProgressCallback(data, size);
     }
     delete[] data;
   }
 
-  class ExecutionProgress {
-    friend class AsyncProgressWorkerBase;
-   public:
-    void Signal() const {
-        uv_async_send(that_->async);
-    }
-
-    void Send(const T* data, size_t count) const {
-        that_->SendProgress_(data, count);
-    }
-
-   private:
-    explicit ExecutionProgress(AsyncProgressWorkerBase *that) : that_(that) {}
-    NAN_DISALLOW_ASSIGN_COPY_MOVE(ExecutionProgress)
-    AsyncProgressWorkerBase* const that_;
-  };
-
-  virtual void Execute(const ExecutionProgress& progress) = 0;
-  virtual void HandleProgressCallback(const T *data, size_t size) = 0;
-
-  virtual void Destroy() {
-      uv_close(reinterpret_cast<uv_handle_t*>(async), AsyncClose_);
-  }
-
  private:
-  void Execute() /*final override*/ {
-      ExecutionProgress progress(this);
-      Execute(progress);
-  }
-
   void SendProgress_(const T *data, size_t count) {
     T *new_data = new T[count];
     {
@@ -1687,23 +1718,9 @@ template<class T>
     uv_mutex_unlock(&async_lock);
 
     delete[] old_data;
-    uv_async_send(async);
+    uv_async_send(this->async);
   }
 
-  inline static NAUV_WORK_CB(AsyncProgress_) {
-    AsyncProgressWorkerBase *worker =
-            static_cast<AsyncProgressWorkerBase*>(async->data);
-    worker->WorkProgress();
-  }
-
-  inline static void AsyncClose_(uv_handle_t* handle) {
-    AsyncProgressWorkerBase *worker =
-            static_cast<AsyncProgressWorkerBase*>(handle->data);
-    delete reinterpret_cast<uv_async_t*>(handle);
-    delete worker;
-  }
-
-  uv_async_t *async;
   uv_mutex_t async_lock;
   T *asyncdata_;
   size_t asyncsize_;

--- a/nan.h
+++ b/nan.h
@@ -1798,7 +1798,7 @@ class AsyncProgressQueueWorker : public AsyncBareProgressWorker<T> {
     }
 
     std::pair<T*, size_t> *datapair =
-      new std::pair<T*, size_t>(new_data, count);
+        new std::pair<T*, size_t>(new_data, count);
 
     uv_mutex_lock(&async_lock);
     asyncdata_.push(datapair);

--- a/nan.h
+++ b/nan.h
@@ -1759,6 +1759,11 @@ class AsyncProgressQueueWorker : public AsyncBareProgressWorker<T> {
     uv_mutex_destroy(&async_lock);
   }
 
+  void WorkComplete() {
+    WorkProgress();
+    AsyncWorker::WorkComplete();
+  }
+
   void WorkProgress() {
     uv_mutex_lock(&async_lock);
 

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -44,6 +44,10 @@
       , "sources"     : [ "cpp/returnemptystring.cpp" ]
     }
   , {
+        "target_name" : "asyncprogressqueueworker"
+      , "sources"     : [ "cpp/asyncprogressqueueworker.cpp" ]
+    }
+  , {
         "target_name" : "asyncworker"
       , "sources"     : [ "cpp/asyncworker.cpp" ]
     }

--- a/test/cpp/asyncprogressqueueworker.cpp
+++ b/test/cpp/asyncprogressqueueworker.cpp
@@ -1,0 +1,69 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2017 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef _WIN32
+#include <unistd.h>
+#define Sleep(x) usleep((x)*1000)
+#endif
+#include <nan.h>
+
+using namespace Nan;  // NOLINT(build/namespaces)
+
+class ProgressQueueWorker : public AsyncProgressQueueWorker<char> {
+ public:
+  ProgressQueueWorker(
+      Callback *callback
+    , Callback *progress
+    , int milliseconds
+    , int iters)
+    : AsyncProgressQueueWorker(callback), progress(progress)
+    , milliseconds(milliseconds), iters(iters) {}
+
+  ~ProgressQueueWorker() {
+    delete progress;
+  }
+
+  void Execute (const AsyncProgressQueueWorker::ExecutionProgress& progress) {
+    for (int i = 0; i < iters; ++i) {
+      progress.Send(reinterpret_cast<const char*>(&i), sizeof(int));
+      Sleep(milliseconds);
+    }
+  }
+
+  void HandleProgressCallback(const char *data, size_t count) {
+    HandleScope scope;
+
+    v8::Local<v8::Value> argv[] = {
+        New<v8::Integer>(*reinterpret_cast<int*>(const_cast<char*>(data)))
+    };
+    progress->Call(1, argv);
+  }
+
+ private:
+  Callback *progress;
+  int milliseconds;
+  int iters;
+};
+
+NAN_METHOD(DoProgress) {
+  Callback *progress = new Callback(info[2].As<v8::Function>());
+  Callback *callback = new Callback(info[3].As<v8::Function>());
+  AsyncQueueWorker(new ProgressQueueWorker(
+      callback
+    , progress
+    , To<uint32_t>(info[0]).FromJust()
+    , To<uint32_t>(info[1]).FromJust()));
+}
+
+NAN_MODULE_INIT(Init) {
+  Set(target
+    , New<v8::String>("a").ToLocalChecked()
+    , New<v8::FunctionTemplate>(DoProgress)->GetFunction());
+}
+
+NODE_MODULE(asyncprogressqueueworker, Init)

--- a/test/js/asyncprogressqueueworker-0ms-test.js
+++ b/test/js/asyncprogressqueueworker-0ms-test.js
@@ -1,0 +1,24 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2017 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+const test     = require('tap').test
+    , testRoot = require('path').resolve(__dirname, '..')
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'asyncprogressqueueworker' });
+
+test('asyncprogressqueueworker1ms', function (t) {
+  // test with 0 ms sleep
+  var worker = bindings.a
+    , progressed = 0
+  worker(0, 500, function(i) {
+    t.ok(i === progressed, 'got the progress updates #' + i);
+    progressed++;
+  }, function () {
+    t.ok(progressed === 500, 'got all progress updates')
+    t.end()
+  })
+})

--- a/test/js/asyncprogressqueueworker-1ms-test.js
+++ b/test/js/asyncprogressqueueworker-1ms-test.js
@@ -1,0 +1,24 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2017 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+const test     = require('tap').test
+    , testRoot = require('path').resolve(__dirname, '..')
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'asyncprogressqueueworker' });
+
+test('asyncprogressqueueworker1ms', function (t) {
+  // test with 1 ms sleep
+  var worker = bindings.a
+    , progressed = 0
+  worker(1, 500, function(i) {
+    t.ok(i === progressed, 'got the progress updates #' + i);
+    progressed++;
+  }, function () {
+    t.ok(progressed === 500, 'got all progress updates')
+    t.end()
+  })
+})

--- a/test/js/asyncprogressqueueworker-test.js
+++ b/test/js/asyncprogressqueueworker-test.js
@@ -1,0 +1,24 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2017 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+const test     = require('tap').test
+    , testRoot = require('path').resolve(__dirname, '..')
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'asyncprogressqueueworker' });
+
+test('asyncprogressqueueworker', function (t) {
+  // test with 100 ms sleep
+  var worker = bindings.a
+    , progressed = 0
+  worker(100, 5, function(i) {
+    t.ok(i === progressed, 'got the progress updates #' + i);
+    progressed++;
+  }, function () {
+    t.ok(progressed === 5, 'got all progress updates')
+    t.end()
+  })
+})

--- a/test/js/asyncprogressworker-1ms-test.js
+++ b/test/js/asyncprogressworker-1ms-test.js
@@ -10,15 +10,15 @@ const test     = require('tap').test
     , testRoot = require('path').resolve(__dirname, '..')
     , bindings = require('bindings')({ module_root: testRoot, bindings: 'asyncprogressworker' });
 
-test('asyncprogressworker', function (t) {
-  // test with 100 ms sleep
+test('asyncprogressworker1ms', function (t) {
+  // test with 1 ms sleep
   var worker = bindings.a
     , progressed = 0
-  worker(100, 5, function(i) {
-    t.ok(i === progressed, 'got the progress updates #' + i);
+  worker(1, 500, function(i) {
+    t.ok(i >= progressed, 'got the progress updates #' + i);
     progressed++;
   }, function () {
-    t.ok(progressed === 5, 'got all progress updates')
+    t.ok(progressed <= 500, 'got some but not necessarily all progress updates')
     t.end()
   })
 })


### PR DESCRIPTION
add `AsyncProgressQueueWorker`: wake the main thread like AsyncProgressWorkerBase, except all events are queued and delivered

There are often cases where we want to handle events initiated by threads other than node threads.  Developers are often told to look at `AsyncProgressWorker` , which allows us to send progress updates from external threads, but this is not necessarily enough.  `AsyncProgressWorker` does what it needs to do, but if it is invoked many times before it wakes the main thread, only the last event will be delivered.  This is great for sending "progress" style events, but sometimes we need to make sure that all events get delivered.  `AsyncProgressWorker` doesn't do the job in those cases.

This PR refactors `AsyncProgressWorkerBase` to separate common elements and adds a new structure, `AsyncProgressQueueWorker` that behaves like `AsyncProgressWorkerBase` except all events are queued and delivered.

* The first patch, `AsyncProgressWorkerBase inherits AsyncBareProgressWorker` is a no-op change, that simply separates `AsyncBareProgressWorker` from `AsyncProgressWorkerBase`.

* The second patch adds the new functionality: `AsyncProgressQueueWorker`

* The third patch adds a test that shows how `AsyncProgressWorker` can (and will) miss some events.

* The fourth patch adds tests that show how `AsyncProgressQueueWorker` does not miss events.

* The fifth patch adds adds documentation for the new  `AsyncProgressQueueWorker` class.

* The sixth patch ensures that any possible remaining events in the queue are drained within `WorkComplete()`

The API of `AsyncProgressQueueWorker` is exactly the same as the API of `AsyncProgressWorkerBase` -- it's a drop-in replacement.  The only difference is that events will not be missed as a result of multiple wake requests being made before the `uv_async_t` wakes the main thread.  For more info, see the warning at the bottom of the [uv_async_t documentation](http://docs.libuv.org/en/v1.x/async.html):

> libuv will coalesce calls to uv_async_send(), that is, not every call to it will yield an execution of the callback. For example: if uv_async_send() is called 5 times in a row before the callback is called, the callback will only be called once. If uv_async_send() is called again after the callback was called, it will be called again.