### PR TITLE
test/cpp: replace `v8::String::Utf8Value` with `Nan::Utf8String`

### DIFF
--- a/test/cpp/accessors2.cpp
+++ b/test/cpp/accessors2.cpp
@@ -133,7 +133,7 @@ NAN_SETTER(SetterGetter::SetProp2) {
       ObjectWrap::Unwrap<SetterGetter>(info.Holder());
   strncpy(
       settergetter->prop2
-    , *v8::String::Utf8Value(value)
+    , *Nan::Utf8String(value)
     , sizeof (settergetter->prop2));
   settergetter->prop2[sizeof (settergetter->prop2) - 1] = '\0';
   assert(strlen(settergetter->log) < sizeof (settergetter->log));

--- a/test/cpp/indexedinterceptors.cpp
+++ b/test/cpp/indexedinterceptors.cpp
@@ -86,7 +86,7 @@ NAN_INDEX_SETTER(IndexedInterceptor::PropertySetter) {
   if (index == 0) {
     std::strncpy(
         interceptor->buf
-      , *v8::String::Utf8Value(value)
+      , *Nan::Utf8String(value)
       , sizeof (interceptor->buf));
     info.GetReturnValue().Set(info.This());
   } else {

--- a/test/cpp/namedinterceptors.cpp
+++ b/test/cpp/namedinterceptors.cpp
@@ -73,7 +73,7 @@ NAN_METHOD(NamedInterceptor::New) {
 NAN_PROPERTY_GETTER(NamedInterceptor::PropertyGetter) {
   NamedInterceptor* interceptor =
     ObjectWrap::Unwrap<NamedInterceptor>(info.Holder());
-  if (!std::strcmp(*v8::String::Utf8Value(property), "prop")) {
+  if (!std::strcmp(*Nan::Utf8String(property), "prop")) {
     info.GetReturnValue().Set(Nan::New(interceptor->buf).ToLocalChecked());
   } else {
     info.GetReturnValue().Set(Nan::New("bar").ToLocalChecked());
@@ -83,10 +83,10 @@ NAN_PROPERTY_GETTER(NamedInterceptor::PropertyGetter) {
 NAN_PROPERTY_SETTER(NamedInterceptor::PropertySetter) {
   NamedInterceptor* interceptor =
     ObjectWrap::Unwrap<NamedInterceptor>(info.Holder());
-  if (!std::strcmp(*v8::String::Utf8Value(property), "prop")) {
+  if (!std::strcmp(*Nan::Utf8String(property), "prop")) {
     std::strncpy(
         interceptor->buf
-      , *v8::String::Utf8Value(value)
+      , *Nan::Utf8String(value)
       , sizeof (interceptor->buf));
     info.GetReturnValue().Set(info.This());
   } else {
@@ -108,7 +108,7 @@ NAN_PROPERTY_DELETER(NamedInterceptor::PropertyDeleter) {
 }
 
 NAN_PROPERTY_QUERY(NamedInterceptor::PropertyQuery) {
-  if (!std::strcmp(*v8::String::Utf8Value(property), "thing")) {
+  if (!std::strcmp(*Nan::Utf8String(property), "thing")) {
     info.GetReturnValue().Set(Nan::New<v8::Integer>(v8::DontEnum));
   }
 }

--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -47,7 +47,7 @@ assertType(U value) {
 
 bool
 stringMatches(Local<Value> value, const char * match) {
-  String::Utf8Value v(value);
+  Nan::Utf8String v(value);
   return std::string(*v) == std::string(match);
 }
 


### PR DESCRIPTION
fix warning: ‘v8::String::Utf8Value::Utf8Value(v8::Local<v8::Value>)’ is deprecated: Use Isolate version [-Wdeprecated-declarations]