### PR TITLE
use Buffer.from('text') rather than new Buffer('text') when available

### DIFF
--- a/test/js/strings-test.js
+++ b/test/js/strings-test.js
@@ -23,10 +23,13 @@ test('FromV8String', function (t) {
   t.equal(a('an utf8 strïng'), 'an utf8 strïng');
   t.equal(b('an utf8 strïng'), 'an utf8 strïng');
 
+  var buf;
+
   if (typeof(Buffer.from) === "function") {
-    t.equal(bindings.encodeHex(), Buffer.from('hello').toString('hex'));
+    buf = Buffer.from('hello');
   } else {
-    t.equal(bindings.encodeHex(), new Buffer('hello').toString('hex'));
+    buf = new Buffer('hello');
   }
+  t.equal(bindings.encodeHex(), buf.toString('hex'));
   t.equal(bindings.encodeUCS2(), 'hello');
 });

--- a/test/js/strings-test.js
+++ b/test/js/strings-test.js
@@ -25,7 +25,9 @@ test('FromV8String', function (t) {
 
   var buf;
 
-  if (typeof(Buffer.from) === "function") {
+  /* we check Buffer.alloc rather than Buffer.from because
+   * we don't want the base class Uint8Array.from */
+  if (typeof(Buffer.alloc) === "function") {
     buf = Buffer.from('hello');
   } else {
     buf = new Buffer('hello');

--- a/test/js/strings-test.js
+++ b/test/js/strings-test.js
@@ -23,6 +23,6 @@ test('FromV8String', function (t) {
   t.equal(a('an utf8 strïng'), 'an utf8 strïng');
   t.equal(b('an utf8 strïng'), 'an utf8 strïng');
 
-  t.equal(bindings.encodeHex(), new Buffer('hello').toString('hex'));
+  t.equal(bindings.encodeHex(), Buffer.from('hello').toString('hex'));
   t.equal(bindings.encodeUCS2(), 'hello');
 });

--- a/test/js/strings-test.js
+++ b/test/js/strings-test.js
@@ -23,6 +23,10 @@ test('FromV8String', function (t) {
   t.equal(a('an utf8 strïng'), 'an utf8 strïng');
   t.equal(b('an utf8 strïng'), 'an utf8 strïng');
 
-  t.equal(bindings.encodeHex(), Buffer.from('hello').toString('hex'));
+  if (typeof(Buffer.from) === "function") {
+    t.equal(bindings.encodeHex(), Buffer.from('hello').toString('hex'));
+  } else {
+    t.equal(bindings.encodeHex(), new Buffer('hello').toString('hex'));
+  }
   t.equal(bindings.encodeUCS2(), 'hello');
 });


### PR DESCRIPTION
fix (node:11826) [DEP0005] DeprecationWarning:
Buffer() is deprecated due to security and usability issues.
Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

Also, includes a check for whether Buffer.from is actually available :-)