### PR TITLE
Deprecate makecallback

### DIFF
--- a/doc/node_misc.md
+++ b/doc/node_misc.md
@@ -58,7 +58,9 @@ For more details, see the Node [async_hooks][] documentation. You might also wan
 <a name="api_nan_make_callback"></a>
 ### Nan::MakeCallback()
 
-Wrappers around the legacy `node::MakeCallback()` APIs.
+Deprecated wrappers around the legacy `node::MakeCallback()` APIs. Node.js 10+
+has deprecated these legacy APIs as they do not provide a mechanism to preserve
+async context.
 
 We recommend that you use the `AsyncResource` class and `AsyncResource::runInAsyncScope` instead of using `Nan::MakeCallback` or
 `v8::Function#Call()` directly. `AsyncResource` properly takes care of running the callback in the correct async execution
@@ -67,14 +69,17 @@ context – something that is essential for functionality like domains, async_ho
 Signatures:
 
 ```c++
+NAN_DEPRECATED
 v8::Local<v8::Value> Nan::MakeCallback(v8::Local<v8::Object> target,
                                        v8::Local<v8::Function> func,
                                        int argc,
                                        v8::Local<v8::Value>* argv);
+NAN_DEPRECATED
 v8::Local<v8::Value> Nan::MakeCallback(v8::Local<v8::Object> target,
                                        v8::Local<v8::String> symbol,
                                        int argc,
                                        v8::Local<v8::Value>* argv);
+NAN_DEPRECATED
 v8::Local<v8::Value> Nan::MakeCallback(v8::Local<v8::Object> target,
                                        const char* method,
                                        int argc,

--- a/nan.h
+++ b/nan.h
@@ -826,7 +826,7 @@ class TryCatch {
   }
 #endif
 
-  inline v8::Local<v8::Value> MakeCallback(
+  NAN_DEPRECATED inline v8::Local<v8::Value> MakeCallback(
       v8::Local<v8::Object> target
     , v8::Local<v8::Function> func
     , int argc
@@ -841,7 +841,7 @@ class TryCatch {
 #endif
   }
 
-  inline v8::Local<v8::Value> MakeCallback(
+  NAN_DEPRECATED inline v8::Local<v8::Value> MakeCallback(
       v8::Local<v8::Object> target
     , v8::Local<v8::String> symbol
     , int argc
@@ -856,7 +856,7 @@ class TryCatch {
 #endif
   }
 
-  inline v8::Local<v8::Value> MakeCallback(
+  NAN_DEPRECATED inline v8::Local<v8::Value> MakeCallback(
       v8::Local<v8::Object> target
     , const char* method
     , int argc

--- a/test/cpp/weak.cpp
+++ b/test/cpp/weak.cpp
@@ -10,13 +10,16 @@
 
 using namespace Nan;  // NOLINT(build/namespaces)
 
+static AsyncResource* async_resource;
 static Persistent<v8::Function> cb;
 
 void weakCallback(
     const WeakCallbackInfo<int> &data) {  // NOLINT(runtime/references)
   int *parameter = data.GetParameter();
   v8::Local<v8::Value> val = New(*parameter);
-  MakeCallback(GetCurrentContext()->Global(), New(cb), 1, &val);
+  async_resource->runInAsyncScope(
+      GetCurrentContext()->Global(), New(cb), 1, &val);
+  delete async_resource;
   delete parameter;
 }
 
@@ -31,6 +34,7 @@ v8::Local<v8::String> wrap(v8::Local<v8::Function> func) {
 }
 
 NAN_METHOD(Hustle) {
+  async_resource = new AsyncResource("nan:test:weak");
   cb.Reset(To<v8::Function>(info[1]).ToLocalChecked());
   info.GetReturnValue().Set(wrap(To<v8::Function>(info[0]).ToLocalChecked()));
 }

--- a/test/cpp/weak2.cpp
+++ b/test/cpp/weak2.cpp
@@ -10,12 +10,15 @@
 
 using namespace Nan;  // NOLINT(build/namespaces)
 
+static AsyncResource* async_resource;
 static Persistent<v8::Function> cb;
 void weakCallback(
     const WeakCallbackInfo<int> &data) {  // NOLINT(runtime/references)
   int *parameter = static_cast<int*>(data.GetInternalField(0));
   v8::Local<v8::Value> val = New(*parameter);
-  MakeCallback(GetCurrentContext()->Global(), New(cb), 1, &val);
+  async_resource->runInAsyncScope(
+      GetCurrentContext()->Global(), New(cb), 1, &val);
+  delete async_resource;
   delete parameter;
 }
 
@@ -36,6 +39,7 @@ v8::Local<v8::String> wrap() {
 }
 
 NAN_METHOD(Hustle) {
+  async_resource = new AsyncResource("nan:test:weak2");
   cb.Reset(To<v8::Function>(info[0]).ToLocalChecked());
   info.GetReturnValue().Set(wrap());
 }


### PR DESCRIPTION
This builds on top of #751. I will rebase when that lands.

This PR deprecates MakeCallback and removes remaining internal uses.

~~TODO: update the docs.~~