### PR TITLE
add more Nan::Call overloads

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1703,10 +1703,10 @@ inline MaybeLocal<v8::Value> Call(
   , int argc
   , v8::Local<v8::Value> argv[]) {
   EscapableHandleScope scope;
-  v8::Local<v8::Value> fn_v = recv->Get(symbol);
+  v8::Local<v8::Value> fn_v =
+      Get(recv, symbol).FromMaybe(v8::Local<v8::Value>());
   if (fn_v.IsEmpty() || !fn_v->IsFunction()) return v8::Local<v8::Value>();
   v8::Local<v8::Function> fn = fn_v.As<v8::Function>();
-
   return scope.Escape(
       Call(fn, recv, argc, argv).FromMaybe(v8::Local<v8::Value>()));
 }

--- a/nan.h
+++ b/nan.h
@@ -1717,7 +1717,8 @@ inline MaybeLocal<v8::Value> Call(
   , int argc
   , v8::Local<v8::Value> argv[]) {
   EscapableHandleScope scope;
-  auto method_string = New<v8::String>(method).ToLocalChecked();
+  v8::Local<v8::String> method_string =
+      New<v8::String>(method).ToLocalChecked();
   return scope.Escape(
       Call(method_string, recv, argc, argv).FromMaybe(v8::Local<v8::Value>()));
 }
@@ -2650,7 +2651,7 @@ struct Tap {
 
   inline void end() {
     HandleScope scope;
-    Call("end", New(t_), 0, nullptr);
+    Call("end", New(t_), 0, NULL);
   }
 
  private:

--- a/test/cpp/threadlocal.cpp
+++ b/test/cpp/threadlocal.cpp
@@ -36,6 +36,7 @@ class TlsTest : public AsyncWorker {
       t->ok(res[j].ok, res[j].msg);
     nauv_key_delete(&tls_key);
     t->ok(_(NULL == ErrorMessage()));
+    t->end();
     delete t;
   }
 


### PR DESCRIPTION
Presently we use MakeCallback throughout the codebase even in cases
where it doesn't make sense (sync calls). Add some more convenience
overloads for Nan::Call to allow such uses to be migrated over to
Nan::Call instead.

In lieu of coverage, change the Tap reverse bindings to use Nan::Call
to perform synchornous calls. This change exposes a timing issue in
one of the tests – fix it by properly calling Tap's t.end().