### PR TITLE
deduplication of DefineOwnProperty() wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ LINT_SOURCES = \
 	nan_converters.h \
 	nan_converters_43_inl.h \
 	nan_converters_pre_43_inl.h \
+	nan_define_own_property_helper.h \
 	nan_implementation_12_inl.h \
 	nan_implementation_pre_12_inl.h \
 	nan_json.h \
@@ -105,6 +106,7 @@ docs: README.md doc/.build.sh doc/asyncworker.md doc/buffers.md doc/callback.md 
 $(ADDONS): nan.h nan_new.h nan_implementation_pre_12_inl.h nan_implementation_12_inl.h \
 		nan_callbacks.h nan_callbacks_12_inl.h nan_callbacks_pre_12_inl.h \
 		nan_converters.h nan_converters_43_inl.h nan_converters_pre_43_inl.h \
+		nan_define_own_property_helper.h \
 		nan_json.h nan_maybe_43_inl.h nan_maybe_pre_43_inl.h \
 		nan_persistent_12_inl.h nan_persistent_pre_12_inl.h nan_private.h \
 		nan_weak.h nan_string_bytes.h test/binding.gyp $(SOURCES)

--- a/nan_define_own_property_helper.h
+++ b/nan_define_own_property_helper.h
@@ -9,6 +9,8 @@
 #ifndef NAN_DEFINE_OWN_PROPERTY_HELPER_H_
 #define NAN_DEFINE_OWN_PROPERTY_HELPER_H_
 
+namespace imp {
+
 inline Maybe<bool> DefineOwnPropertyHelper(
     v8::PropertyAttribute current
   , v8::Handle<v8::Object> obj
@@ -21,5 +23,7 @@ inline Maybe<bool> DefineOwnPropertyHelper(
              ? Just<bool>(obj->ForceSet(key, value, attribs))
              : Nothing<bool>();
 }
+
+}  // end of namespace imp
 
 #endif  // NAN_DEFINE_OWN_PROPERTY_HELPER_H_

--- a/nan_define_own_property_helper.h
+++ b/nan_define_own_property_helper.h
@@ -1,0 +1,25 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2018 NAN contributors
+ *
+ * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#ifndef NAN_DEFINE_OWN_PROPERTY_HELPER_H_
+#define NAN_DEFINE_OWN_PROPERTY_HELPER_H_
+
+inline Maybe<bool> DefineOwnPropertyHelper(
+    v8::PropertyAttribute current
+  , v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key
+  , v8::Handle<v8::Value> value
+  , v8::PropertyAttribute attribs = v8::None) {
+  return !(current & v8::DontDelete) ||                     // configurable OR
+                  (!(current & v8::ReadOnly) &&             // writable AND
+                   !((attribs ^ current) & ~v8::ReadOnly))  // same excluding RO
+             ? Just<bool>(obj->ForceSet(key, value, attribs))
+             : Nothing<bool>();
+}
+
+#endif  // NAN_DEFINE_OWN_PROPERTY_HELPER_H_

--- a/nan_maybe_43_inl.h
+++ b/nan_maybe_43_inl.h
@@ -123,7 +123,7 @@ inline Maybe<bool> DefineOwnProperty(
     return Nothing<bool>();
   }
   v8::PropertyAttribute current = maybeCurrent.FromJust();
-  return DefineOwnPropertyHelper(current, obj, key, value, attribs);
+  return imp::DefineOwnPropertyHelper(current, obj, key, value, attribs);
 #endif
 }
 

--- a/nan_maybe_43_inl.h
+++ b/nan_maybe_43_inl.h
@@ -102,6 +102,10 @@ inline Maybe<bool> Set(
   return obj->Set(isolate->GetCurrentContext(), index, value);
 }
 
+#if NODE_MODULE_VERSION < NODE_4_0_MODULE_VERSION
+#include "nan_define_own_property_helper.h"  // NOLINT(build/include)
+#endif
+
 inline Maybe<bool> DefineOwnProperty(
     v8::Local<v8::Object> obj
   , v8::Local<v8::String> key
@@ -119,11 +123,7 @@ inline Maybe<bool> DefineOwnProperty(
     return Nothing<bool>();
   }
   v8::PropertyAttribute current = maybeCurrent.FromJust();
-  return !(current & v8::DontDelete) ||                     // configurable OR
-                  (!(current & v8::ReadOnly) &&             // writable AND
-                   !((attribs ^ current) & ~v8::ReadOnly))  // same excluding RO
-             ? Just<bool>(obj->ForceSet(key, value, attribs))
-             : Nothing<bool>();
+  return DefineOwnPropertyHelper(current, obj, key, value, attribs);
 #endif
 }
 

--- a/nan_maybe_pre_43_inl.h
+++ b/nan_maybe_pre_43_inl.h
@@ -148,17 +148,15 @@ inline Maybe<bool> Set(
   return Just<bool>(obj->Set(index, value));
 }
 
+#include "nan_define_own_property_helper.h"  // NOLINT(build/include)
+
 inline Maybe<bool> DefineOwnProperty(
     v8::Handle<v8::Object> obj
   , v8::Handle<v8::String> key
   , v8::Handle<v8::Value> value
   , v8::PropertyAttribute attribs = v8::None) {
   v8::PropertyAttribute current = obj->GetPropertyAttributes(key);
-  return !(current & v8::DontDelete) ||                     // configurable OR
-                  (!(current & v8::ReadOnly) &&             // writable AND
-                   !((attribs ^ current) & ~v8::ReadOnly))  // same excluding RO
-             ? Just<bool>(obj->ForceSet(key, value, attribs))
-             : Nothing<bool>();
+  return DefineOwnPropertyHelper(current, obj, key, value, attribs);
 }
 
 NAN_DEPRECATED inline Maybe<bool> ForceSet(

--- a/nan_maybe_pre_43_inl.h
+++ b/nan_maybe_pre_43_inl.h
@@ -156,7 +156,7 @@ inline Maybe<bool> DefineOwnProperty(
   , v8::Handle<v8::Value> value
   , v8::PropertyAttribute attribs = v8::None) {
   v8::PropertyAttribute current = obj->GetPropertyAttributes(key);
-  return DefineOwnPropertyHelper(current, obj, key, value, attribs);
+  return imp::DefineOwnPropertyHelper(current, obj, key, value, attribs);
 }
 
 NAN_DEPRECATED inline Maybe<bool> ForceSet(


### PR DESCRIPTION
This adds a new file called `nan_define_own_property_helper.h` that contains a deduplicated code block taken from very similar code between `nan_maybe_43_inl.h` and `nan_maybe_pre_43_inl.h `

To anyone looking and scratching their head as to how the code block in  `nan_maybe_43_inl.h` ever gets reached at all, this apparently happens in io.js 3 (see #725)

I wasn't sure what to name the common function, so I went with `DefineOwnPropertyHelper()`, but I'm open to other suggestions...

As discussed: https://github.com/nodejs/nan/pull/728#discussion_r167025257