### PR TITLE
fix example deprecation

### DIFF
--- a/doc/object_wrappers.md
+++ b/doc/object_wrappers.md
@@ -100,7 +100,7 @@ class MyObject : public Nan::ObjectWrap {
       const int argc = 1;
       v8::Local<v8::Value> argv[argc] = {info[0]};
       v8::Local<v8::Function> cons = Nan::New(constructor());
-      info.GetReturnValue().Set(cons->NewInstance(argc, argv));
+      info.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
     }
   }
 


### PR DESCRIPTION
When compiling `info.GetReturnValue().Set(cons->NewInstance(argc, argv));` it gives the warning `'v8::Function::NewInstance': was declared deprecated`. This PR fixes it.