### PR TITLE
Add context awareness to Nan::AsyncWorker and Nan::Callback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ LINT_SOURCES = \
 	test/cpp/error.cpp \
 	test/cpp/gc.cpp \
 	test/cpp/indexedinterceptors.cpp \
+	test/cpp/callbackcontext.cpp \
 	test/cpp/converters.cpp \
 	test/cpp/isolatedata.cpp \
 	test/cpp/json-parse.cpp \

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ LINT_SOURCES = \
 	test/cpp/returnvalue.cpp \
 	test/cpp/setcallhandler.cpp \
 	test/cpp/settemplate.cpp \
-	test/cpp/sleeph.h \
+	test/cpp/sleep.h \
 	test/cpp/strings.cpp \
 	test/cpp/symbols.cpp \
 	test/cpp/threadlocal.cpp \

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ LINT_SOURCES = \
 	test/cpp/returnvalue.cpp \
 	test/cpp/setcallhandler.cpp \
 	test/cpp/settemplate.cpp \
+	test/cpp/sleeph.h \
 	test/cpp/strings.cpp \
 	test/cpp/symbols.cpp \
 	test/cpp/threadlocal.cpp \

--- a/doc/asyncworker.md
+++ b/doc/asyncworker.md
@@ -15,7 +15,7 @@
 This class internally handles the details of creating an [`AsyncResource`][AsyncResource], and running the callback in the
 correct async context. To be able to identify the async resources created by this class in async-hooks, provide a
 `resource_name` to the constructor. It is recommended that the module name be used as a prefix to the `resource_name` to avoid
-collisions in the names. For more details see [`AsyncResource`][AsyncResource] documentation.  The `resource_name` needs to stay valid for the lifetime of worker instance.
+collisions in the names. For more details see [`AsyncResource`][AsyncResource] documentation.  The `resource_name` needs to stay valid for the lifetime of the worker instance.
 
 Definition:
 

--- a/doc/asyncworker.md
+++ b/doc/asyncworker.md
@@ -12,12 +12,17 @@
 
 `Nan::AsyncWorker` is an _abstract_ class that you can subclass to have much of the annoying asynchronous queuing and handling taken care of for you. It can even store arbitrary V8 objects for you and have them persist while the asynchronous work is in progress.
 
