### PR TITLE
[LINT] Single-parameter constructors should be marked explicit

### DIFF
--- a/test/cpp/makecallback.cpp
+++ b/test/cpp/makecallback.cpp
@@ -15,7 +15,7 @@ class MyObject : public node::ObjectWrap {
   static NAN_MODULE_INIT(Init);
 
  private:
-  MyObject(v8::Local<v8::Object> resource);
+  explicit MyObject(v8::Local<v8::Object> resource);
   ~MyObject();
 
   AsyncResource async_resource;


### PR DESCRIPTION
fix test/cpp/makecallback.cpp:18: Single-parameter constructors should be marked explicit. [runtime/explicit] [5]