### PR TITLE
add AsyncProgressQueueWorker test for streams

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ LINT_SOURCES = \
 	test/cpp/asyncprogressworkerstream.cpp \
 	test/cpp/asyncprogressworkersignal.cpp \
 	test/cpp/asyncprogressqueueworker.cpp \
+	test/cpp/asyncprogressqueueworkerstream.cpp \
 	test/cpp/asyncworkererror.cpp \
 	test/cpp/buffer.cpp \
 	test/cpp/bufferworkerpersistent.cpp \

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -48,6 +48,10 @@
       , "sources"     : [ "cpp/asyncprogressqueueworker.cpp" ]
     }
   , {
+        "target_name" : "asyncprogressqueueworkerstream"
+      , "sources"     : [ "cpp/asyncprogressqueueworkerstream.cpp" ]
+    }
+  , {
         "target_name" : "asyncworker"
       , "sources"     : [ "cpp/asyncworker.cpp" ]
     }

--- a/test/cpp/asyncprogressqueueworkerstream.cpp
+++ b/test/cpp/asyncprogressqueueworkerstream.cpp
@@ -6,10 +6,6 @@
  * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
  ********************************************************************/
 
-#ifndef _WIN32
-#include <unistd.h>
-#define Sleep(x) usleep((x)*1000)
-#endif
 #include <nan.h>
 
 using namespace Nan;  // NOLINT(build/namespaces)
@@ -21,17 +17,15 @@ struct data_t {
   int data;
 };
 