+This class internally handles the details of creating an [`AsyncResource`][AsyncResource], and running the callback in the
+correct async context. To be able to identify the async resources created by this class in async-hooks, provide a
+`resource_name` to the constructor. It is recommended that the module name be used as a prefix to the `resource_name` to avoid
+collisions in the names. For more details see [`AsyncResource`][AsyncResource] documentation.  The `resource_name` needs to stay valid for the lifetime of worker instance.
+
 Definition:
 
 ```c++
 class AsyncWorker {
  public:
-  explicit AsyncWorker(Callback *callback_);
+  explicit AsyncWorker(Callback *callback_, const char* resource_name = "nan:AsyncWorker");
 
   virtual ~AsyncWorker();
 
@@ -73,9 +78,9 @@ Definition:
 template<class T>
 class AsyncProgressWorkerBase<T> : public AsyncWorker {
  public:
-  explicit AsyncProgressWorker(Callback *callback_);
+  explicit AsyncProgressWorkerBase(Callback *callback_, const char* resource_name = ...);
 
-  virtual ~AsyncProgressWorker();
+  virtual ~AsyncProgressWorkerBase();
 
   void WorkProgress();
 
@@ -108,7 +113,7 @@ Definition:
 template<class T>
 class AsyncProgressQueueWorker<T> : public AsyncWorker {
  public:
-  explicit AsyncProgressQueueWorker(Callback *callback_);
+  explicit AsyncProgressQueueWorker(Callback *callback_, const char* resource_name = "nan:AsyncProgressQueueWorker");
 
   virtual ~AsyncProgressQueueWorker();
 
@@ -137,3 +142,5 @@ Definition:
 ```c++
 void AsyncQueueWorker(AsyncWorker *);
 ```
+
+[AsyncResource]: "node_misc.html#api_nan_asyncresource"

--- a/doc/callback.md
+++ b/doc/callback.md
@@ -22,14 +22,14 @@ class Callback {
 
   v8::Local<v8::Function> operator*() const;
 
-  v8::Local<v8::Value> operator()(AsyncResource* async_resource,
-                                  v8::Local<v8::Object> target,
-                                  int argc = 0,
-                                  v8::Local<v8::Value> argv[] = 0) const;
+  MaybeLocal<v8::Value> operator()(AsyncResource* async_resource,
+                                   v8::Local<v8::Object> target,
+                                   int argc = 0,
+                                   v8::Local<v8::Value> argv[] = 0) const;
 
-  v8::Local<v8::Value> operator()(AsyncResource* async_resource,
-                                  int argc = 0,
-                                  v8::Local<v8::Value> argv[] = 0) const;
+  MaybeLocal<v8::Value> operator()(AsyncResource* async_resource,
+                                   int argc = 0,
+                                   v8::Local<v8::Value> argv[] = 0) const;
 
   void SetFunction(const v8::Local<v8::Function> &fn);
 
@@ -41,13 +41,13 @@ class Callback {
 
   void Reset();
 
-  v8::Local<v8::Value> Call(v8::Local<v8::Object> target,
+  MaybeLocal<v8::Value> Call(v8::Local<v8::Object> target,
                             int argc,
                             v8::Local<v8::Value> argv[],
                             AsyncResource* async_resource) const;
-  v8::Local<v8::Value> Call(int argc,
-                            v8::Local<v8::Value> argv[],
-                            AsyncResource* async_resource) const;
+  MaybeLocal<v8::Value> Call(int argc,
+                             v8::Local<v8::Value> argv[],
+                             AsyncResource* async_resource) const;
 
   // Legacy versions. Use the versions that accept an async_resource instead
   // as they run the callback in the correct async context as specified by the

--- a/doc/callback.md
+++ b/doc/callback.md
@@ -22,11 +22,13 @@ class Callback {
 
   v8::Local<v8::Function> operator*() const;
 
-  v8::Local<v8::Value> operator()(v8::Local<v8::Object> target,
+  v8::Local<v8::Value> operator()(AsyncResource* async_resource,
+                                  v8::Local<v8::Object> target,
                                   int argc = 0,
                                   v8::Local<v8::Value> argv[] = 0) const;
 
-  v8::Local<v8::Value> operator()(int argc = 0,
+  v8::Local<v8::Value> operator()(AsyncResource* async_resource,
+                                  int argc = 0,
                                   v8::Local<v8::Value> argv[] = 0) const;
 
   void SetFunction(const v8::Local<v8::Function> &fn);
@@ -39,6 +41,23 @@ class Callback {
 
   void Reset();
 
+  v8::Local<v8::Value> Call(v8::Local<v8::Object> target,
+                            int argc,
+                            v8::Local<v8::Value> argv[],
+                            AsyncResource* async_resource) const;
+  v8::Local<v8::Value> Call(int argc,
+                            v8::Local<v8::Value> argv[],
+                            AsyncResource* async_resource) const;
+
+  // Legacy versions. Use the versions that accept an async_resource instead
+  // as they run the callback in the correct async context as specified by the
+  // resource.
+  v8::Local<v8::Value> operator()(v8::Local<v8::Object> target,
+                                  int argc = 0,
+                                  v8::Local<v8::Value> argv[] = 0) const;
+
+  v8::Local<v8::Value> operator()(int argc = 0,
+                                  v8::Local<v8::Value> argv[] = 0) const;
   v8::Local<v8::Value> Call(v8::Local<v8::Object> target,
                             int argc,
                             v8::Local<v8::Value> argv[]) const;

--- a/nan.h
+++ b/nan.h
@@ -1486,25 +1486,25 @@ class Callback {
     return this->Call(target, argc, argv);
   }
 
-  inline v8::MaybeLocal<v8::Value> operator()(
+  inline v8::Local<v8::Value> operator()(
+      int argc = 0
+    , v8::Local<v8::Value> argv[] = 0) const {
+    return this->Call(argc, argv);
+  }
+
+  inline MaybeLocal<v8::Value> operator()(
       AsyncResource* resource
     , int argc = 0
     , v8::Local<v8::Value> argv[] = 0) const {
     return this->Call(argc, argv, resource);
   }
 
-  inline v8::MaybeLocal<v8::Value> operator()(
+  inline MaybeLocal<v8::Value> operator()(
       AsyncResource* resource
     , v8::Local<v8::Object> target
     , int argc = 0
     , v8::Local<v8::Value> argv[] = 0) const {
     return this->Call(target, argc, argv, resource);
-  }
-
-  inline v8::Local<v8::Value> operator()(
-      int argc = 0
-    , v8::Local<v8::Value> argv[] = 0) const {
-    return this->Call(argc, argv);
   }
 
   // TODO(kkoopa): remove
@@ -1553,7 +1553,7 @@ class Callback {
 #endif
   }
 
-  inline v8::MaybeLocal<v8::Value>
+  inline MaybeLocal<v8::Value>
   Call(v8::Local<v8::Object> target
      , int argc
      , v8::Local<v8::Value> argv[]
@@ -1569,7 +1569,7 @@ class Callback {
 #endif
   }
 
-  inline v8::MaybeLocal<v8::Value>
+  inline MaybeLocal<v8::Value>
   Call(int argc, v8::Local<v8::Value> argv[], AsyncResource* resource) const {
 #if NODE_MODULE_VERSION >= NODE_8_0_MODULE_VERSION
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
@@ -1590,16 +1590,16 @@ class Callback {
   Persistent<v8::Function> handle_;
 
 #if NODE_MODULE_VERSION >= NODE_8_0_MODULE_VERSION
-  v8::MaybeLocal<v8::Value> Call_(v8::Isolate *isolate
-                                , v8::Local<v8::Object> target
-                                , int argc
-                                , v8::Local<v8::Value> argv[]
-                                , AsyncResource* resource) const {
+  MaybeLocal<v8::Value> Call_(v8::Isolate *isolate
+                            , v8::Local<v8::Object> target
+                            , int argc
+                            , v8::Local<v8::Value> argv[]
+                            , AsyncResource* resource) const {
     EscapableHandleScope scope;
     v8::Local<v8::Function> func = New(handle_);
     auto maybe = resource->runInAsyncScope(target, func, argc, argv);
     v8::Local<v8::Value> local;
-    if (!maybe.ToLocal(&local)) return v8::MaybeLocal<v8::Value>();
+    if (!maybe.ToLocal(&local)) return MaybeLocal<v8::Value>();
     return scope.Escape(local);
   }
 #endif

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -95,6 +95,10 @@
       , "sources"     : [ "cpp/asyncresource.cpp" ]
     }
     , {
+        "target_name" : "callbackcontext"
+      , "sources"     : [ "cpp/callbackcontext.cpp" ]
+    }
+    , {
         "target_name" : "isolatedata"
       , "sources"     : [ "cpp/isolatedata.cpp" ]
     }

--- a/test/cpp/asyncresource.cpp
+++ b/test/cpp/asyncresource.cpp
@@ -7,7 +7,7 @@
  ********************************************************************/
 
 #include <nan.h>
-#include <unistd.h>
+#include "sleep.h"
 
 using namespace Nan;  // NOLINT(build/namespaces)
 
@@ -30,7 +30,7 @@ class DelayRequest : public AsyncResource {
 
 void Delay(uv_work_t* req) {
   DelayRequest *delay_request = static_cast<DelayRequest*>(req->data);
-  sleep(delay_request->milliseconds / 1000);
+  Sleep(delay_request->milliseconds);
 }
 
 void AfterDelay(uv_work_t* req, int status) {

--- a/test/cpp/asyncworker.cpp
+++ b/test/cpp/asyncworker.cpp
@@ -6,10 +6,7 @@
  * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
  ********************************************************************/
 
-#ifndef _WIN32
-#include <unistd.h>
-#define Sleep(x) usleep((x)*1000)
-#endif
+#include "sleep.h"
 #include <nan.h>
 
 using namespace Nan;  // NOLINT(build/namespaces)

--- a/test/cpp/asyncworker.cpp
+++ b/test/cpp/asyncworker.cpp
@@ -17,7 +17,8 @@ using namespace Nan;  // NOLINT(build/namespaces)
 class SleepWorker : public AsyncWorker {
  public:
   SleepWorker(Callback *callback, int milliseconds)
-    : AsyncWorker(callback), milliseconds(milliseconds) {}
+    : AsyncWorker(callback, "nan:test.SleepWorker"),
+      milliseconds(milliseconds) {}
   ~SleepWorker() {}
 
   void Execute () {

--- a/test/cpp/callbackcontext.cpp
+++ b/test/cpp/callbackcontext.cpp
@@ -1,0 +1,66 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2018 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#include <nan.h>
+#include <unistd.h>
+
+using namespace Nan;  // NOLINT(build/namespaces)
+
+class DelayRequest : public AsyncResource {
+ public:
+  DelayRequest(int milliseconds_, v8::Local<v8::Function> callback_)
+    : AsyncResource(MaybeLocal<v8::Object>(), "nan:test.DelayRequest"),
+      callback(callback_),
+      milliseconds(milliseconds_) {
+      request.data = this;
+    }
+  ~DelayRequest() {}
+
+  Callback callback;
+  uv_work_t request;
+  int milliseconds;
+};
+
+void Delay(uv_work_t* req) {
+  DelayRequest *delay_request = static_cast<DelayRequest*>(req->data);
+  sleep(delay_request->milliseconds / 1000);
+}
+
+void AfterDelay(uv_work_t* req, int status) {
+  HandleScope scope;
+
+  DelayRequest *delay_request = static_cast<DelayRequest*>(req->data);
+  v8::Local<v8::Value> argv[0] = {};
+
+  v8::Local<v8::Object> target = New<v8::Object>();
+
+  // Run the callback in the async context.
+  delay_request->callback.Call(target, 0, argv, delay_request);
+
+  delete delay_request;
+}
+
+NAN_METHOD(Delay) {
+  int delay = To<int>(info[0]).FromJust();
+  v8::Local<v8::Function> cb = To<v8::Function>(info[1]).ToLocalChecked();
+
+  DelayRequest* delay_request = new DelayRequest(delay, cb);
+
+  uv_queue_work(
+      uv_default_loop()
+    , &delay_request->request
+    , Delay
+    , reinterpret_cast<uv_after_work_cb>(AfterDelay));
+}
+
+NAN_MODULE_INIT(Init) {
+  Set(target, New<v8::String>("delay").ToLocalChecked(),
+    GetFunction(New<v8::FunctionTemplate>(Delay)).ToLocalChecked());
+}
+
+NODE_MODULE(asyncresource, Init)

--- a/test/cpp/callbackcontext.cpp
+++ b/test/cpp/callbackcontext.cpp
@@ -7,7 +7,7 @@
  ********************************************************************/
 
 #include <nan.h>
-#include <unistd.h>
+#include "sleep.h"
 
 using namespace Nan;  // NOLINT(build/namespaces)
 
@@ -28,7 +28,7 @@ class DelayRequest : public AsyncResource {
 
 void Delay(uv_work_t* req) {
   DelayRequest *delay_request = static_cast<DelayRequest*>(req->data);
-  sleep(delay_request->milliseconds / 1000);
+  Sleep(delay_request->milliseconds);
 }
 
 void AfterDelay(uv_work_t* req, int status) {

--- a/test/cpp/sleep.h
+++ b/test/cpp/sleep.h
@@ -10,5 +10,3 @@
 #include <unistd.h>
 #define Sleep(x) usleep((x)*1000)
 #endif
-
-

--- a/test/cpp/sleep.h
+++ b/test/cpp/sleep.h
@@ -1,0 +1,14 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2017 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef _WIN32
+#include <unistd.h>
+#define Sleep(x) usleep((x)*1000)
+#endif
+
+

--- a/test/js/callbackcontext-test.js
+++ b/test/js/callbackcontext-test.js
@@ -1,0 +1,73 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2018 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+const bindingName = 'callbackcontext';
+
+try {
+  require('async_hooks');
+} catch (e) {
+  console.log('1..0 # Skipped: ' + bindingName);
+  process.exit(0);
+}
+
+const test     = require('tap').test
+    , testRoot = require('path').resolve(__dirname, '..')
+    , delay = require('bindings')({ module_root: testRoot, bindings: bindingName }).delay
+    , asyncHooks = require('async_hooks');
+
+test(bindingName, function (t) {
+  t.plan(7);
+
+  var resourceAsyncId;
+  var originalExecutionAsyncId;
+  var beforeCalled = false;
+  var afterCalled = false;
+  var destroyCalled = false;
+
+  var hooks = asyncHooks.createHook({
+    init: function(asyncId, type, triggerAsyncId, resource) {
+      if (type === 'nan:test.DelayRequest') {
+        resourceAsyncId = asyncId;
+      }
+    },
+    before: function(asyncId) {
+      if (asyncId === resourceAsyncId) {
+        beforeCalled = true;
+      }
+    },
+    after: function(asyncId) {
+      if (asyncId === resourceAsyncId) {
+        afterCalled = true;
+      }
+    },
+    destroy: function(asyncId) {
+      if (asyncId === resourceAsyncId) {
+        destroyCalled = true;
+      }
+    }
+
+  });
+  hooks.enable();
+
+  originalExecutionAsyncId = asyncHooks.executionAsyncId();
+  delay(1000, function() {
+    t.equal(asyncHooks.executionAsyncId(), resourceAsyncId,
+            'callback should have the correct execution context');
+    t.equal(asyncHooks.triggerAsyncId(), originalExecutionAsyncId,
+            'callback should have the correct trigger context');
+    t.ok(beforeCalled, 'before should have been called');
+    t.notOk(afterCalled, 'after should not have been called yet');
+    setTimeout(function() {
+      t.ok(afterCalled, 'after should have been called');
+      t.ok(destroyCalled, 'destroy should have been called');
+      t.equal(asyncHooks.triggerAsyncId(), resourceAsyncId,
+              'setTimeout should have been triggered by the async resource');
+      hooks.disable();
+    }, 1);
+  });
+});


### PR DESCRIPTION
There are three commits here. Each can be individually reviewed.

Background: https://github.com/nodejs/node/issues/13254.

Continuing on from #729, this adds async context support to Nan::Callback and Nan::AsyncWorker (and subclasses). 

I have not added any deprecations to the legacy `Nan::Callback::Call`s versions yet. I propose to do that in the next PR.