### PR TITLE
convert uses of `val.As<Foo>()` to `To<Foo>(val).ToLocalChecked()`

### DIFF
--- a/doc/v8_internals.md
+++ b/doc/v8_internals.md
@@ -33,7 +33,7 @@ NAN_GC_CALLBACK(gcPrologueCallback) {
 }
 
 NAN_METHOD(Hook) {
-  callback.Reset(args[0].As<Function>());
+  callback.Reset(To<Function>(args[0]).ToLocalChecked());
   Nan::AddGCPrologueCallback(gcPrologueCallback);
   info.GetReturnValue().Set(info.Holder());
 }

--- a/examples/async_pi_estimate/async.cc
+++ b/examples/async_pi_estimate/async.cc
@@ -58,7 +58,7 @@ class PiWorker : public AsyncWorker {
 // Asynchronous access to the `Estimate()` function
 NAN_METHOD(CalculateAsync) {
   int points = To<int>(info[0]).FromJust();
-  Callback *callback = new Callback(info[1].As<Function>());
+  Callback *callback = new Callback(To<Function>(info[1]).ToLocalChecked());
 
   AsyncQueueWorker(new PiWorker(callback, points));
 }

--- a/test/cpp/asyncprogressqueueworker.cpp
+++ b/test/cpp/asyncprogressqueueworker.cpp
@@ -44,8 +44,8 @@ class ProgressQueueWorker : public AsyncProgressQueueWorker<char> {
 };
 
 NAN_METHOD(DoProgress) {
-  Callback *progress = new Callback(info[1].As<v8::Function>());
-  Callback *callback = new Callback(info[2].As<v8::Function>());
+  Callback *progress = new Callback(To<v8::Function>(info[1]).ToLocalChecked());
+  Callback *callback = new Callback(To<v8::Function>(info[2]).ToLocalChecked());
   AsyncQueueWorker(new ProgressQueueWorker(
       callback
     , progress

--- a/test/cpp/asyncprogressqueueworkerstream.cpp
+++ b/test/cpp/asyncprogressqueueworkerstream.cpp
@@ -63,8 +63,8 @@ class ProgressQueueWorker : public AsyncProgressQueueWorker<T> {
 };
 
 NAN_METHOD(DoProgress) {
-  Callback *progress = new Callback(info[1].As<v8::Function>());
-  Callback *callback = new Callback(info[2].As<v8::Function>());
+  Callback *progress = new Callback(To<v8::Function>(info[1]).ToLocalChecked());
+  Callback *callback = new Callback(To<v8::Function>(info[2]).ToLocalChecked());
   AsyncQueueWorker(new ProgressQueueWorker<data_t>(
       callback
     , progress

--- a/test/cpp/asyncprogressworker.cpp
+++ b/test/cpp/asyncprogressworker.cpp
@@ -51,8 +51,8 @@ class ProgressWorker : public AsyncProgressWorker {
 };
 
 NAN_METHOD(DoProgress) {
-  Callback *progress = new Callback(info[2].As<v8::Function>());
-  Callback *callback = new Callback(info[3].As<v8::Function>());
+  Callback *progress = new Callback(To<v8::Function>(info[2]).ToLocalChecked());
+  Callback *callback = new Callback(To<v8::Function>(info[3]).ToLocalChecked());
   AsyncQueueWorker(new ProgressWorker(
       callback
     , progress

--- a/test/cpp/asyncprogressworkersignal.cpp
+++ b/test/cpp/asyncprogressworkersignal.cpp
@@ -49,8 +49,8 @@ class ProgressWorker : public AsyncProgressWorker {
 };
 
 NAN_METHOD(DoProgress) {
-  Callback *progress = new Callback(info[2].As<v8::Function>());
-  Callback *callback = new Callback(info[3].As<v8::Function>());
+  Callback *progress = new Callback(To<v8::Function>(info[2]).ToLocalChecked());
+  Callback *callback = new Callback(To<v8::Function>(info[3]).ToLocalChecked());
   AsyncQueueWorker(new ProgressWorker(
       callback
     , progress

--- a/test/cpp/asyncprogressworkerstream.cpp
+++ b/test/cpp/asyncprogressworkerstream.cpp
@@ -71,8 +71,8 @@ class ProgressWorker : public AsyncProgressWorkerBase<T> {
 };
 
 NAN_METHOD(DoProgress) {
-  Callback *progress = new Callback(info[2].As<v8::Function>());
-  Callback *callback = new Callback(info[3].As<v8::Function>());
+  Callback *progress = new Callback(To<v8::Function>(info[2]).ToLocalChecked());
+  Callback *callback = new Callback(To<v8::Function>(info[3]).ToLocalChecked());
   AsyncQueueWorker(new ProgressWorker<data_t>(
       callback
     , progress

--- a/test/cpp/asyncworker.cpp
+++ b/test/cpp/asyncworker.cpp
@@ -29,7 +29,7 @@ class SleepWorker : public AsyncWorker {
 };
 
 NAN_METHOD(DoSleep) {
-  Callback *callback = new Callback(info[1].As<v8::Function>());
+  Callback *callback = new Callback(To<v8::Function>(info[1]).ToLocalChecked());
   AsyncQueueWorker(
       new SleepWorker(callback, To<uint32_t>(info[0]).FromJust()));
 }

--- a/test/cpp/asyncworkererror.cpp
+++ b/test/cpp/asyncworkererror.cpp
@@ -21,7 +21,7 @@ class ErrorWorker : public AsyncWorker {
 };
 
 NAN_METHOD(Work) {
-  Callback *callback = new Callback(info[0].As<v8::Function>());
+  Callback *callback = new Callback(To<v8::Function>(info[0]).ToLocalChecked());
   AsyncQueueWorker(new ErrorWorker(callback));
   info.GetReturnValue().SetUndefined();
 }

--- a/test/cpp/bufferworkerpersistent.cpp
+++ b/test/cpp/bufferworkerpersistent.cpp
@@ -51,8 +51,8 @@ class BufferWorker : public AsyncWorker {
 };
 
 NAN_METHOD(DoSleep) {
-  v8::Local<v8::Object> bufferHandle = info[1].As<v8::Object>();
-  Callback *callback = new Callback(info[2].As<v8::Function>());
+  v8::Local<v8::Object> bufferHandle = To<v8::Object>(info[1]).ToLocalChecked();
+  Callback *callback = new Callback(To<v8::Function>(info[2]).ToLocalChecked());
   assert(!callback->IsEmpty() && "Callback shoud not be empty");
   AsyncQueueWorker(new BufferWorker(
       callback

--- a/test/cpp/nancallback.cpp
+++ b/test/cpp/nancallback.cpp
@@ -11,34 +11,34 @@
 using namespace Nan;  // NOLINT(build/namespaces)
 
 NAN_METHOD(GlobalContext) {
-  Callback(info[0].As<v8::Function>()).Call(0, NULL);
+  Callback(To<v8::Function>(info[0]).ToLocalChecked()).Call(0, NULL);
 }
 
 NAN_METHOD(SpecificContext) {
-  Callback cb(info[0].As<v8::Function>());
+  Callback cb(To<v8::Function>(info[0]).ToLocalChecked());
   cb.Call(GetCurrentContext()->Global(), 0, NULL);
 }
 
 NAN_METHOD(CustomReceiver) {
-  Callback cb(info[0].As<v8::Function>());
-  cb.Call(info[1].As<v8::Object>(), 0, NULL);
+  Callback cb(To<v8::Function>(info[0]).ToLocalChecked());
+  cb.Call(To<v8::Object>(info[1]).ToLocalChecked(), 0, NULL);
 }
 
 NAN_METHOD(CompareCallbacks) {
-  Callback cb1(info[0].As<v8::Function>());
-  Callback cb2(info[1].As<v8::Function>());
-  Callback cb3(info[2].As<v8::Function>());
+  Callback cb1(To<v8::Function>(info[0]).ToLocalChecked());
+  Callback cb2(To<v8::Function>(info[1]).ToLocalChecked());
+  Callback cb3(To<v8::Function>(info[2]).ToLocalChecked());
 
   info.GetReturnValue().Set(New<v8::Boolean>(cb1 == cb2 && cb1 != cb3));
 }
 
 NAN_METHOD(CallDirect) {
-  Callback cb(info[0].As<v8::Function>());
+  Callback cb(To<v8::Function>(info[0]).ToLocalChecked());
   (*cb)->Call(GetCurrentContext()->Global(), 0, NULL);
 }
 
 NAN_METHOD(CallAsFunction) {
-  Callback(info[0].As<v8::Function>())();
+  Callback(To<v8::Function>(info[0]).ToLocalChecked())();
 }
 
 NAN_METHOD(ResetUnset) {
@@ -48,7 +48,7 @@ NAN_METHOD(ResetUnset) {
 }
 
 NAN_METHOD(ResetSet) {
-  Callback callback(info[0].As<v8::Function>());
+  Callback callback(To<v8::Function>(info[0]).ToLocalChecked());
   callback.Reset();
   info.GetReturnValue().Set(callback.IsEmpty());
 }

--- a/test/cpp/persistent.cpp
+++ b/test/cpp/persistent.cpp
@@ -14,7 +14,7 @@ using namespace Nan;  // NOLINT(build/namespaces)
 static Persistent<v8::String> persistentTest1;
 
 NAN_METHOD(Save1) {
-  persistentTest1.Reset(info[0].As<v8::String>());
+  persistentTest1.Reset(To<v8::String>(info[0]).ToLocalChecked());
 }
 
 NAN_METHOD(Get1) {
@@ -26,7 +26,7 @@ NAN_METHOD(Dispose1) {
 }
 
 NAN_METHOD(ToPersistentAndBackAgain) {
-  Persistent<v8::Object> persistent(info[0].As<v8::Object>());
+  Persistent<v8::Object> persistent(To<v8::Object>(info[0]).ToLocalChecked());
   v8::Local<v8::Object> object = New(persistent);
   persistent.Reset();
   memset(&persistent, -1, sizeof(persistent));  // Clobber it good.
@@ -34,7 +34,7 @@ NAN_METHOD(ToPersistentAndBackAgain) {
 }
 
 NAN_METHOD(PersistentToPersistent) {
-  Persistent<v8::String> persistent(info[0].As<v8::String>());
+  Persistent<v8::String> persistent(To<v8::String>(info[0]).ToLocalChecked());
   persistentTest1.Reset(persistent);
   persistent.Reset();
   info.GetReturnValue().Set(New(persistentTest1));

--- a/test/cpp/private.cpp
+++ b/test/cpp/private.cpp
@@ -54,7 +54,7 @@ NAN_METHOD(NoConflict) {
   SetPrivate(object, key, value);
   Set(object, key, other_value);
   v8::Local<v8::Value> got = GetPrivate(object, key).ToLocalChecked();
-  bool v1 = got.As<v8::String>()->StrictEquals(value);
+  bool v1 = To<v8::String>(got).ToLocalChecked()->StrictEquals(value);
   v8::Local<v8::Value> got_other = Get(object, key).ToLocalChecked();
   bool v2 = got_other->StrictEquals(other_value);
   DeletePrivate(object, key);

--- a/test/cpp/returnvalue.cpp
+++ b/test/cpp/returnvalue.cpp
@@ -16,7 +16,7 @@ NAN_METHOD(ReturnAValue) {
   const FunctionCallbackInfo<v8::Value> &cbinfo = info;
   ReturnValue<v8::Value> ret = cbinfo.GetReturnValue();
   if (cbinfo.Length() == 1) {
-    ret.Set(info[0].As<v8::String>());
+    ret.Set(To<v8::String>(info[0]).ToLocalChecked());
   } else {
     ret.Set(New("default").ToLocalChecked());
   }

--- a/test/cpp/weak.cpp
+++ b/test/cpp/weak.cpp
@@ -31,8 +31,8 @@ v8::Local<v8::String> wrap(v8::Local<v8::Function> func) {
 }
 
 NAN_METHOD(Hustle) {
-  cb.Reset(info[1].As<v8::Function>());
-  info.GetReturnValue().Set(wrap(info[0].As<v8::Function>()));
+  cb.Reset(To<v8::Function>(info[1]).ToLocalChecked());
+  info.GetReturnValue().Set(wrap(To<v8::Function>(info[0]).ToLocalChecked()));
 }
 
 NAN_MODULE_INIT(Init) {

--- a/test/cpp/weak2.cpp
+++ b/test/cpp/weak2.cpp
@@ -36,7 +36,7 @@ v8::Local<v8::String> wrap() {
 }
 
 NAN_METHOD(Hustle) {
-  cb.Reset(info[0].As<v8::Function>());
+  cb.Reset(To<v8::Function>(info[0]).ToLocalChecked());
   info.GetReturnValue().Set(wrap());
 }
 


### PR DESCRIPTION
Since a new release seems to be looming around the corner, better to fix these now...

Expanding on bnoordhuis' suggestion here: https://github.com/nodejs/nan/pull/702#discussion_r143352671

The changes are mostly in `test/cpp`, `doc` and `examples` but there were two callers of `To<v8::Function>`  in `nan_json.h` that got converted here as well.