### PR TITLE
avoid unneeded call to Isolate::GetCurrent() in converters

### DIFF
--- a/nan_converters_43_inl.h
+++ b/nan_converters_43_inl.h
@@ -15,7 +15,7 @@ imp::ToFactory<v8::TYPE>::convert(v8::Local<v8::Value> val) {                  \
   v8::Isolate *isolate = v8::Isolate::GetCurrent();                            \
   v8::EscapableHandleScope scope(isolate);                                     \
   return scope.Escape(                                                         \
-      val->To ## TYPE(v8::Isolate::GetCurrent()->GetCurrentContext())          \
+      val->To ## TYPE(isolate->GetCurrentContext())                            \
           .FromMaybe(v8::Local<v8::TYPE>()));                                  \
 }
 


### PR DESCRIPTION
I have seen an unneeded call to Isolate::GetCurrent() in converters during stepping around. Even the overhead of this is small it's unneeded.