### PR TITLE
Fix memory leak in the AsyncProgressWorker tests

### DIFF
--- a/test/cpp/asyncprogressworker.cpp
+++ b/test/cpp/asyncprogressworker.cpp
@@ -23,7 +23,10 @@ class ProgressWorker : public AsyncProgressWorker {
     , int iters)
     : AsyncProgressWorker(callback), progress(progress)
     , milliseconds(milliseconds), iters(iters) {}
-  ~ProgressWorker() {}
+
+  ~ProgressWorker() {
+    delete progress;
+  }
 
   void Execute (const AsyncProgressWorker::ExecutionProgress& progress) {
     for (int i = 0; i < iters; ++i) {

--- a/test/cpp/asyncprogressworkersignal.cpp
+++ b/test/cpp/asyncprogressworkersignal.cpp
@@ -23,7 +23,10 @@ class ProgressWorker : public AsyncProgressWorker {
     , int iters)
     : AsyncProgressWorker(callback), progress(progress)
     , milliseconds(milliseconds), iters(iters) {}
-  ~ProgressWorker() {}
+
+  ~ProgressWorker() {
+    delete progress;
+  }
 
   void Execute (const AsyncProgressWorker::ExecutionProgress& progress) {
     for (int i = 0; i < iters; ++i) {

--- a/test/cpp/asyncprogressworkerstream.cpp
+++ b/test/cpp/asyncprogressworkerstream.cpp
@@ -32,7 +32,10 @@ class ProgressWorker : public AsyncProgressWorkerBase<T> {
     , int iters)
     : AsyncProgressWorkerBase<T>(callback), progress(progress)
     , milliseconds(milliseconds), iters(iters) {}
-  ~ProgressWorker() {}
+
+  ~ProgressWorker() {
+    delete progress;
+  }
 
   void Execute (
     const typename AsyncProgressWorkerBase<T>::ExecutionProgress& progress) {


### PR DESCRIPTION
Delete progress callback in `AsyncProgressWorker` test class destructors

In `test/cpp/asyncprogressworker*.cpp`, the addon functions allocate two
`Nan::Callback` objects, called `progress` and `callback`.

`callback` is passed into the `AsyncWorker` constructor, and gets
deleted by the `AsyncWorker` destructor after work is complete.

`progress` is passed into the user-level test class.  It is called
in `HandleProgressCallback()` but it never gets deleted.

Since this has been approved, I've also updated my other PR #692 that touches `AsyncProgressWorker` with a similar fix...

closes #698 