### PR TITLE
appveyor.yml: allow failures against nodejs 0.8

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,10 @@ environment:
     - nodejs_version: "9"
     - nodejs_version: "10"
 
+matrix:
+  allow_failures:
+    - nodejs_version: "0.8"
+
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node 0.STABLE.latest


### PR DESCRIPTION
...at least until we figure out how to get past the SSL error

This will allow builds to go green if the only failure is `Environment: nodejs_version=0.8`

note:  this build still fails against nodejs version 10 due to the broken named interceptor test