### PR TITLE
Fix typedarrays.cpp: Missing spaces around < [whitespace/operators] [3] 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ LINT_SOURCES = \
 	test/cpp/symbols.cpp \
 	test/cpp/threadlocal.cpp \
 	test/cpp/trycatch.cpp \
+	test/cpp/typedarrays.cpp \
 	test/cpp/weak.cpp \
 	test/cpp/weak2.cpp \
 	test/cpp/wrappedobjectfactory.cpp \

--- a/test/cpp/typedarrays.cpp
+++ b/test/cpp/typedarrays.cpp
@@ -16,7 +16,7 @@ NAN_METHOD(ReadU8) {
   TypedArrayContents<uint8_t> data(info[0]);
 
   v8::Local<v8::Array> result = New<v8::Array>(data.length());
-  for (size_t i=0; i<data.length(); i++) {
+  for (size_t i=0; i < data.length(); i++) {
     Set(result, i, New<v8::Number>((*data)[i]));
   }
 
@@ -27,7 +27,7 @@ NAN_METHOD(ReadI32) {
   TypedArrayContents<int32_t> data(info[0]);
 
   v8::Local<v8::Array> result = New<v8::Array>(data.length());
-  for (size_t i=0; i<data.length(); i++) {
+  for (size_t i=0; i < data.length(); i++) {
     Set(result, i, New<v8::Number>((*data)[i]));
   }
 
@@ -38,7 +38,7 @@ NAN_METHOD(ReadFloat) {
   TypedArrayContents<float> data(info[0]);
 
   v8::Local<v8::Array> result = New<v8::Array>(data.length());\
-  for (size_t i=0; i<data.length(); i++) {
+  for (size_t i=0; i < data.length(); i++) {
     Set(result, i, New<v8::Number>((*data)[i]));
   }
 
@@ -49,7 +49,7 @@ NAN_METHOD(ReadDouble) {
   TypedArrayContents<double> data(info[0]);
 
   v8::Local<v8::Array> result = New<v8::Array>(data.length());
-  for (size_t i=0; i<data.length(); i++) {
+  for (size_t i=0; i < data.length(); i++) {
     Set(result, i, New<v8::Number>((*data)[i]));
   }
 


### PR DESCRIPTION
* Add `test/cpp/typedarrays.cpp` to `Makefile` `LINT_SOURCES`
* typedarrays.cpp: Missing spaces around < [whitespace/operators] [3] 