### PR TITLE
Introduce a GetCurrentEventLoop function to get the current uv event loop

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -561,9 +561,9 @@ class AsyncResource {
 };
 
 inline uv_loop_t* GetCurrentEventLoop() {
-#if NODE_MAJOR_VERSION >= 10 \
-  || NODE_MAJOR_VERSION == 9 && NODE_MINOR_VERSION >= 3 \
-  || NODE_MAJOR_VERSION == 8 && NODE_MINOR_VERSION >= 10
+#if NODE_MAJOR_VERSION >= 10 || \
+  NODE_MAJOR_VERSION == 9 && NODE_MINOR_VERSION >= 3 || \
+  NODE_MAJOR_VERSION == 8 && NODE_MINOR_VERSION >= 10
     return node::GetCurrentEventLoop(v8::Isolate::GetCurrent());
 #else
     return uv_default_loop();

--- a/nan.h
+++ b/nan.h
@@ -561,7 +561,7 @@ class AsyncResource {
 };
 
 inline uv_loop_t* GetCurrentEventLoop() {
-#if NODE_MODULE_VERSION > NODE_9_0_MODULE_VERSION
+#if NODE_MAJOR_VERSION >= 10 || (NODE_MAJOR_VERSION == 9 && NODE_MINOR_VERSION >= 3) || (NODE_MAJOR_VERSION == 8 && NODE_MINOR_VERSION >= 10)
     return node::GetCurrentEventLoop(v8::Isolate::GetCurrent());
 #else
     return uv_default_loop();

--- a/nan.h
+++ b/nan.h
@@ -560,6 +560,14 @@ class AsyncResource {
 #endif
 };
 
+inline uv_loop_t* GetCurrentEventLoop() {
+#if NODE_MODULE_VERSION > NODE_9_0_MODULE_VERSION
+    return node::GetCurrentEventLoop(v8::Isolate::GetCurrent());
+#else
+    return uv_default_loop();
+#endif
+}
+
 //============ =================================================================
 
 /* node 0.12  */
@@ -1899,7 +1907,7 @@ inline MaybeLocal<v8::Value> Call(
       const char* resource_name = "nan:AsyncBareProgressWorkerBase")
       : AsyncWorker(callback_, resource_name) {
     uv_async_init(
-        uv_default_loop()
+        GetCurrentEventLoop()
       , &async
       , AsyncProgress_
     );
@@ -2161,7 +2169,7 @@ inline void AsyncExecuteComplete (uv_work_t* req) {
 
 inline void AsyncQueueWorker (AsyncWorker* worker) {
   uv_queue_work(
-      uv_default_loop()
+      GetCurrentEventLoop()
     , &worker->request
     , AsyncExecute
     , reinterpret_cast<uv_after_work_cb>(AsyncExecuteComplete)

--- a/nan.h
+++ b/nan.h
@@ -561,7 +561,9 @@ class AsyncResource {
 };
 
 inline uv_loop_t* GetCurrentEventLoop() {
-#if NODE_MAJOR_VERSION >= 10 || (NODE_MAJOR_VERSION == 9 && NODE_MINOR_VERSION >= 3) || (NODE_MAJOR_VERSION == 8 && NODE_MINOR_VERSION >= 10)
+#if NODE_MAJOR_VERSION >= 10 \
+  || NODE_MAJOR_VERSION == 9 && NODE_MINOR_VERSION >= 3 \
+  || NODE_MAJOR_VERSION == 8 && NODE_MINOR_VERSION >= 10
     return node::GetCurrentEventLoop(v8::Isolate::GetCurrent());
 #else
     return uv_default_loop();

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "test": "tap --gc --stderr test/js/*-test.js",
+    "test:worker": "node --experimental-worker test/tap-as-worker.js --gc --stderr test/js/*-test.js",
     "rebuild-tests": "node-gyp rebuild --msvs_version=2015 --directory test",
     "docs": "doc/.build.sh"
   },

--- a/test/cpp/asyncresource.cpp
+++ b/test/cpp/asyncresource.cpp
@@ -55,7 +55,7 @@ NAN_METHOD(Delay) {
   DelayRequest* delay_request = new DelayRequest(delay, cb);
 
   uv_queue_work(
-      uv_default_loop()
+      GetCurrentEventLoop()
     , &delay_request->request
     , Delay
     , reinterpret_cast<uv_after_work_cb>(AfterDelay));

--- a/test/cpp/callbackcontext.cpp
+++ b/test/cpp/callbackcontext.cpp
@@ -52,7 +52,7 @@ NAN_METHOD(Delay) {
   DelayRequest* delay_request = new DelayRequest(delay, cb);
 
   uv_queue_work(
-      uv_default_loop()
+      GetCurrentEventLoop()
     , &delay_request->request
     , Delay
     , reinterpret_cast<uv_after_work_cb>(AfterDelay));

--- a/test/tap-as-worker.js
+++ b/test/tap-as-worker.js
@@ -1,12 +1,12 @@
 // Run the tap tests in a worker
 // Not a clean approach, but is sufficient to verify correctness
-const worker_threads = require("worker_threads");
-const path = require("path");
+const worker_threads = require('worker_threads');
+const path = require('path');
 
 if (worker_threads.isMainThread) {
-	const worker = new worker_threads.Worker(__filename, { workerData: process.argv });
-	worker.on("error", console.error);
+  const worker = new worker_threads.Worker(__filename, { workerData: process.argv });
+  worker.on('error', console.error);
 } else {
-	process.argv = worker_threads.workerData;
-	require(path.resolve(require.resolve("tap"), "../../bin/tap.js"));
+  process.argv = worker_threads.workerData;
+  require(path.resolve(require.resolve('tap'), '../../bin/tap.js'));
 }

--- a/test/tap-as-worker.js
+++ b/test/tap-as-worker.js
@@ -4,8 +4,13 @@ const worker_threads = require('worker_threads');
 const path = require('path');
 
 if (worker_threads.isMainThread) {
-  const worker = new worker_threads.Worker(__filename, { workerData: process.argv });
-  worker.on('error', console.error);
+  const worker = new worker_threads.Worker(__filename, {
+    workerData: process.argv
+  });
+  worker.on('error', () => {
+    // Worker will have logged the error, but will not set the exit code
+    process.exit(1);
+  });
 } else {
   process.argv = worker_threads.workerData;
   require(path.resolve(require.resolve('tap'), '../../bin/tap.js'));

--- a/test/tap-as-worker.js
+++ b/test/tap-as-worker.js
@@ -1,0 +1,12 @@
+// Run the tap tests in a worker
+// Not a clean approach, but is sufficient to verify correctness
+const worker_threads = require("worker_threads");
+const path = require("path");
+
+if (worker_threads.isMainThread) {
+	const worker = new worker_threads.Worker(__filename, { workerData: process.argv });
+	worker.on("error", console.error);
+} else {
+	process.argv = worker_threads.workerData;
+	require(path.resolve(require.resolve("tap"), "../../bin/tap.js"));
+}


### PR DESCRIPTION
This is necessary now that node is supporting multiple v8 isolates and uv event loops behind the `--experimental-worker` flag in node v10.5