### PR TITLE
doc/asyncworker.md: remove AsyncProgressQueueWorker::ExecutionProgress::Signal

### DIFF
--- a/doc/asyncworker.md
+++ b/doc/asyncworker.md
@@ -116,7 +116,6 @@ class AsyncProgressQueueWorker<T> : public AsyncWorker {
 
   class ExecutionProgress {
    public:
-    void Signal() const;
     void Send(const T* data, size_t count) const;
   };
 


### PR DESCRIPTION
`AsyncProgressQueueWorker::ExecutionProgress::Signal()` was never supported.
It was removed in f3cdf8d2ed89728b6994dbb568b902ea80203177

Update the markdown docs to reflect this.