-// Unlike test/cpp/ayncprogressworker.cpp this test is explicitly templated.
 template<typename T>
 class ProgressQueueWorker : public AsyncProgressQueueWorker<T> {
  public:
   ProgressQueueWorker(
       Callback *callback
     , Callback *progress
-    , int milliseconds
     , int iters)
     : AsyncProgressQueueWorker<T>(callback), progress(progress)
-    , milliseconds(milliseconds), iters(iters) {}
+    , iters(iters) {}
 
   ~ProgressQueueWorker() {
     delete progress;
@@ -44,7 +38,6 @@ class ProgressQueueWorker : public AsyncProgressQueueWorker<T> {
       data.index = i;
       data.data = i * 2;
       progress.Send(&data, 1);
-      Sleep(milliseconds);
     }
   }
 
@@ -66,18 +59,16 @@ class ProgressQueueWorker : public AsyncProgressQueueWorker<T> {
 
  private:
   Callback *progress;
-  int milliseconds;
   int iters;
 };
 
 NAN_METHOD(DoProgress) {
-  Callback *progress = new Callback(info[2].As<v8::Function>());
-  Callback *callback = new Callback(info[3].As<v8::Function>());
+  Callback *progress = new Callback(info[1].As<v8::Function>());
+  Callback *callback = new Callback(info[2].As<v8::Function>());
   AsyncQueueWorker(new ProgressQueueWorker<data_t>(
       callback
     , progress
-    , To<uint32_t>(info[0]).FromJust()
-    , To<uint32_t>(info[1]).FromJust()));
+    , To<uint32_t>(info[0]).FromJust()));
 }
 
 NAN_MODULE_INIT(Init) {

--- a/test/cpp/asyncprogressqueueworkerstream.cpp
+++ b/test/cpp/asyncprogressqueueworkerstream.cpp
@@ -73,7 +73,7 @@ NAN_METHOD(DoProgress) {
 
 NAN_MODULE_INIT(Init) {
   Set(target
-    , New<v8::String>("a").ToLocalChecked()
+    , New<v8::String>("doProgress").ToLocalChecked()
     , New<v8::FunctionTemplate>(DoProgress)->GetFunction());
 }
 

--- a/test/cpp/asyncprogressqueueworkerstream.cpp
+++ b/test/cpp/asyncprogressqueueworkerstream.cpp
@@ -1,0 +1,89 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2017 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef _WIN32
+#include <unistd.h>
+#define Sleep(x) usleep((x)*1000)
+#endif
+#include <nan.h>
+
+using namespace Nan;  // NOLINT(build/namespaces)
+
+// Custom data type: This serves as an example of how external
+// libraries could be hooked in, populate their objects and send them to JS.
+struct data_t {
+  int index;
+  int data;
+};
+
+// Unlike test/cpp/ayncprogressworker.cpp this test is explicitly templated.
+template<typename T>
+class ProgressQueueWorker : public AsyncProgressQueueWorker<T> {
+ public:
+  ProgressQueueWorker(
+      Callback *callback
+    , Callback *progress
+    , int milliseconds
+    , int iters)
+    : AsyncProgressQueueWorker<T>(callback), progress(progress)
+    , milliseconds(milliseconds), iters(iters) {}
+
+  ~ProgressQueueWorker() {
+    delete progress;
+  }
+
+  void Execute (
+    const typename AsyncProgressQueueWorker<T>::ExecutionProgress& progress) {
+    data_t data;
+    for (int i = 0; i < iters; ++i) {
+      data.index = i;
+      data.data = i * 2;
+      progress.Send(&data, 1);
+      Sleep(milliseconds);
+    }
+  }
+
+  void HandleProgressCallback(const T *data, size_t count) {
+    HandleScope scope;
+    v8::Local<v8::Object> obj = Nan::New<v8::Object>();
+    Nan::Set(
+      obj,
+      Nan::New("index").ToLocalChecked(),
+      New<v8::Integer>(data->index));
+    Nan::Set(
+      obj,
+      Nan::New("data").ToLocalChecked(),
+      New<v8::Integer>(data->data));
+
+    v8::Local<v8::Value> argv[] = { obj };
+    progress->Call(1, argv);
+  }
+
+ private:
+  Callback *progress;
+  int milliseconds;
+  int iters;
+};
+
+NAN_METHOD(DoProgress) {
+  Callback *progress = new Callback(info[2].As<v8::Function>());
+  Callback *callback = new Callback(info[3].As<v8::Function>());
+  AsyncQueueWorker(new ProgressQueueWorker<data_t>(
+      callback
+    , progress
+    , To<uint32_t>(info[0]).FromJust()
+    , To<uint32_t>(info[1]).FromJust()));
+}
+
+NAN_MODULE_INIT(Init) {
+  Set(target
+    , New<v8::String>("a").ToLocalChecked()
+    , New<v8::FunctionTemplate>(DoProgress)->GetFunction());
+}
+
+NODE_MODULE(asyncprogressqueueworkerstream, Init)

--- a/test/js/asyncprogressqueueworkerstream-test.js
+++ b/test/js/asyncprogressqueueworkerstream-test.js
@@ -1,0 +1,54 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2017 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+const test     = require('tap').test
+    , testRoot = require('path').resolve(__dirname, '..')
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'asyncprogressqueueworkerstream' })
+    , util = require('util');
+
+const nodeVersion = process.versions.node.split('.')
+var Readable
+if (nodeVersion[0] == 0 && nodeVersion[1] <= 8)
+  Readable = require('readable-stream')
+else
+  Readable = require('stream').Readable
+
+function StreamProgressWorker(t) {
+  Readable.call(this, {objectMode: true})
+  var self = this
+  // initialize stream from cpp on next tick
+  process.nextTick(function () {
+    var worker = bindings.a
+    worker(100, 5, function(i) {
+      self.push(i)
+    }, function () {
+      self.push(null)
+    })
+  })
+}
+util.inherits(StreamProgressWorker, Readable)
+
+StreamProgressWorker.prototype._read = function (data) {
+
+};
+
+
+test('asyncprogressqueueworker', function (t) {
+  var stream = new StreamProgressWorker(t)
+  var progressed = 0;
+
+  stream
+    .on('end', function() {
+      t.ok(progressed === 5, 'cpp should have sent 5 objects')
+      t.end()
+    })
+    .on('data', function(data) {
+      progressed++
+      console.log(data);
+    })
+})

--- a/test/js/asyncprogressqueueworkerstream-test.js
+++ b/test/js/asyncprogressqueueworkerstream-test.js
@@ -23,7 +23,7 @@ function StreamProgressWorker(t) {
   var self = this
   // initialize stream from cpp on next tick
   process.nextTick(function () {
-    var worker = bindings.a
+    var worker = bindings.doProgress
     worker(5, function(i) {
       self.push(i)
     }, function () {

--- a/test/js/asyncprogressqueueworkerstream-test.js
+++ b/test/js/asyncprogressqueueworkerstream-test.js
@@ -24,7 +24,7 @@ function StreamProgressWorker(t) {
   // initialize stream from cpp on next tick
   process.nextTick(function () {
     var worker = bindings.a
-    worker(100, 5, function(i) {
+    worker(5, function(i) {
       self.push(i)
     }, function () {
       self.push(null)


### PR DESCRIPTION
`AsyncProgressQueueWorker<T>` is a better choice over `AsyncProgressWorker<T>` when it comes to streaming, in most cases.  As such, we should include an example of how to use it.

This pull request adds an `AsyncProgressQueueWorker` test for streams, similar to the test for `AsyncProgressWorker`.   So similar, in fact, that this test is copied exactly from the `AsyncProgressWorker` test, but with all sleeps removed.

* The first patch copies the old test to a new test.

* The second patch shows the changes that I made to accommodate `AsyncProgressQueueWorker<T>`