### PR TITLE
test/cpp: deduplicate Sleep() macro

### DIFF
--- a/test/cpp/asyncprogressworker.cpp
+++ b/test/cpp/asyncprogressworker.cpp
@@ -6,11 +6,8 @@
  * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
  ********************************************************************/
 
-#ifndef _WIN32
-#include <unistd.h>
-#define Sleep(x) usleep((x)*1000)
-#endif
 #include <nan.h>
+#include "sleep.h"  // NOLINT(build/include)
 
 using namespace Nan;  // NOLINT(build/namespaces)
 

--- a/test/cpp/asyncprogressworker.cpp
+++ b/test/cpp/asyncprogressworker.cpp
@@ -7,6 +7,7 @@
  ********************************************************************/
 
 #include <nan.h>
+
 #include "sleep.h"  // NOLINT(build/include)
 
 using namespace Nan;  // NOLINT(build/namespaces)

--- a/test/cpp/asyncprogressworkersignal.cpp
+++ b/test/cpp/asyncprogressworkersignal.cpp
@@ -6,11 +6,8 @@
  * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
  ********************************************************************/
 
-#ifndef _WIN32
-#include <unistd.h>
-#define Sleep(x) usleep((x)*1000)
-#endif
 #include <nan.h>
+#include "sleep.h"  // NOLINT(build/include)
 
 using namespace Nan;  // NOLINT(build/namespaces)
 

--- a/test/cpp/asyncprogressworkersignal.cpp
+++ b/test/cpp/asyncprogressworkersignal.cpp
@@ -7,6 +7,7 @@
  ********************************************************************/
 
 #include <nan.h>
+
 #include "sleep.h"  // NOLINT(build/include)
 
 using namespace Nan;  // NOLINT(build/namespaces)

--- a/test/cpp/asyncprogressworkerstream.cpp
+++ b/test/cpp/asyncprogressworkerstream.cpp
@@ -6,11 +6,8 @@
  * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
  ********************************************************************/
 
-#ifndef _WIN32
-#include <unistd.h>
-#define Sleep(x) usleep((x)*1000)
-#endif
 #include <nan.h>
+#include "sleep.h"  // NOLINT(build/include)
 
 using namespace Nan;  // NOLINT(build/namespaces)
 

--- a/test/cpp/asyncprogressworkerstream.cpp
+++ b/test/cpp/asyncprogressworkerstream.cpp
@@ -7,6 +7,7 @@
  ********************************************************************/
 
 #include <nan.h>
+
 #include "sleep.h"  // NOLINT(build/include)
 
 using namespace Nan;  // NOLINT(build/namespaces)

--- a/test/cpp/bufferworkerpersistent.cpp
+++ b/test/cpp/bufferworkerpersistent.cpp
@@ -6,11 +6,8 @@
  * MIT License <https://github.com/nodejs/nan/blob/master/LICENSE.md>
  ********************************************************************/
 
-#ifndef _WIN32
-#include <unistd.h>
-#define Sleep(x) usleep((x)*1000)
-#endif
 #include <nan.h>
+#include "sleep.h"  // NOLINT(build/include)
 
 using namespace Nan;  // NOLINT(build/namespaces)
 

--- a/test/cpp/bufferworkerpersistent.cpp
+++ b/test/cpp/bufferworkerpersistent.cpp
@@ -7,6 +7,7 @@
  ********************************************************************/
 
 #include <nan.h>
+
 #include "sleep.h"  // NOLINT(build/include)
 
 using namespace Nan;  // NOLINT(build/namespaces)


### PR DESCRIPTION
A nice new `Sleep()` macro has been added in a header file.  Let's all use it.