### PR TITLE
Bandaid for async hooks

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1280,7 +1280,7 @@ class Utf8String {
     AsyncResource(
         v8::Local<v8::String> name
       , v8::Local<v8::Object> resource = New<v8::Object>()) {
-#if NODE_MODULE_VERSION >= NODE_8_0_MODULE_VERSION
+#if NODE_MODULE_VERSION >= NODE_9_0_MODULE_VERSION
       v8::Isolate* isolate = v8::Isolate::GetCurrent();
 
       if (resource.IsEmpty()) {
@@ -1294,7 +1294,7 @@ class Utf8String {
     AsyncResource(
         const char* name
       , v8::Local<v8::Object> resource = New<v8::Object>()) {
-#if NODE_MODULE_VERSION >= NODE_8_0_MODULE_VERSION
+#if NODE_MODULE_VERSION >= NODE_9_0_MODULE_VERSION
       v8::Isolate* isolate = v8::Isolate::GetCurrent();
 
       if (resource.IsEmpty()) {
@@ -1308,7 +1308,7 @@ class Utf8String {
     }
 
     ~AsyncResource() {
-#if NODE_MODULE_VERSION >= NODE_8_0_MODULE_VERSION
+#if NODE_MODULE_VERSION >= NODE_9_0_MODULE_VERSION
       v8::Isolate* isolate = v8::Isolate::GetCurrent();
       node::EmitAsyncDestroy(isolate, context);
 #endif
@@ -1319,7 +1319,7 @@ class Utf8String {
       , v8::Local<v8::Function> func
       , int argc
       , v8::Local<v8::Value>* argv) {
-#if NODE_MODULE_VERSION < NODE_8_0_MODULE_VERSION
+#if NODE_MODULE_VERSION < NODE_9_0_MODULE_VERSION
       return MakeCallback(target, func, argc, argv);
 #else
       return node::MakeCallback(
@@ -1332,7 +1332,7 @@ class Utf8String {
       , v8::Local<v8::String> symbol
       , int argc
       , v8::Local<v8::Value>* argv) {
-#if NODE_MODULE_VERSION < NODE_8_0_MODULE_VERSION
+#if NODE_MODULE_VERSION < NODE_9_0_MODULE_VERSION
       return MakeCallback(target, symbol, argc, argv);
 #else
       return node::MakeCallback(
@@ -1345,7 +1345,7 @@ class Utf8String {
       , const char* method
       , int argc
       , v8::Local<v8::Value>* argv) {
-#if NODE_MODULE_VERSION < NODE_8_0_MODULE_VERSION
+#if NODE_MODULE_VERSION < NODE_9_0_MODULE_VERSION
       return MakeCallback(target, method, argc, argv);
 #else
       return node::MakeCallback(
@@ -1355,7 +1355,7 @@ class Utf8String {
 
    private:
     NAN_DISALLOW_ASSIGN_COPY_MOVE(AsyncResource)
-#if NODE_MODULE_VERSION >= NODE_8_0_MODULE_VERSION
+#if NODE_MODULE_VERSION >= NODE_9_0_MODULE_VERSION
     node::async_context context;
 #endif
   };
@@ -1582,7 +1582,7 @@ class Callback {
      , int argc
      , v8::Local<v8::Value> argv[]
      , AsyncResource* resource) const {
-#if NODE_MODULE_VERSION >= NODE_8_0_MODULE_VERSION
+#if NODE_MODULE_VERSION >= NODE_9_0_MODULE_VERSION
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
     return Call_(isolate, target, argc, argv, resource);
 #elif NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
@@ -1595,7 +1595,7 @@ class Callback {
 
   inline MaybeLocal<v8::Value>
   Call(int argc, v8::Local<v8::Value> argv[], AsyncResource* resource) const {
-#if NODE_MODULE_VERSION >= NODE_8_0_MODULE_VERSION
+#if NODE_MODULE_VERSION >= NODE_9_0_MODULE_VERSION
     v8::Isolate* isolate = v8::Isolate::GetCurrent();
     return Call(isolate->GetCurrentContext()->Global(), argc, argv, resource);
 #elif NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
@@ -1613,7 +1613,7 @@ class Callback {
   NAN_DISALLOW_ASSIGN_COPY_MOVE(Callback)
   Persistent<v8::Function> handle_;
 
-#if NODE_MODULE_VERSION >= NODE_8_0_MODULE_VERSION
+#if NODE_MODULE_VERSION >= NODE_9_0_MODULE_VERSION
   MaybeLocal<v8::Value> Call_(v8::Isolate *isolate
                             , v8::Local<v8::Object> target
                             , int argc

--- a/test/js/asyncresource-test.js
+++ b/test/js/asyncresource-test.js
@@ -6,6 +6,11 @@
  * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
  ********************************************************************/
 
+const version = process.versions.node.split('.');
+if (version[0] < 9) {
+  process.exit(0);
+}
+
 try {
   require('async_hooks');
 } catch (e) {

--- a/test/js/asyncworker-test.js
+++ b/test/js/asyncworker-test.js
@@ -6,6 +6,7 @@
  * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
  ********************************************************************/
 
+const version = process.versions.node.split('.');
 const test     = require('tap').test
     , testRoot = require('path').resolve(__dirname, '..')
     , bindings = require('bindings')({ module_root: testRoot, bindings: 'asyncworker' });
@@ -30,6 +31,12 @@ test('asyncworker', function (t) {
 
 test('asyncworker context', function (t) {
   var asyncHooks;
+  if (version[0] < 9) {
+    t.ok(true);
+    t.end();
+    return;
+  }
+
   try {
     asyncHooks = require('async_hooks');
   } catch (e) {

--- a/test/js/callbackcontext-test.js
+++ b/test/js/callbackcontext-test.js
@@ -8,6 +8,12 @@
 
 const bindingName = 'callbackcontext';
 
+const version = process.versions.node.split('.');
+if (version[0] < 9) {
+  console.log('1..0 # Skipped: ' + bindingName);
+  process.exit(0);
+}
+
 try {
   require('async_hooks');
 } catch (e) {


### PR DESCRIPTION
Temporary fix disabling async_hooks for Node 8 below 8.6. Having some non-obvious issues with getting the older `async_hooks` API working. Addresses #735.