### PR TITLE
[HELP WANTED] Fix bugs in named interceptor test.

### DIFF
--- a/test/cpp/namedinterceptors.cpp
+++ b/test/cpp/namedinterceptors.cpp
@@ -96,7 +96,7 @@ NAN_PROPERTY_SETTER(NamedInterceptor::PropertySetter) {
 
 NAN_PROPERTY_ENUMERATOR(NamedInterceptor::PropertyEnumerator) {
   v8::Local<v8::Array> arr = Nan::New<v8::Array>();
-  Set(arr, 0, Nan::New("value").ToLocalChecked());
+  Set(arr, Nan::New("zero").ToLocalChecked(), Nan::New("value").ToLocalChecked());
   info.GetReturnValue().Set(arr);
 }
 

--- a/test/cpp/namedinterceptors.cpp
+++ b/test/cpp/namedinterceptors.cpp
@@ -96,7 +96,7 @@ NAN_PROPERTY_SETTER(NamedInterceptor::PropertySetter) {
 
 NAN_PROPERTY_ENUMERATOR(NamedInterceptor::PropertyEnumerator) {
   v8::Local<v8::Array> arr = Nan::New<v8::Array>();
-  Set(arr, 0, Nan::New("value").ToLocalChecked());
+  Set(arr, 0, Nan::New(57));
   info.GetReturnValue().Set(arr);
 }
 

--- a/test/cpp/namedinterceptors.cpp
+++ b/test/cpp/namedinterceptors.cpp
@@ -96,7 +96,7 @@ NAN_PROPERTY_SETTER(NamedInterceptor::PropertySetter) {
 
 NAN_PROPERTY_ENUMERATOR(NamedInterceptor::PropertyEnumerator) {
   v8::Local<v8::Array> arr = Nan::New<v8::Array>();
-  Set(arr, 0, Nan::New(57));
+  Set(arr, 0, Nan::New("value").ToLocalChecked());
   info.GetReturnValue().Set(arr);
 }
 

--- a/test/js/namedinterceptors-test.js
+++ b/test/js/namedinterceptors-test.js
@@ -19,5 +19,5 @@ test('namedinterceptors', function (t) {
   delete interceptor.something;
   t.equal(interceptor.prop, 'goober');
   t.ok(Object.prototype.hasOwnProperty.call(interceptor, "thing"));
-  t.ok(Object.keys(interceptor)[0] === 'value');
+  t.ok(Object.keys(interceptor)['zero'] === 'value');
 });

--- a/test/js/namedinterceptors-test.js
+++ b/test/js/namedinterceptors-test.js
@@ -19,5 +19,5 @@ test('namedinterceptors', function (t) {
   delete interceptor.something;
   t.equal(interceptor.prop, 'goober');
   t.ok(Object.prototype.hasOwnProperty.call(interceptor, "thing"));
-  t.ok(Object.keys(interceptor)[0] === 'value');
+  t.ok(Object.keys(interceptor)[0] === '57');
 });

--- a/test/js/namedinterceptors-test.js
+++ b/test/js/namedinterceptors-test.js
@@ -19,5 +19,5 @@ test('namedinterceptors', function (t) {
   delete interceptor.something;
   t.equal(interceptor.prop, 'goober');
   t.ok(Object.prototype.hasOwnProperty.call(interceptor, "thing"));
-  t.ok(Object.keys(interceptor)[0] === '57');
+  t.ok(Object.keys(interceptor)[0] === 'value');
 });


### PR DESCRIPTION
Copied, more or less, from commit 946377f194e3aaf2aeb5141fa38768f5ca56734a

Returning a string in the enumerator was never allowed but wasn't
enforced until recently.  In Node.js 10, it hits a CHECK in V8.

This builds, but the tests fail:
```
#
# Fatal error in , line 0
# Check failed: element->IsName().
#
#
#
#FailureMessage Object: 0x7ffd987f3690not ok test/js/namedinterceptors-test.js ................ 0/1
    Command: "/home/mk/.nvm/versions/node/v10.2.1/bin/node --expose-gc namedinterceptors-test.js"
    TAP version 13
    not ok 1 test/js/namedinterceptors-test.js
      ---
        exit:    ~
        signal:  SIGILL
        stderr:  |
          #
          # Fatal error in , line 0
          # Check failed: element->IsName().
          #
          #
          #
          #FailureMessage Object: 0x7ffd987f3690
        command: "/home/mk/.nvm/versions/node/v10.2.1/bin/node --expose-gc namedinterceptors-test.js"
      ...
    
    1..1
    # tests 1
    # fail  1
    
```

I'm not sure what else is needed but this is at least a starting point for fixing the Node 10 CI failure.