### PR TITLE
add nan-*.tgz to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,4 +6,5 @@ examples/
 appveyor.yml
 Makefile
 cpplint.py
+nan-*.tgz
 doc/.build.sh


### PR DESCRIPTION
The 2.11.1 package at NPM includes a file nan-2.11.1.tgz - most likely npm pack was executed before npm publish.

I added nan-*.tgz to .npmignore to avoid this in future.