### PR TITLE
Fix AsyncProgressWorkerBase::SendProgress_ sends invalid data

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -2046,10 +2046,10 @@ class AsyncProgressWorkerBase : public AsyncBareProgressWorker<T> {
     T *old_data = asyncdata_;
     asyncdata_ = new_data;
     asyncsize_ = count;
+    uv_async_send(&this->async);
     uv_mutex_unlock(&async_lock);
 
     delete[] old_data;
-    uv_async_send(&this->async);
   }
 
   uv_mutex_t async_lock;


### PR DESCRIPTION
Current ProgressWorker implementation can send invalid progress data (described below) in `AsyncProgressWorkerBase::HandleProgressCallback`.

This PR fix it by extending the range to apply mutex.

The issue can occur in the following case:

1. ProgressWorker requests to [SendProgress_](https://github.com/nodejs/nan/blob/b058fb047d18a58250e66ae831444441c1f2ac7a/nan.h#L2038) and the event is registered to the uv queue by [uv_async_send](https://github.com/nodejs/nan/blob/b058fb047d18a58250e66ae831444441c1f2ac7a/nan.h#L2052) (but not awaken now)

2. ProgressWorker requests to send progress again, but just after called [mutex_unlock](https://github.com/nodejs/nan/blob/b058fb047d18a58250e66ae831444441c1f2ac7a/nan.h#L2049) (this is before calling [uv_async_send](https://github.com/nodejs/nan/blob/b058fb047d18a58250e66ae831444441c1f2ac7a/nan.h#L2052)), the running thread switches to another one, and [HandleProgressCallback](https://github.com/nodejs/nan/blob/b058fb047d18a58250e66ae831444441c1f2ac7a/nan.h#L2032) is called.
In this case, HandleProgressCallback sends `data` and `count` which were updated in the 2nd call of `SendProgress`. And then, `asyncdata_` set to null and `asyncsize_` is kept old value.

3. Running thread back to the `ProgressWorker::SendProgress_`, and [uv_async_send](https://github.com/nodejs/nan/blob/b058fb047d18a58250e66ae831444441c1f2ac7a/nan.h#L2052) is called (though the corresponding data is already callbacked.)

4. [HandleProgressCallback](https://github.com/nodejs/nan/blob/b058fb047d18a58250e66ae831444441c1f2ac7a/nan.h#L2032) is called again, but `data` is null and `count` is old value.
This behavior seems invalid.
