### PR TITLE
Added missing multifile2.h to solve Makefile error

### DIFF
--- a/test/cpp/multifile2.cpp
+++ b/test/cpp/multifile2.cpp
@@ -7,6 +7,7 @@
  ********************************************************************/
 
 #include <nan.h>
+#include <multifile2.h>
 
 using namespace Nan;  // NOLINT(build/namespaces)
 


### PR DESCRIPTION
A missing header file was giving an error upon make command, I solved it by including it.

Cheers,

Stefanos