### PR TITLE
doc: fix the comment about PersistentBase::IsEmpty

### DIFF
--- a/doc/persistent.md
+++ b/doc/persistent.md
@@ -43,12 +43,13 @@ template<typename T> class PersistentBase {
    */
   template<typename S> void Reset(const PersistentBase<S> &other);
 
+  /** Returns true if the handle is empty. */
+  bool IsEmpty() const;
+
   /**
    * If non-empty, destroy the underlying storage cell
    * IsEmpty() will return true after this call.
    */
-  bool IsEmpty();
-
   void Empty();
 
   template<typename S> bool operator==(const PersistentBase<S> &that);


### PR DESCRIPTION
* Fix the comments about PersistentBase's `IsEmpty` and `Empty` functions

* Add the missing `const` to `IsEmpty` to match the actual code