### PR TITLE
Deprecate old Callback::Call

### DIFF
--- a/doc/callback.md
+++ b/doc/callback.md
@@ -49,7 +49,7 @@ class Callback {
                              v8::Local<v8::Value> argv[],
                              AsyncResource* async_resource) const;
 
-  // Legacy versions. Use the versions that accept an async_resource instead
+  // Deprecated versions. Use the versions that accept an async_resource instead
   // as they run the callback in the correct async context as specified by the
   // resource.
   v8::Local<v8::Value> operator()(v8::Local<v8::Object> target,

--- a/doc/callback.md
+++ b/doc/callback.md
@@ -51,7 +51,8 @@ class Callback {
 
   // Deprecated versions. Use the versions that accept an async_resource instead
   // as they run the callback in the correct async context as specified by the
-  // resource.
+  // resource. If you want to call a synchronous JS function (i.e. on a
+  // non-empty JS stack), you can use Nan::Call instead.
   v8::Local<v8::Value> operator()(v8::Local<v8::Object> target,
                                   int argc = 0,
                                   v8::Local<v8::Value> argv[] = 0) const;

--- a/doc/maybe_types.md
+++ b/doc/maybe_types.md
@@ -130,7 +130,7 @@ Signature:
 
 ```c++
 Nan::MaybeLocal<v8::Value> Nan::Call(v8::Local<v8::Function> fun, v8::Local<v8::Object> recv, int argc, v8::Local<v8::Value> argv[]);
-Nan::MaybeLocal<v8::Value> Nan::Call(Nan::Callback* callback, v8::Local<v8::Object> recv,
+Nan::MaybeLocal<v8::Value> Nan::Call(const Nan::Callback& callback, v8::Local<v8::Object> recv,
  int argc, v8::Local<v8::Value> argv[]);
 ```
 

--- a/doc/maybe_types.md
+++ b/doc/maybe_types.md
@@ -122,12 +122,16 @@ template<typename T> Nan::Maybe<T> Nan::Just(const T &t);
 <a name="api_nan_call"></a>
 ### Nan::Call()
 
-A helper method for calling [`v8::Function#Call()`](https://v8docs.nodesource.com/io.js-3.3/d5/d54/classv8_1_1_function.html#a468a89f737af0612db10132799c827c0) in a way compatible across supported versions of V8.
+A helper method for calling a synchronous [`v8::Function#Call()`](https://v8docs.nodesource.com/io.js-3.3/d5/d54/classv8_1_1_function.html#a468a89f737af0612db10132799c827c0) in a way compatible across supported versions of V8.
+
+For asynchronous callbacks, use Nan::Callback::Call along with an AsyncResource.
 
 Signature:
 
 ```c++
 Nan::MaybeLocal<v8::Value> Nan::Call(v8::Local<v8::Function> fun, v8::Local<v8::Object> recv, int argc, v8::Local<v8::Value> argv[]);
+Nan::MaybeLocal<v8::Value> Nan::Call(Nan::Callback* callback, v8::Local<v8::Object> recv,
+ int argc, v8::Local<v8::Value> argv[]);
 ```
 
 

--- a/nan.h
+++ b/nan.h
@@ -1479,17 +1479,19 @@ class Callback {
     return !operator==(other);
   }
 
+  // TODO(ofrobots): This is dangerous as it allows a call without async
+  // context. In a semver-major consider disallowing this.
   inline
   v8::Local<v8::Function> operator*() const { return GetFunction(); }
 
-  inline v8::Local<v8::Value> operator()(
+  NAN_DEPRECATED inline v8::Local<v8::Value> operator()(
       v8::Local<v8::Object> target
     , int argc = 0
     , v8::Local<v8::Value> argv[] = 0) const {
     return this->Call(target, argc, argv);
   }
 
-  inline v8::Local<v8::Value> operator()(
+  NAN_DEPRECATED inline v8::Local<v8::Value> operator()(
       int argc = 0
     , v8::Local<v8::Value> argv[] = 0) const {
     return this->Call(argc, argv);
@@ -1523,6 +1525,8 @@ class Callback {
     handle_.Reset();
   }
 
+  // TODO(ofrobots): This is dangerous as it allows a call without async
+  // context. In a semver-major consider disallowing this.
   inline v8::Local<v8::Function> GetFunction() const {
     return New(handle_);
   }
@@ -1531,7 +1535,7 @@ class Callback {
     return handle_.IsEmpty();
   }
 
-  inline v8::Local<v8::Value>
+  NAN_DEPRECATED inline v8::Local<v8::Value>
   Call(v8::Local<v8::Object> target
      , int argc
      , v8::Local<v8::Value> argv[]) const {
@@ -1543,7 +1547,7 @@ class Callback {
 #endif
   }
 
-  inline v8::Local<v8::Value>
+  NAN_DEPRECATED inline v8::Local<v8::Value>
   Call(int argc, v8::Local<v8::Value> argv[]) const {
 #if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
     v8::Isolate *isolate = v8::Isolate::GetCurrent();

--- a/nan.h
+++ b/nan.h
@@ -1479,8 +1479,6 @@ class Callback {
     return !operator==(other);
   }
 
-  // TODO(ofrobots): This is dangerous as it allows a call without async
-  // context. In a semver-major consider disallowing this.
   inline
   v8::Local<v8::Function> operator*() const { return GetFunction(); }
 
@@ -1525,8 +1523,6 @@ class Callback {
     handle_.Reset();
   }
 
-  // TODO(ofrobots): This is dangerous as it allows a call without async
-  // context. In a semver-major consider disallowing this.
   inline v8::Local<v8::Function> GetFunction() const {
     return New(handle_);
   }
@@ -1535,6 +1531,10 @@ class Callback {
     return handle_.IsEmpty();
   }
 
+  // Deprecated: For async callbacks Use the versions that accept an
+  // AsyncResource. If this callback does not correspond to an async resource,
+  // that is, it is a synchronous function call on a non-empty JS stack, you
+  // should Nan::Call instead.
   NAN_DEPRECATED inline v8::Local<v8::Value>
   Call(v8::Local<v8::Object> target
      , int argc
@@ -1547,6 +1547,10 @@ class Callback {
 #endif
   }
 
+  // Deprecated: For async callbacks Use the versions that accept an
+  // AsyncResource. If this callback does not correspond to an async resource,
+  // that is, it is a synchronous function call on a non-empty JS stack, you
+  // should Nan::Call instead.
   NAN_DEPRECATED inline v8::Local<v8::Value>
   Call(int argc, v8::Local<v8::Value> argv[]) const {
 #if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
@@ -1653,6 +1657,14 @@ class Callback {
   }
 #endif
 };
+
+inline MaybeLocal<v8::Value> Call(
+    Nan::Callback* callback
+  , v8::Local<v8::Object> recv
+  , int argc
+  , v8::Local<v8::Value> argv[]) {
+  return Call(callback->GetFunction(), recv, argc, argv);
+}
 
 /* abstract */ class AsyncWorker {
  public:

--- a/nan.h
+++ b/nan.h
@@ -1659,11 +1659,11 @@ class Callback {
 };
 
 inline MaybeLocal<v8::Value> Call(
-    Nan::Callback* callback
+    const Nan::Callback& callback
   , v8::Local<v8::Object> recv
   , int argc
   , v8::Local<v8::Value> argv[]) {
-  return Call(callback->GetFunction(), recv, argc, argv);
+  return Call(*callback, recv, argc, argv);
 }
 
 /* abstract */ class AsyncWorker {

--- a/test/cpp/asyncprogressqueueworker.cpp
+++ b/test/cpp/asyncprogressqueueworker.cpp
@@ -35,7 +35,7 @@ class ProgressQueueWorker : public AsyncProgressQueueWorker<char> {
     v8::Local<v8::Value> argv[] = {
         New<v8::Integer>(*reinterpret_cast<int*>(const_cast<char*>(data)))
     };
-    progress->Call(1, argv);
+    progress->Call(1, argv, async_resource);
   }
 
  private:

--- a/test/cpp/asyncprogressqueueworkerstream.cpp
+++ b/test/cpp/asyncprogressqueueworkerstream.cpp
@@ -54,7 +54,7 @@ class ProgressQueueWorker : public AsyncProgressQueueWorker<T> {
       New<v8::Integer>(data->data));
 
     v8::Local<v8::Value> argv[] = { obj };
-    progress->Call(1, argv);
+    progress->Call(1, argv, this->async_resource);
   }
 
  private:

--- a/test/cpp/asyncprogressworker.cpp
+++ b/test/cpp/asyncprogressworker.cpp
@@ -41,7 +41,7 @@ class ProgressWorker : public AsyncProgressWorker {
     v8::Local<v8::Value> argv[] = {
         New<v8::Integer>(*reinterpret_cast<int*>(const_cast<char*>(data)))
     };
-    progress->Call(1, argv);
+    progress->Call(1, argv, async_resource);
   }
 
  private:

--- a/test/cpp/asyncprogressworkersignal.cpp
+++ b/test/cpp/asyncprogressworkersignal.cpp
@@ -39,7 +39,7 @@ class ProgressWorker : public AsyncProgressWorker {
     HandleScope scope;
 
     v8::Local<v8::Value> arg = New<v8::Boolean>(data == NULL && count == 0);
-    progress->Call(1, &arg);
+    progress->Call(1, &arg, async_resource);
   }
 
  private:

--- a/test/cpp/asyncprogressworkerstream.cpp
+++ b/test/cpp/asyncprogressworkerstream.cpp
@@ -61,7 +61,7 @@ class ProgressWorker : public AsyncProgressWorkerBase<T> {
       New<v8::Integer>(data->data));
 
     v8::Local<v8::Value> argv[] = { obj };
-    progress->Call(1, argv);
+    progress->Call(1, argv, this->async_resource);
   }
 
  private:

--- a/test/cpp/bufferworkerpersistent.cpp
+++ b/test/cpp/bufferworkerpersistent.cpp
@@ -37,13 +37,13 @@ class BufferWorker : public AsyncWorker {
     HandleScope scope;
 
     v8::Local<v8::Value> handle = GetFromPersistent("buffer");
-    callback->Call(1, &handle);
+    callback->Call(1, &handle, async_resource);
 
     handle = GetFromPersistent(New("puffer").ToLocalChecked());
-    callback->Call(1, &handle);
+    callback->Call(1, &handle, async_resource);
 
     handle = GetFromPersistent(0u);
-    callback->Call(1, &handle);
+    callback->Call(1, &handle, async_resource);
   }
 
  private:

--- a/test/cpp/nancallback.cpp
+++ b/test/cpp/nancallback.cpp
@@ -11,17 +11,20 @@
 using namespace Nan;  // NOLINT(build/namespaces)
 
 NAN_METHOD(GlobalContext) {
-  Callback(To<v8::Function>(info[0]).ToLocalChecked()).Call(0, NULL);
+  AsyncResource resource("nan:test.nancallback");
+  Callback(To<v8::Function>(info[0]).ToLocalChecked()).Call(0, NULL, &resource);
 }
 
 NAN_METHOD(SpecificContext) {
+  AsyncResource resource("nan:test.nancallback");
   Callback cb(To<v8::Function>(info[0]).ToLocalChecked());
-  cb.Call(GetCurrentContext()->Global(), 0, NULL);
+  cb.Call(GetCurrentContext()->Global(), 0, NULL, &resource);
 }
 
 NAN_METHOD(CustomReceiver) {
+  AsyncResource resource("nan:test.nancallback");
   Callback cb(To<v8::Function>(info[0]).ToLocalChecked());
-  cb.Call(To<v8::Object>(info[1]).ToLocalChecked(), 0, NULL);
+  cb.Call(To<v8::Object>(info[1]).ToLocalChecked(), 0, NULL, &resource);
 }
 
 NAN_METHOD(CompareCallbacks) {
@@ -38,7 +41,8 @@ NAN_METHOD(CallDirect) {
 }
 
 NAN_METHOD(CallAsFunction) {
-  Callback(To<v8::Function>(info[0]).ToLocalChecked())();
+  AsyncResource resource("nan:test.nancallback");
+  Callback(To<v8::Function>(info[0]).ToLocalChecked())(&resource);
 }
 
 NAN_METHOD(ResetUnset) {


### PR DESCRIPTION
Note: this builds on top of commits from #732. I will rebase after that PR lands.

Now that we have exposed the concept of `AsyncResource` to `Nan::Callback` and `Nan::AsyncWorker`, let's go ahead and deprecate the legacy `Callback::Call` functions that do not accept a context.

Related: deprecation of legacy `MakeCallback` in Node: https://github.com/nodejs/node/pull/18632