### PR TITLE
Deprecation warnings

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1486,13 +1486,26 @@ class Callback {
       v8::Local<v8::Object> target
     , int argc = 0
     , v8::Local<v8::Value> argv[] = 0) const {
-    return this->Call(target, argc, argv);
+#if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+    v8::Isolate *isolate = v8::Isolate::GetCurrent();
+    return Call_(isolate, target, argc, argv);
+#else
+    return Call_(target, argc, argv);
+#endif
   }
 
   NAN_DEPRECATED inline v8::Local<v8::Value> operator()(
       int argc = 0
     , v8::Local<v8::Value> argv[] = 0) const {
-    return this->Call(argc, argv);
+#if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+    v8::Isolate *isolate = v8::Isolate::GetCurrent();
+    v8::EscapableHandleScope scope(isolate);
+    return scope.Escape(
+        Call_(isolate, isolate->GetCurrentContext()->Global(), argc, argv));
+#else
+    v8::HandleScope scope;
+    return scope.Close(Call_(v8::Context::GetCurrent()->Global(), argc, argv));
+#endif
   }
 
   inline MaybeLocal<v8::Value> operator()(

--- a/nan_json.h
+++ b/nan_json.h
@@ -134,14 +134,17 @@ class JSON {
 #if NAN_JSON_H_NEED_PARSE
   inline v8::Local<v8::Value> parse(v8::Local<v8::Value> arg) {
     assert(!parse_cb_.IsEmpty() && "parse_cb_ is empty");
-    return parse_cb_.Call(1, &arg);
+    AsyncResource resource("nan:JSON.parse");
+    return parse_cb_.Call(1, &arg, &resource).FromMaybe(v8::Local<v8::Value>());
   }
 #endif  // NAN_JSON_H_NEED_PARSE
 
 #if NAN_JSON_H_NEED_STRINGIFY
   inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg) {
     assert(!stringify_cb_.IsEmpty() && "stringify_cb_ is empty");
-    return stringify_cb_.Call(1, &arg);
+    AsyncResource resource("nan:JSON.stringify");
+    return stringify_cb_.Call(1, &arg, &resource)
+        .FromMaybe(v8::Local<v8::Value>());
   }
 
   inline v8::Local<v8::Value> stringify(v8::Local<v8::Value> arg,
@@ -153,7 +156,9 @@ class JSON {
       Nan::Null(),
       gap
     };
-    return stringify_cb_.Call(3, argv);
+    AsyncResource resource("nan:JSON.stringify");
+    return stringify_cb_.Call(3, argv, &resource)
+        .FromMaybe(v8::Local<v8::Value>());
   }
 #endif  // NAN_JSON_H_NEED_STRINGIFY
 };


### PR DESCRIPTION
I was about to publish 2.9.0 when I noticed spurious deprecation warnings. This should fix the problem. Since I have already tagged and pushed 2.9.0, I guess the best course of action is to skip publishing 2.9.0 to npm and jump directly to 2.9.1.