### PR TITLE
Allow SetWeak() for non-object persistent handles.

### DIFF
--- a/nan_weak.h
+++ b/nan_weak.h
@@ -270,12 +270,13 @@ inline void Persistent<T, M>::SetWeak(
       , WeakCallbackInfo<P>::template invokeparameter<true>
       , type);
   } else {
-    v8::Local<T>* self = reinterpret_cast<v8::Local<T>*>(this);
-    assert((*self)->IsObject());
-    int count = (*self)->InternalFieldCount();
+    v8::Local<v8::Value>* self_v(reinterpret_cast<v8::Local<v8::Value>*>(this));
+    assert((*self_v)->IsObject());
+    v8::Local<v8::Object> self((*self_v).As<v8::Object>());
+    int count = self->InternalFieldCount();
     void *internal_fields[kInternalFieldsInWeakCallback] = {0, 0};
     for (int i = 0; i < count && i < kInternalFieldsInWeakCallback; i++) {
-      internal_fields[i] = (*self)->GetAlignedPointerFromInternalField(i);
+      internal_fields[i] = self->GetAlignedPointerFromInternalField(i);
     }
     wcbd = new WeakCallbackInfo<P>(
         reinterpret_cast<Persistent<v8::Value>*>(this)
@@ -283,7 +284,7 @@ inline void Persistent<T, M>::SetWeak(
       , 0
       , internal_fields[0]
       , internal_fields[1]);
-    (*self)->SetAlignedPointerInInternalField(0, wcbd);
+    self->SetAlignedPointerInInternalField(0, wcbd);
     v8::PersistentBase<T>::SetWeak(
         static_cast<WeakCallbackInfo<P>*>(0)
       , WeakCallbackInfo<P>::template invoketwofield<true>
@@ -307,12 +308,13 @@ inline void Persistent<T, M>::SetWeak(
         wcbd
       , WeakCallbackInfo<P>::invokeparameter);
   } else {
-    v8::Local<T>* self = reinterpret_cast<v8::Local<T>*>(this);
-    assert((*self)->IsObject());
-    int count = (*self)->InternalFieldCount();
+    v8::Local<v8::Value>* self_v(reinterpret_cast<v8::Local<v8::Value>*>(this));
+    assert((*self_v)->IsObject());
+    v8::Local<v8::Object> self((*self_v).As<v8::Object>());
+    int count = self->InternalFieldCount();
     void *internal_fields[kInternalFieldsInWeakCallback] = {0, 0};
     for (int i = 0; i < count && i < kInternalFieldsInWeakCallback; i++) {
-      internal_fields[i] = (*self)->GetAlignedPointerFromInternalField(i);
+      internal_fields[i] = self->GetAlignedPointerFromInternalField(i);
     }
     wcbd = new WeakCallbackInfo<P>(
         reinterpret_cast<Persistent<v8::Value>*>(this)
@@ -320,7 +322,7 @@ inline void Persistent<T, M>::SetWeak(
       , 0
       , internal_fields[0]
       , internal_fields[1]);
-    (*self)->SetAlignedPointerInInternalField(0, wcbd);
+    self->SetAlignedPointerInInternalField(0, wcbd);
     v8::PersistentBase<T>::SetPhantom(
         static_cast<WeakCallbackInfo<P>*>(0)
       , WeakCallbackInfo<P>::invoketwofield
@@ -345,12 +347,13 @@ inline void Persistent<T, M>::SetWeak(
         wcbd
       , WeakCallbackInfo<P>::invokeparameter);
   } else {
-    v8::Local<T>* self = reinterpret_cast<v8::Local<T>*>(this);
-    assert((*self)->IsObject());
-    int count = (*self)->InternalFieldCount();
+    v8::Local<v8::Value>* self_v(reinterpret_cast<v8::Local<v8::Value>*>(this));
+    assert((*self_v)->IsObject());
+    v8::Local<v8::Object> self((*self_v).As<v8::Object>());
+    int count = self->InternalFieldCount();
     void *internal_fields[kInternalFieldsInWeakCallback] = {0, 0};
     for (int i = 0; i < count && i < kInternalFieldsInWeakCallback; i++) {
-      internal_fields[i] = (*self)->GetAlignedPointerFromInternalField(i);
+      internal_fields[i] = self->GetAlignedPointerFromInternalField(i);
     }
     wcbd = new WeakCallbackInfo<P>(
         reinterpret_cast<Persistent<v8::Value>*>(this)
@@ -358,7 +361,7 @@ inline void Persistent<T, M>::SetWeak(
       , 0
       , internal_fields[0]
       , internal_fields[1]);
-    (*self)->SetAlignedPointerInInternalField(0, wcbd);
+    self->SetAlignedPointerInInternalField(0, wcbd);
     v8::PersistentBase<T>::SetPhantom(
         WeakCallbackInfo<P>::invoketwofield
       , 0
@@ -380,12 +383,13 @@ inline void Persistent<T, M>::SetWeak(
       , parameter);
     v8::PersistentBase<T>::SetWeak(wcbd, WeakCallbackInfo<P>::invoke);
   } else {
-    v8::Local<T>* self = reinterpret_cast<v8::Local<T>*>(this);
-    assert((*self)->IsObject());
-    int count = (*self)->InternalFieldCount();
+    v8::Local<v8::Value>* self_v(reinterpret_cast<v8::Local<v8::Value>*>(this));
+    assert((*self_v)->IsObject());
+    v8::Local<v8::Object> self((*self_v).As<v8::Object>());
+    int count = self->InternalFieldCount();
     void *internal_fields[kInternalFieldsInWeakCallback] = {0, 0};
     for (int i = 0; i < count && i < kInternalFieldsInWeakCallback; i++) {
-      internal_fields[i] = (*self)->GetAlignedPointerFromInternalField(i);
+      internal_fields[i] = self->GetAlignedPointerFromInternalField(i);
     }
     wcbd = new WeakCallbackInfo<P>(
         reinterpret_cast<Persistent<v8::Value>*>(this)
@@ -411,12 +415,13 @@ inline void PersistentBase<T>::SetWeak(
       , parameter);
     persistent.MakeWeak(wcbd, WeakCallbackInfo<P>::invoke);
   } else {
-    v8::Local<T>* self = reinterpret_cast<v8::Local<T>*>(this);
-    assert((*self)->IsObject());
-    int count = (*self)->InternalFieldCount();
+    v8::Local<v8::Value>* self_v(reinterpret_cast<v8::Local<v8::Value>*>(this));
+    assert((*self_v)->IsObject());
+    v8::Local<v8::Object> self((*self_v).As<v8::Object>());
+    int count = self->InternalFieldCount();
     void *internal_fields[kInternalFieldsInWeakCallback] = {0, 0};
     for (int i = 0; i < count && i < kInternalFieldsInWeakCallback; i++) {
-      internal_fields[i] = (*self)->GetPointerFromInternalField(i);
+      internal_fields[i] = self->GetPointerFromInternalField(i);
     }
     wcbd = new WeakCallbackInfo<P>(
         reinterpret_cast<Persistent<v8::Value>*>(this)

--- a/test/cpp/weak.cpp
+++ b/test/cpp/weak.cpp
@@ -39,10 +39,22 @@ NAN_METHOD(Hustle) {
   info.GetReturnValue().Set(wrap(To<v8::Function>(info[0]).ToLocalChecked()));
 }
 
+inline void WeakExternalCallback(const WeakCallbackInfo<void>&) {}
+
+NAN_METHOD(WeakExternal) {
+  void* baton = &baton;  // Actual value doesn't really matter.
+  Persistent<v8::External> external(New<v8::External>(baton));
+  external.SetWeak(baton, WeakExternalCallback, WeakCallbackType::kParameter);
+}
+
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("hustle").ToLocalChecked()
     , New<v8::FunctionTemplate>(Hustle)->GetFunction()
+  );
+  Set(target
+    , New<v8::String>("weakExternal").ToLocalChecked()
+    , New<v8::FunctionTemplate>(WeakExternal)->GetFunction()
   );
 }
 

--- a/test/js/weak-test.js
+++ b/test/js/weak-test.js
@@ -34,3 +34,13 @@ test('weak', function (t) {
     }
   }, 100);
 });
+
+test('weak external', function (t) {
+  t.plan(2);
+
+  var weak = bindings;
+  t.type(weak.weakExternal, 'function');
+
+  weak.weakExternal();
+  t.ok(true);  // All good if the previous line didn't crash.
+});


### PR DESCRIPTION
The definition of the SetWeak() template method constrained the type to
types with a GetAlignedPointerFromInternalField() method.  In practice
that meant it only worked with T=v8::Object.

Lift that restriction so that e.g. T=v8::External now also works.  Note
that `SetWeak(WeakCallbackType::kInternalFields)` for types without the
aforementioned method will result in a run-time assertion.
<hr>

I wrote this over a year ago but I forgot to PR it. I don't need it now but I did want it at the time and it still seems useful so here goes.