### PR TITLE
[doc] fix links and a few copy paste errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Native Abstractions for Node.js
 
 [![NPM](https://nodei.co/npm/nan.png?downloads=true&downloadRank=true)](https://nodei.co/npm/nan/) [![NPM](https://nodei.co/npm-dl/nan.png?months=6&height=3)](https://nodei.co/npm/nan/)
 
-[![Build Status](https://api.travis-ci.org/nodejs/nan.svg?branch=master)](http://travis-ci.org/nodejs/nan)
+[![Build Status](https://api.travis-ci.org/nodejs/nan.svg?branch=master)](https://travis-ci.org/nodejs/nan)
 [![Build status](https://ci.appveyor.com/api/projects/status/kh73pbm9dsju7fgh)](https://ci.appveyor.com/project/RodVagg/nan)
 
 Thanks to the crazy changes in V8 (and some in Node core), keeping native addons compiling happily across versions, particularly 0.10 to 0.12 to 4.0, is a minor nightmare. The goal of this project is to store all logic necessary to develop native Node.js addons without having to inspect `NODE_MODULE_VERSION` and get yourself into a macro-tangle.
@@ -70,7 +70,7 @@ Additional to the NAN documentation below, please consult:
 
 * [The V8 Getting Started * Guide](https://github.com/v8/v8/wiki/Getting%20Started%20with%20Embedding)
 * [The V8 Embedders * Guide](https://github.com/v8/v8/wiki/Embedder%27s%20Guide)
-* [V8 API Documentation](http://v8docs.nodesource.com/)
+* [V8 API Documentation](https://v8docs.nodesource.com/)
 * [Node Add-on Documentation](https://nodejs.org/api/addons.html)
 
 <!-- START API -->
@@ -219,7 +219,7 @@ The _JSON_ object provides the c++ versions of the methods offered by the `JSON`
  - <a href="doc/json.md#api_nan_json_parse"><b><code>Nan::JSON.Parse</code></b></a>
  - <a href="doc/json.md#api_nan_json_stringify"><b><code>Nan::JSON.Stringify</code></b></a>
 
-Refer to the V8 JSON object in the [V8 documentation](https://v8docs.nodesource.com/node-7.4/da/d6f/classv8_1_1_j_s_o_n.html) for more information about these methods and their arguments.
+Refer to the V8 JSON object in the [V8 documentation](https://v8docs.nodesource.com/node-8.11/da/d6f/classv8_1_1_j_s_o_n.html) for more information about these methods and their arguments.
 
 ### Errors
 
@@ -400,7 +400,7 @@ For the current list of WG members / Collaborators, see the project [README.md](
 
 ### Consensus Seeking Process
 
-The WG follows a [Consensus Seeking](http://en.wikipedia.org/wiki/Consensus-seeking_decision-making) decision making model.
+The WG follows a [Consensus Seeking](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making) decision making model.
 
 Modifications of the contents of the NAN repository are made on a collaborative basis. Anybody with a GitHub account may propose a modification via pull request and it will be considered by the WG. All pull requests must be reviewed and accepted by a WG member with sufficient expertise who is able to take full responsibility for the change. In the case of pull requests proposed by an existing WG member, an additional WG member is required for sign-off. Consensus should be sought if additional WG members participate and there is disagreement around a particular modification.
 

--- a/doc/errors.md
+++ b/doc/errors.md
@@ -24,7 +24,7 @@ Also consult the V8 Embedders Guide section on [Exceptions](https://developers.g
 <a name="api_nan_error"></a>
 ### Nan::Error()
 
-Create a new Error object using the [v8::Exception](https://v8docs.nodesource.com/io.js-3.3/da/d6a/classv8_1_1_exception.html) class in a way that is compatible across the supported versions of V8.
+Create a new Error object using the [v8::Exception](https://v8docs.nodesource.com/node-8.11/da/d6a/classv8_1_1_exception.html) class in a way that is compatible across the supported versions of V8.
 
 Note that an Error object is simply a specialized form of `v8::Value`.
 
@@ -39,7 +39,7 @@ v8::Local<v8::Value> Nan::Error(v8::Local<v8::String> msg);
 <a name="api_nan_range_error"></a>
 ### Nan::RangeError()
 
-Create a new RangeError object using the [v8::Exception](https://v8docs.nodesource.com/io.js-3.3/da/d6a/classv8_1_1_exception.html) class in a way that is compatible across the supported versions of V8.
+Create a new RangeError object using the [v8::Exception](https://v8docs.nodesource.com/node-8.11/da/d6a/classv8_1_1_exception.html) class in a way that is compatible across the supported versions of V8.
 
 Note that an RangeError object is simply a specialized form of `v8::Value`.
 
@@ -54,7 +54,7 @@ v8::Local<v8::Value> Nan::RangeError(v8::Local<v8::String> msg);
 <a name="api_nan_reference_error"></a>
 ### Nan::ReferenceError()
 
-Create a new ReferenceError object using the [v8::Exception](https://v8docs.nodesource.com/io.js-3.3/da/d6a/classv8_1_1_exception.html) class in a way that is compatible across the supported versions of V8.
+Create a new ReferenceError object using the [v8::Exception](https://v8docs.nodesource.com/node-8.11/da/d6a/classv8_1_1_exception.html) class in a way that is compatible across the supported versions of V8.
 
 Note that an ReferenceError object is simply a specialized form of `v8::Value`.
 
@@ -69,7 +69,7 @@ v8::Local<v8::Value> Nan::ReferenceError(v8::Local<v8::String> msg);
 <a name="api_nan_syntax_error"></a>
 ### Nan::SyntaxError()
 
-Create a new SyntaxError object using the [v8::Exception](https://v8docs.nodesource.com/io.js-3.3/da/d6a/classv8_1_1_exception.html) class in a way that is compatible across the supported versions of V8.
+Create a new SyntaxError object using the [v8::Exception](https://v8docs.nodesource.com/node-8.11/da/d6a/classv8_1_1_exception.html) class in a way that is compatible across the supported versions of V8.
 
 Note that an SyntaxError object is simply a specialized form of `v8::Value`.
 
@@ -84,7 +84,7 @@ v8::Local<v8::Value> Nan::SyntaxError(v8::Local<v8::String> msg);
 <a name="api_nan_type_error"></a>
 ### Nan::TypeError()
 
-Create a new TypeError object using the [v8::Exception](https://v8docs.nodesource.com/io.js-3.3/da/d6a/classv8_1_1_exception.html) class in a way that is compatible across the supported versions of V8.
+Create a new TypeError object using the [v8::Exception](https://v8docs.nodesource.com/node-8.11/da/d6a/classv8_1_1_exception.html) class in a way that is compatible across the supported versions of V8.
 
 Note that an TypeError object is simply a specialized form of `v8::Value`.
 
@@ -194,7 +194,7 @@ v8::Local<v8::Value> Nan::ErrnoException(int errorno,
 <a name="api_nan_try_catch"></a>
 ### Nan::TryCatch
 
-A simple wrapper around [`v8::TryCatch`](https://v8docs.nodesource.com/io.js-3.3/d4/dc6/classv8_1_1_try_catch.html) compatible with all supported versions of V8. Can be used as a direct replacement in most cases. See also [`Nan::FatalException()`](#api_nan_fatal_exception) for an internal use compatible with `node::FatalException`.
+A simple wrapper around [`v8::TryCatch`](https://v8docs.nodesource.com/node-8.11/d4/dc6/classv8_1_1_try_catch.html) compatible with all supported versions of V8. Can be used as a direct replacement in most cases. See also [`Nan::FatalException()`](#api_nan_fatal_exception) for an internal use compatible with `node::FatalException`.
 
 Signature:
 

--- a/doc/json.md
+++ b/doc/json.md
@@ -5,13 +5,13 @@ The _JSON_ object provides the c++ versions of the methods offered by the `JSON`
  - <a href="#api_nan_json_parse"><b><code>Nan::JSON.Parse</code></b></a>
  - <a href="#api_nan_json_stringify"><b><code>Nan::JSON.Stringify</code></b></a>
 
-Refer to the V8 JSON object in the [V8 documentation](https://v8docs.nodesource.com/node-7.4/da/d6f/classv8_1_1_j_s_o_n.html) for more information about these methods and their arguments.
+Refer to the V8 JSON object in the [V8 documentation](https://v8docs.nodesource.com/node-8.11/da/d6f/classv8_1_1_j_s_o_n.html) for more information about these methods and their arguments.
 
 <a name="api_nan_json_parse"></a>
 
 ### Nan::JSON.Parse
 
-A simple wrapper around [`v8::JSON::Parse`](https://v8docs.nodesource.com/node-7.4/da/d6f/classv8_1_1_j_s_o_n.html#a936310d2540fb630ed37d3ee3ffe4504).
+A simple wrapper around [`v8::JSON::Parse`](https://v8docs.nodesource.com/node-8.11/da/d6f/classv8_1_1_j_s_o_n.html#a936310d2540fb630ed37d3ee3ffe4504).
 
 Definition:
 
@@ -37,7 +37,7 @@ if (!result.IsEmpty()) {
 
 ### Nan::JSON.Stringify
 
-A simple wrapper around [`v8::JSON::Stringify`](https://v8docs.nodesource.com/node-7.4/da/d6f/classv8_1_1_j_s_o_n.html#a44b255c3531489ce43f6110209138860).
+A simple wrapper around [`v8::JSON::Stringify`](https://v8docs.nodesource.com/node-8.11/da/d6f/classv8_1_1_j_s_o_n.html#a44b255c3531489ce43f6110209138860).
 
 Definition:
 

--- a/doc/maybe_types.md
+++ b/doc/maybe_types.md
@@ -47,7 +47,7 @@ The `Nan::MaybeLocal` and `Nan::Maybe` types are monads that encapsulate `v8::Lo
 <a name="api_nan_maybe_local"></a>
 ### Nan::MaybeLocal
 
-A `Nan::MaybeLocal<T>` is a wrapper around [`v8::Local<T>`](https://v8docs.nodesource.com/io.js-3.3/de/deb/classv8_1_1_local.html) that enforces a check that determines whether the `v8::Local<T>` is empty before it can be used.
+A `Nan::MaybeLocal<T>` is a wrapper around [`v8::Local<T>`](https://v8docs.nodesource.com/node-8.11/de/deb/classv8_1_1_local.html) that enforces a check that determines whether the `v8::Local<T>` is empty before it can be used.
 
 If an API method returns a `Nan::MaybeLocal`, the API method can potentially fail either because an exception is thrown, or because an exception is pending, e.g. because a previous API call threw an exception that hasn't been caught yet, or because a `v8::TerminateExecution` exception was thrown. In that case, an empty `Nan::MaybeLocal` is returned.
 
@@ -71,7 +71,7 @@ template<typename T> class Nan::MaybeLocal {
 };
 ```
 
-See the documentation for [`v8::MaybeLocal`](https://v8docs.nodesource.com/io.js-3.3/d8/d7d/classv8_1_1_maybe_local.html) for further details.
+See the documentation for [`v8::MaybeLocal`](https://v8docs.nodesource.com/node-8.11/d8/d7d/classv8_1_1_maybe_local.html) for further details.
 
 <a name="api_nan_maybe"></a>
 ### Nan::Maybe
@@ -99,7 +99,7 @@ template<typename T> class Nan::Maybe {
 };
 ```
 
-See the documentation for [`v8::Maybe`](https://v8docs.nodesource.com/io.js-3.3/d9/d4b/classv8_1_1_maybe.html) for further details.
+See the documentation for [`v8::Maybe`](https://v8docs.nodesource.com/node-8.11/d9/d4b/classv8_1_1_maybe.html) for further details.
 
 <a name="api_nan_nothing"></a>
 ### Nan::Nothing
@@ -122,7 +122,7 @@ template<typename T> Nan::Maybe<T> Nan::Just(const T &t);
 <a name="api_nan_call"></a>
 ### Nan::Call()
 
-A helper method for calling a synchronous [`v8::Function#Call()`](https://v8docs.nodesource.com/io.js-3.3/d5/d54/classv8_1_1_function.html#a468a89f737af0612db10132799c827c0) in a way compatible across supported versions of V8.
+A helper method for calling a synchronous [`v8::Function#Call()`](https://v8docs.nodesource.com/node-8.11/d5/d54/classv8_1_1_function.html#a9c3d0e4e13ddd7721fce238aa5b94a11) in a way compatible across supported versions of V8.
 
 For asynchronous callbacks, use Nan::Callback::Call along with an AsyncResource.
 
@@ -139,7 +139,7 @@ Nan::MaybeLocal<v8::Value> Nan::Call(const Nan::Callback& callback, int argc, v8
 <a name="api_nan_to_detail_string"></a>
 ### Nan::ToDetailString()
 
-A helper method for calling [`v8::Value#ToDetailString()`](https://v8docs.nodesource.com/io.js-3.3/dc/d0a/classv8_1_1_value.html#a2f9770296dc2c8d274bc8cc0dca243e5) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Value#ToDetailString()`](https://v8docs.nodesource.com/node-8.11/dc/d0a/classv8_1_1_value.html#a2f9770296dc2c8d274bc8cc0dca243e5) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -151,7 +151,7 @@ Nan::MaybeLocal<v8::String> Nan::ToDetailString(v8::Local<v8::Value> val);
 <a name="api_nan_to_array_index"></a>
 ### Nan::ToArrayIndex()
 
-A helper method for calling [`v8::Value#ToArrayIndex()`](https://v8docs.nodesource.com/io.js-3.3/dc/d0a/classv8_1_1_value.html#acc5bbef3c805ec458470c0fcd6f13493) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Value#ToArrayIndex()`](https://v8docs.nodesource.com/node-8.11/dc/d0a/classv8_1_1_value.html#acc5bbef3c805ec458470c0fcd6f13493) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -163,7 +163,7 @@ Nan::MaybeLocal<v8::Uint32> Nan::ToArrayIndex(v8::Local<v8::Value> val);
 <a name="api_nan_equals"></a>
 ### Nan::Equals()
 
-A helper method for calling [`v8::Value#Equals()`](https://v8docs.nodesource.com/io.js-3.3/dc/d0a/classv8_1_1_value.html#a0d9616ab2de899d4e3047c30a10c9285) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Value#Equals()`](https://v8docs.nodesource.com/node-8.11/dc/d0a/classv8_1_1_value.html#a08fba1d776a59bbf6864b25f9152c64b) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -175,7 +175,7 @@ Nan::Maybe<bool> Nan::Equals(v8::Local<v8::Value> a, v8::Local<v8::Value>(b));
 <a name="api_nan_new_instance"></a>
 ### Nan::NewInstance()
 
-A helper method for calling [`v8::Function#NewInstance()`](https://v8docs.nodesource.com/io.js-3.3/d5/d54/classv8_1_1_function.html#a691b13f7a553069732cbacf5ac8c62ec) and [`v8::ObjectTemplate#NewInstance()`](https://v8docs.nodesource.com/io.js-3.3/db/d5f/classv8_1_1_object_template.html#ad605a7543cfbc5dab54cdb0883d14ae4) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Function#NewInstance()`](https://v8docs.nodesource.com/node-8.11/d5/d54/classv8_1_1_function.html#ae477558b10c14b76ed00e8dbab44ce5b) and [`v8::ObjectTemplate#NewInstance()`](https://v8docs.nodesource.com/node-8.11/db/d5f/classv8_1_1_object_template.html#ad605a7543cfbc5dab54cdb0883d14ae4) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -189,7 +189,7 @@ Nan::MaybeLocal<v8::Object> Nan::NewInstance(v8::Local<v8::ObjectTemplate> h);
 <a name="api_nan_get_function"></a>
 ### Nan::GetFunction()
 
-A helper method for calling [`v8::FunctionTemplate#GetFunction()`](https://v8docs.nodesource.com/io.js-3.3/d8/d83/classv8_1_1_function_template.html#a56d904662a86eca78da37d9bb0ed3705) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::FunctionTemplate#GetFunction()`](https://v8docs.nodesource.com/node-8.11/d8/d83/classv8_1_1_function_template.html#a56d904662a86eca78da37d9bb0ed3705) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -201,7 +201,7 @@ Nan::MaybeLocal<v8::Function> Nan::GetFunction(v8::Local<v8::FunctionTemplate> t
 <a name="api_nan_set"></a>
 ### Nan::Set()
 
-A helper method for calling [`v8::Object#Set()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#a67604ea3734f170c66026064ea808f20) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#Set()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a67604ea3734f170c66026064ea808f20) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -218,7 +218,7 @@ Nan::Maybe<bool> Nan::Set(v8::Local<v8::Object> obj,
 <a name="api_nan_define_own_property"></a>
 ### Nan::DefineOwnProperty()
 
-A helper method for calling [`v8::Object#DefineOwnProperty()`](https://v8docs.nodesource.com/node-4.8/db/d85/classv8_1_1_object.html#a6f76b2ed605cb8f9185b92de0033a820) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#DefineOwnProperty()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a6f76b2ed605cb8f9185b92de0033a820) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -235,7 +235,7 @@ Nan::Maybe<bool> Nan::DefineOwnProperty(v8::Local<v8::Object> obj,
 
 Deprecated, use <a href="#api_nan_define_own_property"><code>Nan::DefineOwnProperty()</code></a>.
 
-<del>A helper method for calling [`v8::Object#ForceSet()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#a796b7b682896fb64bf1872747734e836) in a way compatible across supported versions of V8.</del>
+<del>A helper method for calling [`v8::Object#ForceSet()`](https://v8docs.nodesource.com/node-0.12/db/d85/classv8_1_1_object.html#acfbdfd7427b516ebdb5c47c4df5ed96c) in a way compatible across supported versions of V8.</del>
 
 Signature:
 
@@ -250,7 +250,7 @@ NAN_DEPRECATED Nan::Maybe<bool> Nan::ForceSet(v8::Local<v8::Object> obj,
 <a name="api_nan_get"></a>
 ### Nan::Get()
 
-A helper method for calling [`v8::Object#Get()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#a2565f03e736694f6b1e1cf22a0b4eac2) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#Get()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a2565f03e736694f6b1e1cf22a0b4eac2) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -264,7 +264,7 @@ Nan::MaybeLocal<v8::Value> Nan::Get(v8::Local<v8::Object> obj, uint32_t index);
 <a name="api_nan_get_property_attribute"></a>
 ### Nan::GetPropertyAttributes()
 
-A helper method for calling [`v8::Object#GetPropertyAttributes()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#a9b898894da3d1db2714fd9325a54fe57) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#GetPropertyAttributes()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a9b898894da3d1db2714fd9325a54fe57) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -278,7 +278,7 @@ Nan::Maybe<v8::PropertyAttribute> Nan::GetPropertyAttributes(
 <a name="api_nan_has"></a>
 ### Nan::Has()
 
-A helper method for calling [`v8::Object#Has()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#ab3c3d89ea7c2f9afd08965bd7299a41d) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#Has()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#ab3c3d89ea7c2f9afd08965bd7299a41d) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -291,7 +291,7 @@ Nan::Maybe<bool> Nan::Has(v8::Local<v8::Object> obj, uint32_t index);
 <a name="api_nan_delete"></a>
 ### Nan::Delete()
 
-A helper method for calling [`v8::Object#Delete()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#a2fa0f5a592582434ed1ceceff7d891ef) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#Delete()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a48e4a19b2cedff867eecc73ddb7d377f) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -305,7 +305,7 @@ Nan::Maybe<bool> Nan::Delete(v8::Local<v8::Object> obj, uint32_t index);
 <a name="api_nan_get_property_names"></a>
 ### Nan::GetPropertyNames()
 
-A helper method for calling [`v8::Object#GetPropertyNames()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#aced885270cfd2c956367b5eedc7fbfe8) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#GetPropertyNames()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#aced885270cfd2c956367b5eedc7fbfe8) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -317,7 +317,7 @@ Nan::MaybeLocal<v8::Array> Nan::GetPropertyNames(v8::Local<v8::Object> obj);
 <a name="api_nan_get_own_property_names"></a>
 ### Nan::GetOwnPropertyNames()
 
-A helper method for calling [`v8::Object#GetOwnPropertyNames()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#a79a6e4d66049b9aa648ed4dfdb23e6eb) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#GetOwnPropertyNames()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a79a6e4d66049b9aa648ed4dfdb23e6eb) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -329,7 +329,7 @@ Nan::MaybeLocal<v8::Array> Nan::GetOwnPropertyNames(v8::Local<v8::Object> obj);
 <a name="api_nan_set_prototype"></a>
 ### Nan::SetPrototype()
 
-A helper method for calling [`v8::Object#SetPrototype()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#a442706b22fceda6e6d1f632122a9a9f4) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#SetPrototype()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a442706b22fceda6e6d1f632122a9a9f4) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -342,7 +342,7 @@ Nan::Maybe<bool> Nan::SetPrototype(v8::Local<v8::Object> obj,
 <a name="api_nan_object_proto_to_string"></a>
 ### Nan::ObjectProtoToString()
 
-A helper method for calling [`v8::Object#ObjectProtoToString()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#ab7a92b4dcf822bef72f6c0ac6fea1f0b) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#ObjectProtoToString()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#ab7a92b4dcf822bef72f6c0ac6fea1f0b) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -354,7 +354,7 @@ Nan::MaybeLocal<v8::String> Nan::ObjectProtoToString(v8::Local<v8::Object> obj);
 <a name="api_nan_has_own_property"></a>
 ### Nan::HasOwnProperty()
 
-A helper method for calling [`v8::Object#HasOwnProperty()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#ab7b7245442ca6de1e1c145ea3fd653ff) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#HasOwnProperty()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#ab7b7245442ca6de1e1c145ea3fd653ff) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -367,7 +367,7 @@ Nan::Maybe<bool> Nan::HasOwnProperty(v8::Local<v8::Object> obj,
 <a name="api_nan_has_real_named_property"></a>
 ### Nan::HasRealNamedProperty()
 
-A helper method for calling [`v8::Object#HasRealNamedProperty()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#ad8b80a59c9eb3c1e6c3cd6c84571f767) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#HasRealNamedProperty()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#ad8b80a59c9eb3c1e6c3cd6c84571f767) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -380,7 +380,7 @@ Nan::Maybe<bool> Nan::HasRealNamedProperty(v8::Local<v8::Object> obj,
 <a name="api_nan_has_real_indexed_property"></a>
 ### Nan::HasRealIndexedProperty()
 
-A helper method for calling [`v8::Object#HasRealIndexedProperty()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#af94fc1135a5e74a2193fb72c3a1b9855) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#HasRealIndexedProperty()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#af94fc1135a5e74a2193fb72c3a1b9855) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -393,7 +393,7 @@ Nan::Maybe<bool> Nan::HasRealIndexedProperty(v8::Local<v8::Object> obj,
 <a name="api_nan_has_real_named_callback_property"></a>
 ### Nan::HasRealNamedCallbackProperty()
 
-A helper method for calling [`v8::Object#HasRealNamedCallbackProperty()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#af743b7ea132b89f84d34d164d0668811) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#HasRealNamedCallbackProperty()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#af743b7ea132b89f84d34d164d0668811) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -407,7 +407,7 @@ Nan::Maybe<bool> Nan::HasRealNamedCallbackProperty(
 <a name="api_nan_get_real_named_property_in_prototype_chain"></a>
 ### Nan::GetRealNamedPropertyInPrototypeChain()
 
-A helper method for calling [`v8::Object#GetRealNamedPropertyInPrototypeChain()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#a8700b1862e6b4783716964ba4d5e6172) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#GetRealNamedPropertyInPrototypeChain()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a8700b1862e6b4783716964ba4d5e6172) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -421,7 +421,7 @@ Nan::MaybeLocal<v8::Value> Nan::GetRealNamedPropertyInPrototypeChain(
 <a name="api_nan_get_real_named_property"></a>
 ### Nan::GetRealNamedProperty()
 
-A helper method for calling [`v8::Object#GetRealNamedProperty()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#a84471a824576a5994fdd0ffcbf99ccc0) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#GetRealNamedProperty()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a84471a824576a5994fdd0ffcbf99ccc0) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -434,7 +434,7 @@ Nan::MaybeLocal<v8::Value> Nan::GetRealNamedProperty(v8::Local<v8::Object> obj,
 <a name="api_nan_call_as_function"></a>
 ### Nan::CallAsFunction()
 
-A helper method for calling [`v8::Object#CallAsFunction()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#a9ef18be634e79b4f0cdffa1667a29f58) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#CallAsFunction()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#ad3ffc36f3dfc3592ce2a96bc047ee2cd) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -449,7 +449,7 @@ Nan::MaybeLocal<v8::Value> Nan::CallAsFunction(v8::Local<v8::Object> obj,
 <a name="api_nan_call_as_constructor"></a>
 ### Nan::CallAsConstructor()
 
-A helper method for calling [`v8::Object#CallAsConstructor()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#a50d571de50d0b0dfb28795619d07a01b) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#CallAsConstructor()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a50d571de50d0b0dfb28795619d07a01b) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -463,7 +463,7 @@ Nan::MaybeLocal<v8::Value> Nan::CallAsConstructor(v8::Local<v8::Object> obj,
 <a name="api_nan_get_source_line"></a>
 ### Nan::GetSourceLine()
 
-A helper method for calling [`v8::Message#GetSourceLine()`](https://v8docs.nodesource.com/io.js-3.3/d9/d28/classv8_1_1_message.html#a849f7a6c41549d83d8159825efccd23a) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Message#GetSourceLine()`](https://v8docs.nodesource.com/node-8.11/d9/d28/classv8_1_1_message.html#a849f7a6c41549d83d8159825efccd23a) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -475,7 +475,7 @@ Nan::MaybeLocal<v8::String> Nan::GetSourceLine(v8::Local<v8::Message> msg);
 <a name="api_nan_get_line_number"></a>
 ### Nan::GetLineNumber()
 
-A helper method for calling [`v8::Message#GetLineNumber()`](https://v8docs.nodesource.com/io.js-3.3/d9/d28/classv8_1_1_message.html#adbe46c10a88a6565f2732a2d2adf99b9) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Message#GetLineNumber()`](https://v8docs.nodesource.com/node-8.11/d9/d28/classv8_1_1_message.html#adbe46c10a88a6565f2732a2d2adf99b9) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -487,7 +487,7 @@ Nan::Maybe<int> Nan::GetLineNumber(v8::Local<v8::Message> msg);
 <a name="api_nan_get_start_column"></a>
 ### Nan::GetStartColumn()
 
-A helper method for calling [`v8::Message#GetStartColumn()`](https://v8docs.nodesource.com/io.js-3.3/d9/d28/classv8_1_1_message.html#a60ede616ba3822d712e44c7a74487ba6) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Message#GetStartColumn()`](https://v8docs.nodesource.com/node-8.11/d9/d28/classv8_1_1_message.html#a60ede616ba3822d712e44c7a74487ba6) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -499,7 +499,7 @@ Nan::Maybe<int> Nan::GetStartColumn(v8::Local<v8::Message> msg);
 <a name="api_nan_get_end_column"></a>
 ### Nan::GetEndColumn()
 
-A helper method for calling [`v8::Message#GetEndColumn()`](https://v8docs.nodesource.com/io.js-3.3/d9/d28/classv8_1_1_message.html#aaa004cf19e529da980bc19fcb76d93be) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Message#GetEndColumn()`](https://v8docs.nodesource.com/node-8.11/d9/d28/classv8_1_1_message.html#aaa004cf19e529da980bc19fcb76d93be) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -511,7 +511,7 @@ Nan::Maybe<int> Nan::GetEndColumn(v8::Local<v8::Message> msg);
 <a name="api_nan_clone_element_at"></a>
 ### Nan::CloneElementAt()
 
-A helper method for calling [`v8::Array#CloneElementAt()`](https://v8docs.nodesource.com/io.js-3.3/d3/d32/classv8_1_1_array.html#a1d3a878d4c1c7cae974dd50a1639245e) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Array#CloneElementAt()`](https://v8docs.nodesource.com/node-4.8/d3/d32/classv8_1_1_array.html#a1d3a878d4c1c7cae974dd50a1639245e) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -522,7 +522,7 @@ Nan::MaybeLocal<v8::Object> Nan::CloneElementAt(v8::Local<v8::Array> array, uint
 <a name="api_nan_has_private"></a>
 ### Nan::HasPrivate()
 
-A helper method for calling [`v8::Object#HasPrivate()`](https://v8docs.nodesource.com/node-7.2/db/d85/classv8_1_1_object.html#af68a0b98066cfdeb8f943e98a40ba08d) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#HasPrivate()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#af68a0b98066cfdeb8f943e98a40ba08d) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -533,7 +533,7 @@ Nan::Maybe<bool> Nan::HasPrivate(v8::Local<v8::Object> object, v8::Local<v8::Str
 <a name="api_nan_get_private"></a>
 ### Nan::GetPrivate()
 
-A helper method for calling [`v8::Object#GetPrivate()`](https://v8docs.nodesource.com/node-7.2/db/d85/classv8_1_1_object.html#a169f2da506acbec34deadd9149a1925a) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#GetPrivate()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a169f2da506acbec34deadd9149a1925a) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -544,7 +544,7 @@ Nan::MaybeLocal<v8::Value> Nan::GetPrivate(v8::Local<v8::Object> object, v8::Loc
 <a name="api_nan_set_private"></a>
 ### Nan::SetPrivate()
 
-A helper method for calling [`v8::Object#SetPrivate()`](https://v8docs.nodesource.com/node-7.2/db/d85/classv8_1_1_object.html#ace1769b0f3b86bfe9fda1010916360ee) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#SetPrivate()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#ace1769b0f3b86bfe9fda1010916360ee) in a way compatible across supported versions of V8.
 
 Signature:
 
@@ -555,7 +555,7 @@ Nan::Maybe<bool> Nan::SetPrivate(v8::Local<v8::Object> object, v8::Local<v8::Str
 <a name="api_nan_delete_private"></a>
 ### Nan::DeletePrivate()
 
-A helper method for calling [`v8::Object#DeletePrivate()`](https://v8docs.nodesource.com/node-7.2/db/d85/classv8_1_1_object.html#a138bb32a304f3982be02ad499693b8fd) in a way compatible across supported versions of V8.
+A helper method for calling [`v8::Object#DeletePrivate()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a138bb32a304f3982be02ad499693b8fd) in a way compatible across supported versions of V8.
 
 Signature:
 

--- a/doc/methods.md
+++ b/doc/methods.md
@@ -37,7 +37,7 @@ In order to expose functionality to JavaScript via a template, you must provide 
 <a name="api_nan_function_callback_info"></a>
 ### Nan::FunctionCallbackInfo
 
-`Nan::FunctionCallbackInfo` should be used in place of [`v8::FunctionCallbackInfo`](https://v8docs.nodesource.com/node-8.0/dd/d0d/classv8_1_1_function_callback_info.html), even with older versions of Node where `v8::FunctionCallbackInfo` does not exist.
+`Nan::FunctionCallbackInfo` should be used in place of [`v8::FunctionCallbackInfo`](https://v8docs.nodesource.com/node-8.11/dd/d0d/classv8_1_1_function_callback_info.html), even with older versions of Node where `v8::FunctionCallbackInfo` does not exist.
 
 Definition:
 
@@ -56,14 +56,14 @@ template<typename T> class FunctionCallbackInfo {
 };
 ```
 
-See the [`v8::FunctionCallbackInfo`](https://v8docs.nodesource.com/node-8.0/dd/d0d/classv8_1_1_function_callback_info.html) documentation for usage details on these. See [`Nan::ReturnValue`](#api_nan_return_value) for further information on how to set a return value from methods.
+See the [`v8::FunctionCallbackInfo`](https://v8docs.nodesource.com/node-8.11/dd/d0d/classv8_1_1_function_callback_info.html) documentation for usage details on these. See [`Nan::ReturnValue`](#api_nan_return_value) for further information on how to set a return value from methods.
 
 **Note:** `FunctionCallbackInfo::Callee` is removed in Node.js after `10.0.0` because it is was deprecated in V8. Consider using `info.Data()` to pass any information you need.
 
 <a name="api_nan_property_callback_info"></a>
 ### Nan::PropertyCallbackInfo
 
-`Nan::PropertyCallbackInfo` should be used in place of [`v8::PropertyCallbackInfo`](https://v8docs.nodesource.com/node-8.0/d7/dc5/classv8_1_1_property_callback_info.html), even with older versions of Node where `v8::PropertyCallbackInfo` does not exist.
+`Nan::PropertyCallbackInfo` should be used in place of [`v8::PropertyCallbackInfo`](https://v8docs.nodesource.com/node-8.11/d7/dc5/classv8_1_1_property_callback_info.html), even with older versions of Node where `v8::PropertyCallbackInfo` does not exist.
 
 Definition:
 
@@ -78,12 +78,12 @@ template<typename T> class PropertyCallbackInfo : public PropertyCallbackInfoBas
 };
 ```
 
-See the [`v8::PropertyCallbackInfo`](https://v8docs.nodesource.com/node-8.0/d7/dc5/classv8_1_1_property_callback_info.html) documentation for usage details on these. See [`Nan::ReturnValue`](#api_nan_return_value) for further information on how to set a return value from property accessor methods.
+See the [`v8::PropertyCallbackInfo`](https://v8docs.nodesource.com/node-8.11/d7/dc5/classv8_1_1_property_callback_info.html) documentation for usage details on these. See [`Nan::ReturnValue`](#api_nan_return_value) for further information on how to set a return value from property accessor methods.
 
 <a name="api_nan_return_value"></a>
 ### Nan::ReturnValue
 
-`Nan::ReturnValue` is used in place of [`v8::ReturnValue`](https://v8docs.nodesource.com/node-8.0/da/da7/classv8_1_1_return_value.html) on both [`Nan::FunctionCallbackInfo`](#api_nan_function_callback_info) and [`Nan::PropertyCallbackInfo`](#api_nan_property_callback_info) as the return type of `GetReturnValue()`.
+`Nan::ReturnValue` is used in place of [`v8::ReturnValue`](https://v8docs.nodesource.com/node-8.11/da/da7/classv8_1_1_return_value.html) on both [`Nan::FunctionCallbackInfo`](#api_nan_function_callback_info) and [`Nan::PropertyCallbackInfo`](#api_nan_property_callback_info) as the return type of `GetReturnValue()`.
 
 Example usage:
 
@@ -118,7 +118,7 @@ template<typename T> class ReturnValue {
 };
 ```
 
-See the documentation on [`v8::ReturnValue`](https://v8docs.nodesource.com/node-8.0/da/da7/classv8_1_1_return_value.html) for further information on this.
+See the documentation on [`v8::ReturnValue`](https://v8docs.nodesource.com/node-8.11/da/da7/classv8_1_1_return_value.html) for further information on this.
 
 <a name="api_nan_method"></a>
 ### Method declaration
@@ -522,7 +522,7 @@ bool SetAccessor(v8::Local<v8::Object> obj,
                  v8::PropertyAttribute attribute = v8::None)
 ```
 
-See the V8 [`ObjectTemplate#SetAccessor()`](https://v8docs.nodesource.com/node-8.0/db/d5f/classv8_1_1_object_template.html#aca0ed196f8a9adb1f68b1aadb6c9cd77) and [`Object#SetAccessor()`](https://v8docs.nodesource.com/node-8.0/db/d85/classv8_1_1_object.html#a3f9dee085f5ec346465f1dc924325043) for further information about how to use `Nan::SetAccessor()`.
+See the V8 [`ObjectTemplate#SetAccessor()`](https://v8docs.nodesource.com/node-8.11/db/d5f/classv8_1_1_object_template.html#aca0ed196f8a9adb1f68b1aadb6c9cd77) and [`Object#SetAccessor()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#ae91b3b56b357f285288c89fbddc46d1b) for further information about how to use `Nan::SetAccessor()`.
 
 <a name="api_nan_set_named_property_handler"></a>
 ### Nan::SetNamedPropertyHandler()
@@ -547,7 +547,7 @@ void SetNamedPropertyHandler(v8::Local<v8::ObjectTemplate> tpl,
                              v8::Local<v8::Value> data = v8::Local<v8::Value>())
 ```
 
-See the V8 [`ObjectTemplate#SetNamedPropertyHandler()`](https://v8docs.nodesource.com/io.js-3.3/db/d5f/classv8_1_1_object_template.html#a34d1cc45b642cd131706663801aadd76) for further information about how to use `Nan::SetNamedPropertyHandler()`.
+See the V8 [`ObjectTemplate#SetNamedPropertyHandler()`](https://v8docs.nodesource.com/node-8.11/db/d5f/classv8_1_1_object_template.html#a33b3ebd7de641f6cc6414b7de01fc1c7) for further information about how to use `Nan::SetNamedPropertyHandler()`.
 
 <a name="api_nan_set_indexed_property_handler"></a>
 ### Nan::SetIndexedPropertyHandler()
@@ -572,7 +572,7 @@ void SetIndexedPropertyHandler(v8::Local<v8::ObjectTemplate> tpl,
                                v8::Local<v8::Value> data = v8::Local<v8::Value>())
 ```
 
-See the V8 [`ObjectTemplate#SetIndexedPropertyHandler()`](https://v8docs.nodesource.com/node-8.0/db/d5f/classv8_1_1_object_template.html#ac89f06d634add0e890452033f7d17ff1) for further information about how to use `Nan::SetIndexedPropertyHandler()`.
+See the V8 [`ObjectTemplate#SetIndexedPropertyHandler()`](https://v8docs.nodesource.com/node-8.11/db/d5f/classv8_1_1_object_template.html#ac89f06d634add0e890452033f7d17ff1) for further information about how to use `Nan::SetIndexedPropertyHandler()`.
 
 <a name="api_nan_set_template"></a>
 ### Nan::SetTemplate()
@@ -591,7 +591,7 @@ void Nan::SetTemplate(v8::Local<v8::Template> templ,
                       v8::PropertyAttribute attributes)
 ```
 
-Calls the `Template`'s [`Set()`](https://v8docs.nodesource.com/node-8.0/db/df7/classv8_1_1_template.html#ae3fbaff137557aa6a0233bc7e52214ac).
+Calls the `Template`'s [`Set()`](https://v8docs.nodesource.com/node-8.11/db/df7/classv8_1_1_template.html#ae3fbaff137557aa6a0233bc7e52214ac).
 
 <a name="api_nan_set_prototype_template"></a>
 ### Nan::SetPrototypeTemplate()
@@ -610,7 +610,7 @@ void Nan::SetPrototypeTemplate(v8::Local<v8::FunctionTemplate> templ,
                                v8::PropertyAttribute attributes)
 ```
 
-Calls the `FunctionTemplate`'s _PrototypeTemplate's_ [`Set()`](https://v8docs.nodesource.com/io.js-3.3/db/df7/classv8_1_1_template.html#a2db6a56597bf23c59659c0659e564ddf).
+Calls the `FunctionTemplate`'s _PrototypeTemplate's_ [`Set()`](https://v8docs.nodesource.com/node-8.11/db/df7/classv8_1_1_template.html#a2db6a56597bf23c59659c0659e564ddf).
 
 <a name="api_nan_set_instance_template"></a>
 ### Nan::SetInstanceTemplate()
@@ -629,7 +629,7 @@ void Nan::SetInstanceTemplate(v8::Local<v8::FunctionTemplate> templ,
                               v8::PropertyAttribute attributes)
 ```
 
-Calls the `FunctionTemplate`'s _InstanceTemplate's_ [`Set()`](https://v8docs.nodesource.com/io.js-3.3/db/df7/classv8_1_1_template.html#a2db6a56597bf23c59659c0659e564ddf).
+Calls the `FunctionTemplate`'s _InstanceTemplate's_ [`Set()`](https://v8docs.nodesource.com/node-8.11/db/df7/classv8_1_1_template.html#a2db6a56597bf23c59659c0659e564ddf).
 
 <a name="api_nan_set_call_handler"></a>
 ### Nan::SetCallHandler()
@@ -643,7 +643,7 @@ Signature:
 void Nan::SetCallHandler(v8::Local<v8::FunctionTemplate> templ, Nan::FunctionCallback callback, v8::Local<v8::Value> data = v8::Local<v8::Value>())
 ```
 
-Calls the `FunctionTemplate`'s [`SetCallHandler()`](https://v8docs.nodesource.com/node-8.0/d8/d83/classv8_1_1_function_template.html#a2d3845db66392074c5a018a66efbfada).
+Calls the `FunctionTemplate`'s [`SetCallHandler()`](https://v8docs.nodesource.com/node-8.11/d8/d83/classv8_1_1_function_template.html#ab7574b298db3c27fbc2ed465c08ea2f8).
 
 <a name="api_nan_set_call_as_function_handler"></a>
 ### Nan::SetCallAsFunctionHandler()
@@ -657,5 +657,5 @@ Signature:
 void Nan::SetCallAsFunctionHandler(v8::Local<v8::ObjectTemplate> templ, Nan::FunctionCallback callback, v8::Local<v8::Value> data = v8::Local<v8::Value>())
 ```
 
-Calls the `ObjectTemplate`'s [`SetCallAsFunctionHandler()`](https://v8docs.nodesource.com/node-8.0/db/d5f/classv8_1_1_object_template.html#a5e9612fc80bf6db8f2da199b9b0bd04e).
+Calls the `ObjectTemplate`'s [`SetCallAsFunctionHandler()`](https://v8docs.nodesource.com/node-8.11/db/d5f/classv8_1_1_object_template.html#a5e9612fc80bf6db8f2da199b9b0bd04e).
 

--- a/doc/new.md
+++ b/doc/new.md
@@ -15,7 +15,7 @@ NAN provides a `Nan::New()` helper for the creation of new JavaScript objects in
 
 `Nan::New()` should be used to instantiate new JavaScript objects.
 
-Refer to the specific V8 type in the [V8 documentation](https://v8docs.nodesource.com/io.js-3.3/d1/d83/classv8_1_1_data.html) for information on the types of arguments required for instantiation.
+Refer to the specific V8 type in the [V8 documentation](https://v8docs.nodesource.com/node-8.11/d1/d83/classv8_1_1_data.html) for information on the types of arguments required for instantiation.
 
 Signatures:
 
@@ -75,7 +75,7 @@ v8::Local<v8::String> Nan::New<T>(Nan::ExternalOneByteStringResource * value);
 v8::Local<v8::RegExp> Nan::New<T>(v8::Local<v8::String> pattern, v8::RegExp::Flags flags);
 ```
 
-Note that `Nan::ExternalOneByteStringResource` maps to [`v8::String::ExternalOneByteStringResource`](https://v8docs.nodesource.com/io.js-3.3/d9/db3/classv8_1_1_string_1_1_external_one_byte_string_resource.html), and `v8::String::ExternalAsciiStringResource` in older versions of V8.
+Note that `Nan::ExternalOneByteStringResource` maps to [`v8::String::ExternalOneByteStringResource`](https://v8docs.nodesource.com/node-8.11/d9/db3/classv8_1_1_string_1_1_external_one_byte_string_resource.html), and `v8::String::ExternalAsciiStringResource` in older versions of V8.
 
 
 <a name="api_nan_undefined"></a>
@@ -125,7 +125,7 @@ v8::Local<v8::Boolean> Nan::False()
 <a name="api_nan_empty_string"></a>
 ### Nan::EmptyString()
 
-Call [`v8::String::Empty`](https://v8docs.nodesource.com/io.js-3.3/d2/db3/classv8_1_1_string.html#a7c1bc8886115d7ee46f1d571dd6ebc6d) to reference the empty string in a way that is compatible across all supported versions of V8.
+Call [`v8::String::Empty`](https://v8docs.nodesource.com/node-8.11/d2/db3/classv8_1_1_string.html#a7c1bc8886115d7ee46f1d571dd6ebc6d) to reference the empty string in a way that is compatible across all supported versions of V8.
 
 Signature:
 
@@ -137,7 +137,7 @@ v8::Local<v8::String> Nan::EmptyString()
 <a name="api_nan_new_one_byte_string"></a>
 ### Nan::NewOneByteString()
 
-An implementation of [`v8::String::NewFromOneByte()`](https://v8docs.nodesource.com/io.js-3.3/d2/db3/classv8_1_1_string.html#a5264d50b96d2c896ce525a734dc10f09) provided for consistent availability and API across supported versions of V8. Allocates a new string from Latin-1 data.
+An implementation of [`v8::String::NewFromOneByte()`](https://v8docs.nodesource.com/node-8.11/d2/db3/classv8_1_1_string.html#a5264d50b96d2c896ce525a734dc10f09) provided for consistent availability and API across supported versions of V8. Allocates a new string from Latin-1 data.
 
 Signature:
 

--- a/doc/persistent.md
+++ b/doc/persistent.md
@@ -94,7 +94,7 @@ template<typename T> class PersistentBase {
 };
 ```
 
-See the V8 documentation for [`PersistentBase`](https://v8docs.nodesource.com/io.js-3.3/d4/dca/classv8_1_1_persistent_base.html) for further information.
+See the V8 documentation for [`PersistentBase`](https://v8docs.nodesource.com/node-8.11/d4/dca/classv8_1_1_persistent_base.html) for further information.
 
 **Tip:** To get a `v8::Local` reference to the original object back from a `PersistentBase` or `Persistent` object:
 
@@ -126,7 +126,7 @@ template<typename T> class NonCopyablePersistentTraits {
 };
 ```
 
-See the V8 documentation for [`NonCopyablePersistentTraits`](https://v8docs.nodesource.com/io.js-3.3/de/d73/classv8_1_1_non_copyable_persistent_traits.html) for further information.
+See the V8 documentation for [`NonCopyablePersistentTraits`](https://v8docs.nodesource.com/node-8.11/de/d73/classv8_1_1_non_copyable_persistent_traits.html) for further information.
 
 <a name="api_nan_copyable_persistent_traits"></a>
 ### Nan::CopyablePersistentTraits & v8::CopyablePersistentTraits
@@ -151,7 +151,7 @@ class CopyablePersistentTraits {
 };
 ```
 
-See the V8 documentation for [`CopyablePersistentTraits`](https://v8docs.nodesource.com/io.js-3.3/da/d5c/structv8_1_1_copyable_persistent_traits.html) for further information.
+See the V8 documentation for [`CopyablePersistentTraits`](https://v8docs.nodesource.com/node-8.11/da/d5c/structv8_1_1_copyable_persistent_traits.html) for further information.
 
 <a name="api_nan_persistent"></a>
 ### Nan::Persistent
@@ -204,7 +204,7 @@ template<typename T, typename M> class Persistent : public PersistentBase<T> {
 };
 ```
 
-See the V8 documentation for [`Persistent`](https://v8docs.nodesource.com/io.js-3.3/d2/d78/classv8_1_1_persistent.html) for further information.
+See the V8 documentation for [`Persistent`](https://v8docs.nodesource.com/node-8.11/d2/d78/classv8_1_1_persistent.html) for further information.
 
 <a name="api_nan_global"></a>
 ### Nan::Global
@@ -238,7 +238,7 @@ template<typename T> class Global : public PersistentBase<T> {
 };
 ```
 
-See the V8 documentation for [`Global`](https://v8docs.nodesource.com/io.js-3.3/d5/d40/classv8_1_1_global.html) for further information.
+See the V8 documentation for [`Global`](https://v8docs.nodesource.com/node-8.11/d5/d40/classv8_1_1_global.html) for further information.
 
 <a name="api_nan_weak_callback_info"></a>
 ### Nan::WeakCallbackInfo
@@ -279,7 +279,7 @@ int *data = new int(0);
 obj.SetWeak(data, callback, WeakCallbackType::kParameter);
 ```
 
-See the V8 documentation for [`WeakCallbackInfo`](https://v8docs.nodesource.com/io.js-3.3/d8/d06/classv8_1_1_weak_callback_info.html) for further information.
+See the V8 documentation for [`WeakCallbackInfo`](https://v8docs.nodesource.com/node-8.11/d8/d06/classv8_1_1_weak_callback_info.html) for further information.
 
 <a name="api_nan_weak_callback_type"></a>
 ### Nan::WeakCallbackType

--- a/doc/scopes.md
+++ b/doc/scopes.md
@@ -14,7 +14,7 @@ Also see the V8 Embedders Guide section on [Handles and Garbage Collection](http
 <a name="api_nan_handle_scope"></a>
 ### Nan::HandleScope
 
-A simple wrapper around [`v8::HandleScope`](https://v8docs.nodesource.com/io.js-3.3/d3/d95/classv8_1_1_handle_scope.html).
+A simple wrapper around [`v8::HandleScope`](https://v8docs.nodesource.com/node-8.11/d3/d95/classv8_1_1_handle_scope.html).
 
 Definition:
 

--- a/doc/script.md
+++ b/doc/script.md
@@ -9,7 +9,7 @@ NAN provides a `v8::Script` helpers as the API has changed over the supported ve
 <a name="api_nan_compile_script"></a>
 ### Nan::CompileScript()
 
-A wrapper around [`v8::Script::Compile()`](https://v8docs.nodesource.com/io.js-3.3/da/da5/classv8_1_1_script_compiler.html#a93f5072a0db55d881b969e9fc98e564b).
+A wrapper around [`v8::ScriptCompiler::Compile()`](https://v8docs.nodesource.com/node-8.11/da/da5/classv8_1_1_script_compiler.html#a93f5072a0db55d881b969e9fc98e564b).
 
 Note that `Nan::BoundScript` is an alias for `v8::Script`.
 

--- a/doc/v8_internals.md
+++ b/doc/v8_internals.md
@@ -48,7 +48,7 @@ Signature:
 void Nan::AddGCEpilogueCallback(v8::Isolate::GCEpilogueCallback callback, v8::GCType gc_type_filter = v8::kGCTypeAll)
 ```
 
-Calls V8's [`AddGCEpilogueCallback()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#a90d1860babc76059c62514b422f56960).
+Calls V8's [`AddGCEpilogueCallback()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#a580f976e4290cead62c2fc4dd396be3e).
 
 <a name="api_nan_remove_gc_epilogue_callback"></a>
 ### Nan::RemoveGCEpilogueCallback()
@@ -59,7 +59,7 @@ Signature:
 void Nan::RemoveGCEpilogueCallback(v8::Isolate::GCEpilogueCallback callback)
 ```
 
-Calls V8's [`RemoveGCEpilogueCallback()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#a05c60859fd4b8e96bfcd451281ed6c7c).
+Calls V8's [`RemoveGCEpilogueCallback()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#adca9294555a3908e9f23c7bb0f0f284c).
 
 <a name="api_nan_add_gc_prologue_callback"></a>
 ### Nan::AddGCPrologueCallback()
@@ -70,7 +70,7 @@ Signature:
 void Nan::AddGCPrologueCallback(v8::Isolate::GCPrologueCallback, v8::GCType gc_type_filter callback)
 ```
 
-Calls V8's [`AddGCPrologueCallback()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#ab4b87b8f9f8e5bf95eba4009357e001f).
+Calls V8's [`AddGCPrologueCallback()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#a6dbef303603ebdb03da6998794ea05b8).
 
 <a name="api_nan_remove_gc_prologue_callback"></a>
 ### Nan::RemoveGCPrologueCallback()
@@ -81,7 +81,7 @@ Signature:
 void Nan::RemoveGCPrologueCallback(v8::Isolate::GCPrologueCallback callback)
 ```
 
-Calls V8's [`RemoveGCEpilogueCallback()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#a9f6c51932811593f81ff30b949124186).
+Calls V8's [`RemoveGCPrologueCallback()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#a5f72c7cda21415ce062bbe5c58abe09e).
 
 <a name="api_nan_get_heap_statistics"></a>
 ### Nan::GetHeapStatistics()
@@ -92,7 +92,7 @@ Signature:
 void Nan::GetHeapStatistics(v8::HeapStatistics *heap_statistics)
 ```
 
-Calls V8's [`GetHeapStatistics()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#a5593ac74687b713095c38987e5950b34).
+Calls V8's [`GetHeapStatistics()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#a5593ac74687b713095c38987e5950b34).
 
 <a name="api_nan_set_counter_function"></a>
 ### Nan::SetCounterFunction()
@@ -103,7 +103,7 @@ Signature:
 void Nan::SetCounterFunction(v8::CounterLookupCallback cb)
 ```
 
-Calls V8's [`SetCounterFunction()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#a045d7754e62fa0ec72ae6c259b29af94).
+Calls V8's [`SetCounterFunction()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#a045d7754e62fa0ec72ae6c259b29af94).
 
 <a name="api_nan_set_create_histogram_function"></a>
 ### Nan::SetCreateHistogramFunction()
@@ -114,7 +114,7 @@ Signature:
 void Nan::SetCreateHistogramFunction(v8::CreateHistogramCallback cb) 
 ```
 
-Calls V8's [`SetCreateHistogramFunction()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#a542d67e85089cb3f92aadf032f99e732).
+Calls V8's [`SetCreateHistogramFunction()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#a542d67e85089cb3f92aadf032f99e732).
 
 <a name="api_nan_set_add_histogram_sample_function"></a>
 ### Nan::SetAddHistogramSampleFunction()
@@ -125,7 +125,7 @@ Signature:
 void Nan::SetAddHistogramSampleFunction(v8::AddHistogramSampleCallback cb) 
 ```
 
-Calls V8's [`SetAddHistogramSampleFunction()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#aeb420b690bc2c216882d6fdd00ddd3ea).
+Calls V8's [`SetAddHistogramSampleFunction()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#aeb420b690bc2c216882d6fdd00ddd3ea).
 
 <a name="api_nan_idle_notification"></a>
 ### Nan::IdleNotification()
@@ -133,10 +133,10 @@ Calls V8's [`SetAddHistogramSampleFunction()`](https://v8docs.nodesource.com/io.
 Signature:
 
 ```c++
-void Nan::IdleNotification(v8::HeapStatistics *heap_statistics)
+bool Nan::IdleNotification(int idle_time_in_ms)
 ```
 
-Calls V8's [`IdleNotification()` or `IdleNotificationDeadline()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#ad6a2a02657f5425ad460060652a5a118) depending on V8 version.
+Calls V8's [`IdleNotification()` or `IdleNotificationDeadline()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#ad6a2a02657f5425ad460060652a5a118) depending on V8 version.
 
 <a name="api_nan_low_memory_notification"></a>
 ### Nan::LowMemoryNotification()
@@ -147,7 +147,7 @@ Signature:
 void Nan::LowMemoryNotification() 
 ```
 
-Calls V8's [`LowMemoryNotification()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#a24647f61d6b41f69668094bdcd6ea91f).
+Calls V8's [`LowMemoryNotification()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#a24647f61d6b41f69668094bdcd6ea91f).
 
 <a name="api_nan_context_disposed_notification"></a>
 ### Nan::ContextDisposedNotification()
@@ -158,7 +158,7 @@ Signature:
 void Nan::ContextDisposedNotification()
 ```
 
-Calls V8's [`ContextDisposedNotification()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#ad7f5dc559866343fe6cd8db1f134d48b).
+Calls V8's [`ContextDisposedNotification()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#ad7f5dc559866343fe6cd8db1f134d48b).
 
 <a name="api_nan_get_internal_field_pointer"></a>
 ### Nan::GetInternalFieldPointer()
@@ -171,7 +171,7 @@ Signature:
 void* Nan::GetInternalFieldPointer(v8::Local<v8::Object> object, int index) 
 ```
 
-Calls the Object's [`GetAlignedPointerFromInternalField()` or `GetPointerFromInternalField()`](https://v8docs.nodesource.com/io.js-3.3/db/d85/classv8_1_1_object.html#ab3c57184263cf29963ef0017bec82281) depending on the version of V8.
+Calls the Object's [`GetAlignedPointerFromInternalField()` or `GetPointerFromInternalField()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#a580ea84afb26c005d6762eeb9e3c308f) depending on the version of V8.
 
 <a name="api_nan_set_internal_field_pointer"></a>
 ### Nan::SetInternalFieldPointer()
@@ -184,7 +184,7 @@ Signature:
 void Nan::SetInternalFieldPointer(v8::Local<v8::Object> object, int index, void* value)
 ```
 
-Calls the Object's [`SetAlignedPointerInInternalField()` or `SetPointerInInternalField()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#ad7f5dc559866343fe6cd8db1f134d48b) depending on the version of V8.
+Calls the Object's [`SetAlignedPointerInInternalField()` or `SetPointerInInternalField()`](https://v8docs.nodesource.com/node-8.11/db/d85/classv8_1_1_object.html#ab3c57184263cf29963ef0017bec82281) depending on the version of V8.
 
 <a name="api_nan_adjust_external_memory"></a>
 ### Nan::AdjustExternalMemory()
@@ -195,5 +195,5 @@ Signature:
 int Nan::AdjustExternalMemory(int bytesChange)
 ```
 
-Calls V8's [`AdjustAmountOfExternalAllocatedMemory()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#ae1a59cac60409d3922582c4af675473e).
+Calls V8's [`AdjustAmountOfExternalAllocatedMemory()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#ae1a59cac60409d3922582c4af675473e).
 

--- a/doc/v8_misc.md
+++ b/doc/v8_misc.md
@@ -12,7 +12,7 @@
 
 Converts an object to a UTF-8-encoded character array. If conversion to a string fails (e.g. due to an exception in the toString() method of the object) then the length() method returns 0 and the * operator returns NULL. The underlying memory used for this object is managed by the object.
 
-An implementation of [`v8::String::Utf8Value`](https://v8docs.nodesource.com/io.js-3.3/d4/d1b/classv8_1_1_string_1_1_utf8_value.html) that is consistent across all supported versions of V8.
+An implementation of [`v8::String::Utf8Value`](https://v8docs.nodesource.com/node-8.11/d4/d1b/classv8_1_1_string_1_1_utf8_value.html) that is consistent across all supported versions of V8.
 
 Definition:
 
@@ -31,7 +31,7 @@ class Nan::Utf8String {
 <a name="api_nan_get_current_context"></a>
 ### Nan::GetCurrentContext()
 
-A call to [`v8::Isolate::GetCurrent()->GetCurrentContext()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#a81c7a1ed7001ae2a65e89107f75fd053) that works across all supported versions of V8.
+A call to [`v8::Isolate::GetCurrent()->GetCurrentContext()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#a81c7a1ed7001ae2a65e89107f75fd053) that works across all supported versions of V8.
 
 Signature:
 
@@ -42,7 +42,7 @@ v8::Local<v8::Context> Nan::GetCurrentContext()
 <a name="api_nan_set_isolate_data"></a>
 ### Nan::SetIsolateData()
 
-A helper to provide a consistent API to [`v8::Isolate#SetData()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#a7acadfe7965997e9c386a05f098fbe36).
+A helper to provide a consistent API to [`v8::Isolate#SetData()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#a7acadfe7965997e9c386a05f098fbe36).
 
 Signature:
 
@@ -54,7 +54,7 @@ void Nan::SetIsolateData(v8::Isolate *isolate, T *data)
 <a name="api_nan_get_isolate_data"></a>
 ### Nan::GetIsolateData()
 
-A helper to provide a consistent API to [`v8::Isolate#GetData()`](https://v8docs.nodesource.com/io.js-3.3/d5/dda/classv8_1_1_isolate.html#aabd223436bc1100a787dadaa024c6257).
+A helper to provide a consistent API to [`v8::Isolate#GetData()`](https://v8docs.nodesource.com/node-8.11/d5/dda/classv8_1_1_isolate.html#aabd223436bc1100a787dadaa024c6257).
 
 Signature:
 


### PR DESCRIPTION
Corrected links to v8 docs (used 8.11 where possible) as I got a 404 for the io-js-3.3 links.

Corrected a few copy/paste errors in docs.