### PR TITLE
Update dependency version except tap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,14 @@ matrix:
   exclude:
     - os: osx
       env: TRAVIS_NODE_VERSION="0.12"
+before_install:
+  - npm install node-gyp -g
 install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then export CXX=g++-4.8; fi
   - $CXX --version
   - if [[ $TRAVIS_NODE_VERSION == "0.8" ]]; then npm config set strict-ssl false; fi
   - if [[ $(echo "$TRAVIS_NODE_VERSION < 4" | bc -l) ]]; then npm install npm@2 && mv node_modules npm && npm/.bin/npm --version && npm/.bin/npm install; else npm --version && npm install; fi
-  - node_modules/.bin/node-gyp rebuild --directory test
-script: node_modules/.bin/tap --gc test/js/*-test.js
+script:
+  - npm run rebuild-tests
+  - npm run test

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "test": "tap --gc --stderr test/js/*-test.js",
+    "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
     "docs": "doc/.build.sh"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "bindings": "~1.2.1",
     "node-gyp": "^3.7.0",
+    "readable-stream": "^2.3.6",
     "tap": "^0.7.1"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/nodejs/nan.git"
   },
   "scripts": {
-    "test": "tap --gc test/js/*-test.js",
+    "test": "tap --gc --stderr test/js/*-test.js",
     "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
     "docs": "doc/.build.sh"
   },
@@ -29,7 +29,7 @@
     "node-gyp": "^3.7.0",
     "readable-stream": "^2.1.4",
     "request": "^2.87.0",
-    "tap": "^12.0.1",
+    "tap": "^0.7.1",
     "xtend": "~4.0.0"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -24,13 +24,8 @@
   ],
   "devDependencies": {
     "bindings": "~1.2.1",
-    "commander": "^2.8.1",
-    "glob": "^5.0.14",
     "node-gyp": "^3.7.0",
-    "readable-stream": "^2.1.4",
-    "request": "^2.87.0",
-    "tap": "^0.7.1",
-    "xtend": "~4.0.0"
+    "tap": "^0.7.1"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/nodejs/nan.git"
   },
   "scripts": {
-    "test": "tap --gc --stderr test/js/*-test.js",
+    "test": "tap --gc test/js/*-test.js",
     "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
     "docs": "doc/.build.sh"
   },
@@ -26,10 +26,10 @@
     "bindings": "~1.2.1",
     "commander": "^2.8.1",
     "glob": "^5.0.14",
-    "request": "=2.81.0",
-    "node-gyp": "~3.6.2",
+    "node-gyp": "^3.7.0",
     "readable-stream": "^2.1.4",
-    "tap": "~0.7.1",
+    "request": "^2.87.0",
+    "tap": "^12.0.1",
     "xtend": "~4.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
As title,
By the way, I thought that `tap` version is too old to update to latest version for reducing vulnerability, but if we can find a version for lowest node version and less vulnerability, it may be a good trade-off?

and CI build pass. https://travis-ci.org/realdennis/nan