### PR TITLE
nan_maybe_pre_43_inl.h: fix warnings in DefineOwnProperty()

### DIFF
--- a/nan_maybe_pre_43_inl.h
+++ b/nan_maybe_pre_43_inl.h
@@ -156,7 +156,7 @@ inline Maybe<bool> DefineOwnProperty(
   v8::PropertyAttribute current = obj->GetPropertyAttributes(key);
   return !(current & v8::DontDelete) ||                     // configurable OR
                  !(current & v8::ReadOnly) &&               // writable AND
-                     !((attribs ^ current) & ~v8::ReadOnly) // same excluding RO
+                 !((attribs ^ current) & ~v8::ReadOnly)     // same excluding RO
              ? Just<bool>(obj->ForceSet(key, value, attribs))
              : Nothing<bool>();
 }

--- a/nan_maybe_pre_43_inl.h
+++ b/nan_maybe_pre_43_inl.h
@@ -155,8 +155,8 @@ inline Maybe<bool> DefineOwnProperty(
   , v8::PropertyAttribute attribs = v8::None) {
   v8::PropertyAttribute current = obj->GetPropertyAttributes(key);
   return !(current & v8::DontDelete) ||                     // configurable OR
-                 !(current & v8::ReadOnly) &&               // writable AND
-                 !((attribs ^ current) & ~v8::ReadOnly)     // same excluding RO
+                  (!(current & v8::ReadOnly) &&             // writable AND
+                   !((attribs ^ current) & ~v8::ReadOnly))  // same excluding RO
              ? Just<bool>(obj->ForceSet(key, value, attribs))
              : Nothing<bool>();
 }


### PR DESCRIPTION
I think I agree with the compiler. The function was difficult to read. I think it's easier (and prettier) to just do as it says.

closes #717 