### PR TITLE
add Nan::Call overload

### DIFF
--- a/doc/maybe_types.md
+++ b/doc/maybe_types.md
@@ -132,6 +132,7 @@ Signature:
 Nan::MaybeLocal<v8::Value> Nan::Call(v8::Local<v8::Function> fun, v8::Local<v8::Object> recv, int argc, v8::Local<v8::Value> argv[]);
 Nan::MaybeLocal<v8::Value> Nan::Call(const Nan::Callback& callback, v8::Local<v8::Object> recv,
  int argc, v8::Local<v8::Value> argv[]);
+Nan::MaybeLocal<v8::Value> Nan::Call(const Nan::Callback& callback, int argc, v8::Local<v8::Value> argv[]);
 ```
 
 

--- a/nan.h
+++ b/nan.h
@@ -1679,6 +1679,18 @@ inline MaybeLocal<v8::Value> Call(
   return Call(*callback, recv, argc, argv);
 }
 
+inline MaybeLocal<v8::Value> Call(
+    const Nan::Callback& callback
+  , int argc
+  , v8::Local<v8::Value> argv[]) {
+#if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  return Call(*callback, isolate->GetCurrentContext()->Global(), argc, argv);
+#else
+  return Call(*callback, v8::Context::GetCurrent()->Global(), argc, argv);
+#endif
+}
+
 /* abstract */ class AsyncWorker {
  public:
   explicit AsyncWorker(Callback *callback_,

--- a/nan.h
+++ b/nan.h
@@ -1685,9 +1685,16 @@ inline MaybeLocal<v8::Value> Call(
   , v8::Local<v8::Value> argv[]) {
 #if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
-  return Call(*callback, isolate->GetCurrentContext()->Global(), argc, argv);
+  v8::EscapableHandleScope scope(isolate);
+  return scope.Escape(
+      Call(*callback, isolate->GetCurrentContext()->Global(), argc, argv);
+  )
 #else
-  return Call(*callback, v8::Context::GetCurrent()->Global(), argc, argv);
+  EscapableHandleScope scope;
+  return scope.Escape(Call(*callback,
+                           v8::Context::GetCurrent()->Global(),
+                           argc,
+                           argv).ToLocalChecked());
 #endif
 }
 

--- a/nan.h
+++ b/nan.h
@@ -1687,14 +1687,13 @@ inline MaybeLocal<v8::Value> Call(
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::EscapableHandleScope scope(isolate);
   return scope.Escape(
-      Call(*callback, isolate->GetCurrentContext()->Global(), argc, argv);
-  )
+      Call(*callback, isolate->GetCurrentContext()->Global(), argc, argv)
+          .FromMaybe(v8::Local<v8::Value>()));
 #else
   EscapableHandleScope scope;
-  return scope.Escape(Call(*callback,
-                           v8::Context::GetCurrent()->Global(),
-                           argc,
-                           argv).ToLocalChecked());
+  return scope.Escape(
+      Call(*callback, v8::Context::GetCurrent()->Global(), argc, argv)
+          .FromMaybe(v8::Local<v8::Value>()));
 #endif
 }
 


### PR DESCRIPTION
While working on adapting node-sass to the new async context preserving mechanism to call, I noticed that it would be handy to have another overload.

This commit adds a non-receiver overload for Nan::Call to make it more comparable to Nan::Callback::Call.