### PR TITLE
Fix compiling on io.js 1 & 2

### DIFF
--- a/nan_json.h
+++ b/nan_json.h
@@ -88,7 +88,8 @@ class JSON {
     v8::Isolate* context_or_isolate = v8::Isolate::GetCurrent();
 #endif  // NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION
     result = v8::JSON::Parse(context_or_isolate, json_string);
-#endif  // NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION && NODE_MODULE_VERSION <= IOJS_2_0_MODULE_VERSION
+#endif  // NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION &&
+        // NODE_MODULE_VERSION <= IOJS_2_0_MODULE_VERSION
     if (result.IsEmpty()) return v8::Local<v8::Value>();
     return scope.Escape(result.ToLocalChecked());
 #endif  // NAN_JSON_H_NEED_PARSE

--- a/nan_json.h
+++ b/nan_json.h
@@ -78,7 +78,8 @@ class JSON {
     return scope.Escape(parse(json_string));
 #else
     Nan::MaybeLocal<v8::Value> result;
-#if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION && NODE_MODULE_VERSION <= IOJS_2_0_MODULE_VERSION
+#if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION && \
+    NODE_MODULE_VERSION <= IOJS_2_0_MODULE_VERSION
     result = v8::JSON::Parse(json_string);
 #else
 #if NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION

--- a/nan_json.h
+++ b/nan_json.h
@@ -78,7 +78,7 @@ class JSON {
     return scope.Escape(parse(json_string));
 #else
     Nan::MaybeLocal<v8::Value> result;
-#if NODE_MODULE_VERSION == NODE_0_12_MODULE_VERSION
+#if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION && NODE_MODULE_VERSION <= IOJS_2_0_MODULE_VERSION
     result = v8::JSON::Parse(json_string);
 #else
 #if NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION
@@ -87,7 +87,7 @@ class JSON {
     v8::Isolate* context_or_isolate = v8::Isolate::GetCurrent();
 #endif  // NODE_MODULE_VERSION > NODE_6_0_MODULE_VERSION
     result = v8::JSON::Parse(context_or_isolate, json_string);
-#endif  // NODE_MODULE_VERSION == NODE_0_12_MODULE_VERSION
+#endif  // NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION && NODE_MODULE_VERSION <= IOJS_2_0_MODULE_VERSION
     if (result.IsEmpty()) return v8::Local<v8::Value>();
     return scope.Escape(result.ToLocalChecked());
 #endif  // NAN_JSON_H_NEED_PARSE


### PR DESCRIPTION
This fixes a compilation error on io.js 1 and 2. V8 4.2.77 (io.js 2.5.0) still uses `Parse(Local<String> json_string)`, and V8 4.4.63 (io.js 3.3.1) uses `Parse(Isolate *isolate, Local<String> json_string)`