### PR TITLE
Add scope.Escape() to Call()

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1658,9 +1658,9 @@ class Callback {
     v8::EscapableHandleScope scope(isolate);
 # if NODE_MODULE_VERSION >= NODE_9_0_MODULE_VERSION
     AsyncResource async("nan:Callback:Call");
-    return Call_(isolate, isolate->GetCurrentContext()->Global(), argc, argv,
-                 &async)
-        .FromMaybe(v8::Local<v8::Value>());
+    return scope.Escape(Call_(isolate, isolate->GetCurrentContext()->Global(),
+                              argc, argv, &async)
+                            .FromMaybe(v8::Local<v8::Value>()));
 # else
     return scope.Escape(
         Call_(isolate, isolate->GetCurrentContext()->Global(), argc, argv));

--- a/test/cpp/nancallback.cpp
+++ b/test/cpp/nancallback.cpp
@@ -57,6 +57,16 @@ NAN_METHOD(ResetSet) {
   info.GetReturnValue().Set(callback.IsEmpty());
 }
 
+NAN_METHOD(CallRetval) {
+  Callback callback(To<v8::Function>(info[0]).ToLocalChecked());
+  v8::Local<v8::Value> result = callback.Call(0, NULL);
+  if (result->IsNumber()) {
+    info.GetReturnValue().Set(Nan::True());
+  } else {
+    info.GetReturnValue().Set(Nan::False());
+  }
+}
+
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("globalContext").ToLocalChecked()
@@ -89,6 +99,10 @@ NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("resetSet").ToLocalChecked()
     , New<v8::FunctionTemplate>(ResetSet)->GetFunction()
+  );
+  Set(target
+    , New<v8::String>("callRetval").ToLocalChecked()
+    , New<v8::FunctionTemplate>(CallRetval)->GetFunction()
   );
 }
 

--- a/test/js/nancallback-test.js
+++ b/test/js/nancallback-test.js
@@ -12,7 +12,7 @@ const test     = require('tap').test
     , round = Math.round;
 
 test('nancallback', function (t) {
-  t.plan(17)
+  t.plan(19)
 
   var persistent = bindings;
   t.type(persistent.globalContext, 'function');
@@ -23,6 +23,7 @@ test('nancallback', function (t) {
   t.type(persistent.callAsFunction, 'function');
   t.type(persistent.resetUnset, 'function');
   t.type(persistent.resetSet, 'function');
+  t.type(persistent.callRetval, 'function');
   persistent.globalContext(function () { t.ok(true); });
   persistent.specificContext(function () { t.ok(true); });
   persistent.customReceiver(function () { t.equal(this, process); }, process);
@@ -30,6 +31,7 @@ test('nancallback', function (t) {
   persistent.callAsFunction(function () { t.ok(true); });
   t.ok(persistent.resetUnset());
   t.ok(persistent.resetSet(function () {}));
+  t.ok(persistent.callRetval(function () { return 1; }));
 
   var round2 = Math.round
     , x = function(param) { return param + 1; }


### PR DESCRIPTION
Added a `scope.Escape()` in `Call()` as suggested by @addaleax in #813.

fixes: #813 