### PR TITLE
Fix Node.js v10.12.0 deprecation warnings.

### DIFF
--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -100,9 +100,17 @@ Factory<v8::Function>::New( FunctionCallback callback
     obj->SetInternalField(imp::kDataIndex, val);
   }
 
-  return scope.Escape(v8::Function::New( isolate
-                          , imp::FunctionCallbackWrapper
-                          , obj));
+#if NODE_MAJOR_VERSION >= 10
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Local<v8::Function> function =
+      v8::Function::New(context, imp::FunctionCallbackWrapper, obj)
+      .ToLocalChecked();
+#else
+  v8::Local<v8::Function> function =
+      v8::Function::New(isolate, imp::FunctionCallbackWrapper, obj);
+#endif
+
+  return scope.Escape(function);
 }
 
 //=== Function Template ========================================================
@@ -332,12 +340,25 @@ Factory<v8::String>::New(ExternalOneByteStringResource * value) {
 
 //=== String Object ============================================================
 
+// See https://github.com/nodejs/nan/pull/811#discussion_r224594980.
+// Disable the warning as there is no way around it.
+// TODO(bnoordhuis) Use isolate-based version in Node.js v12.
 Factory<v8::StringObject>::return_t
 Factory<v8::StringObject>::New(v8::Local<v8::String> value) {
-#if V8_MAJOR_VERSION >= 7
-  return v8::StringObject::New(v8::Isolate::GetCurrent(), value).As<v8::StringObject>();
-#else
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   return v8::StringObject::New(value).As<v8::StringObject>();
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+#ifdef _MSC_VER
+#pragma warning(pop)
 #endif
 }
 

--- a/nan_object_wrap.h
+++ b/nan_object_wrap.h
@@ -64,7 +64,10 @@ class ObjectWrap {
   inline void MakeWeak() {
     persistent().v8::PersistentBase<v8::Object>::SetWeak(
         this, WeakCallback, v8::WeakCallbackType::kParameter);
+#if NODE_MAJOR_VERSION < 10
+    // FIXME(bnoordhuis) Probably superfluous in older Node.js versions too.
     persistent().MarkIndependent();
+#endif
   }
 
 #elif NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION

--- a/test/cpp/accessors.cpp
+++ b/test/cpp/accessors.cpp
@@ -61,7 +61,8 @@ NAN_MODULE_INIT(SetterGetter::Init) {
   );
 
   v8::Local<v8::Function> createnew =
-    Nan::New<v8::FunctionTemplate>(CreateNew)->GetFunction();
+    Nan::GetFunction(
+        Nan::New<v8::FunctionTemplate>(CreateNew)).ToLocalChecked();
   Set(target, Nan::New<v8::String>("create").ToLocalChecked(), createnew);
 }
 
@@ -70,7 +71,8 @@ v8::Local<v8::Value> SetterGetter::NewInstance () {
   v8::Local<v8::FunctionTemplate> constructorHandle =
       Nan::New(settergetter_constructor);
   v8::Local<v8::Object> instance =
-    Nan::NewInstance(constructorHandle->GetFunction()).ToLocalChecked();
+    Nan::NewInstance(
+        Nan::GetFunction(constructorHandle).ToLocalChecked()).ToLocalChecked();
   return scope.Escape(instance);
 }
 

--- a/test/cpp/accessors2.cpp
+++ b/test/cpp/accessors2.cpp
@@ -49,7 +49,8 @@ NAN_MODULE_INIT(SetterGetter::Init) {
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
   SetPrototypeMethod(tpl, "log", SetterGetter::Log);
   v8::Local<v8::Function> createnew =
-    Nan::New<v8::FunctionTemplate>(CreateNew)->GetFunction();
+    Nan::GetFunction(Nan::New<v8::FunctionTemplate>(CreateNew))
+    .ToLocalChecked();
   Set(target, Nan::New<v8::String>("create").ToLocalChecked(), createnew);
 }
 
@@ -58,7 +59,8 @@ v8::Local<v8::Value> SetterGetter::NewInstance () {
   v8::Local<v8::FunctionTemplate> constructorHandle =
       Nan::New(settergetter_constructor);
   v8::Local<v8::Object> instance =
-    Nan::NewInstance(constructorHandle->GetFunction()).ToLocalChecked();
+    Nan::NewInstance(Nan::GetFunction(constructorHandle).ToLocalChecked())
+    .ToLocalChecked();
   SetAccessor(
       instance
     , Nan::New("prop1").ToLocalChecked()

--- a/test/cpp/asyncprogressqueueworker.cpp
+++ b/test/cpp/asyncprogressqueueworker.cpp
@@ -55,7 +55,7 @@ NAN_METHOD(DoProgress) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("doProgress").ToLocalChecked()
-    , New<v8::FunctionTemplate>(DoProgress)->GetFunction());
+    , GetFunction(New<v8::FunctionTemplate>(DoProgress)).ToLocalChecked());
 }
 
 NODE_MODULE(asyncprogressqueueworker, Init)

--- a/test/cpp/asyncprogressqueueworkerstream.cpp
+++ b/test/cpp/asyncprogressqueueworkerstream.cpp
@@ -74,7 +74,7 @@ NAN_METHOD(DoProgress) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("doProgress").ToLocalChecked()
-    , New<v8::FunctionTemplate>(DoProgress)->GetFunction());
+    , GetFunction(New<v8::FunctionTemplate>(DoProgress)).ToLocalChecked());
 }
 
 NODE_MODULE(asyncprogressqueueworkerstream, Init)

--- a/test/cpp/asyncprogressworker.cpp
+++ b/test/cpp/asyncprogressworker.cpp
@@ -61,7 +61,7 @@ NAN_METHOD(DoProgress) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("a").ToLocalChecked()
-    , New<v8::FunctionTemplate>(DoProgress)->GetFunction());
+    , GetFunction(New<v8::FunctionTemplate>(DoProgress)).ToLocalChecked());
 }
 
 NODE_MODULE(asyncprogressworker, Init)

--- a/test/cpp/asyncprogressworkersignal.cpp
+++ b/test/cpp/asyncprogressworkersignal.cpp
@@ -59,7 +59,7 @@ NAN_METHOD(DoProgress) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("a").ToLocalChecked()
-    , New<v8::FunctionTemplate>(DoProgress)->GetFunction());
+    , GetFunction(New<v8::FunctionTemplate>(DoProgress)).ToLocalChecked());
 }
 
 NODE_MODULE(asyncprogressworkersignal, Init)

--- a/test/cpp/asyncprogressworkerstream.cpp
+++ b/test/cpp/asyncprogressworkerstream.cpp
@@ -81,7 +81,7 @@ NAN_METHOD(DoProgress) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("a").ToLocalChecked()
-    , New<v8::FunctionTemplate>(DoProgress)->GetFunction());
+    , GetFunction(New<v8::FunctionTemplate>(DoProgress)).ToLocalChecked());
 }
 
 NODE_MODULE(asyncprogressworkerstream, Init)

--- a/test/cpp/asyncworker.cpp
+++ b/test/cpp/asyncworker.cpp
@@ -36,7 +36,7 @@ NAN_METHOD(DoSleep) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("a").ToLocalChecked()
-    , New<v8::FunctionTemplate>(DoSleep)->GetFunction());
+    , GetFunction(New<v8::FunctionTemplate>(DoSleep)).ToLocalChecked());
 }
 
 NODE_MODULE(asyncworker, Init)

--- a/test/cpp/asyncworkererror.cpp
+++ b/test/cpp/asyncworkererror.cpp
@@ -29,7 +29,7 @@ NAN_METHOD(Work) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New("a").ToLocalChecked()
-    , New<v8::FunctionTemplate>(Work)->GetFunction());
+    , GetFunction(New<v8::FunctionTemplate>(Work)).ToLocalChecked());
 }
 
 NODE_MODULE(asyncworkererror, Init)

--- a/test/cpp/buffer.cpp
+++ b/test/cpp/buffer.cpp
@@ -56,19 +56,19 @@ NAN_MODULE_INIT(Init) {
   }
   Set(target
     , New<v8::String>("new1").ToLocalChecked()
-    , New<v8::FunctionTemplate>(New1)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(New1)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("new2").ToLocalChecked()
-    , New<v8::FunctionTemplate>(New2)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(New2)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("new3").ToLocalChecked()
-    , New<v8::FunctionTemplate>(New3)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(New3)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("copy").ToLocalChecked()
-    , New<v8::FunctionTemplate>(Copy)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(Copy)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/bufferworkerpersistent.cpp
+++ b/test/cpp/bufferworkerpersistent.cpp
@@ -61,7 +61,7 @@ NAN_METHOD(DoSleep) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("a").ToLocalChecked()
-    , New<v8::FunctionTemplate>(DoSleep)->GetFunction());
+    , GetFunction(New<v8::FunctionTemplate>(DoSleep)).ToLocalChecked());
 }
 
 NODE_MODULE(bufferworkerpersistent, Init)

--- a/test/cpp/converters.cpp
+++ b/test/cpp/converters.cpp
@@ -75,63 +75,63 @@ NAN_METHOD(Int32Value) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("toBoolean").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ToBoolean)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ToBoolean)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("toNumber").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ToNumber)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ToNumber)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("toString").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ToString)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ToString)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("toDetailString").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ToDetailString)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ToDetailString)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("toFunction").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ToFunction)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ToFunction)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("toObject").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ToObject)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ToObject)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("toInteger").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ToInteger)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ToInteger)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("toUint32").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ToUint32)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ToUint32)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("toInt32").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ToInt32)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ToInt32)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("toArrayIndex").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ToArrayIndex)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ToArrayIndex)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("booleanValue").ToLocalChecked()
-    , New<v8::FunctionTemplate>(BooleanValue)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(BooleanValue)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("numberValue").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NumberValue)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NumberValue)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("integerValue").ToLocalChecked()
-    , New<v8::FunctionTemplate>(IntegerValue)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(IntegerValue)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("uint32Value").ToLocalChecked()
-    , New<v8::FunctionTemplate>(Uint32Value)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(Uint32Value)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("int32Value").ToLocalChecked()
-    , New<v8::FunctionTemplate>(Int32Value)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(Int32Value)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/error.cpp
+++ b/test/cpp/error.cpp
@@ -45,7 +45,7 @@ X(TypeError)
   Nan::Set(                                                                    \
       target                                                                   \
     , Nan::New(#NAME).ToLocalChecked()                                         \
-    , Nan::New<v8::FunctionTemplate>(NAME)->GetFunction());
+    , Nan::GetFunction(New<v8::FunctionTemplate>(NAME)).ToLocalChecked());
 
 
 NAN_MODULE_INIT(Init) {

--- a/test/cpp/gc.cpp
+++ b/test/cpp/gc.cpp
@@ -36,11 +36,11 @@ NAN_METHOD(Check) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("hook").ToLocalChecked()
-    , New<v8::FunctionTemplate>(Hook)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(Hook)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("check").ToLocalChecked()
-    , New<v8::FunctionTemplate>(Check)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(Check)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/indexedinterceptors.cpp
+++ b/test/cpp/indexedinterceptors.cpp
@@ -50,7 +50,8 @@ NAN_MODULE_INIT(IndexedInterceptor::Init) {
     , IndexedInterceptor::PropertyEnumerator);
 
   v8::Local<v8::Function> createnew =
-    Nan::New<v8::FunctionTemplate>(CreateNew)->GetFunction();
+    Nan::GetFunction(Nan::New<v8::FunctionTemplate>(CreateNew))
+    .ToLocalChecked();
   Set(target, Nan::New("create").ToLocalChecked(), createnew);
 }
 
@@ -59,7 +60,8 @@ v8::Local<v8::Value> IndexedInterceptor::NewInstance () {
   v8::Local<v8::FunctionTemplate> constructorHandle =
       Nan::New(indexedinterceptors_constructor);
   v8::Local<v8::Object> instance =
-    Nan::NewInstance(constructorHandle->GetFunction()).ToLocalChecked();
+    Nan::NewInstance(Nan::GetFunction(constructorHandle).ToLocalChecked())
+    .ToLocalChecked();
   return scope.Escape(instance);
 }
 

--- a/test/cpp/isolatedata.cpp
+++ b/test/cpp/isolatedata.cpp
@@ -31,7 +31,7 @@ NAN_METHOD(SetAndGet) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("setAndGet").ToLocalChecked()
-    , New<v8::FunctionTemplate>(SetAndGet)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(SetAndGet)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/json-parse.cpp
+++ b/test/cpp/json-parse.cpp
@@ -27,7 +27,7 @@ NAN_METHOD(Parse) {
 NAN_MODULE_INIT(Init) {
   Nan::Set(target
     , Nan::New<v8::String>("parse").ToLocalChecked()
-    , Nan::New<v8::FunctionTemplate>(Parse)->GetFunction()
+    , Nan::GetFunction(Nan::New<v8::FunctionTemplate>(Parse)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/json-stringify.cpp
+++ b/test/cpp/json-stringify.cpp
@@ -64,7 +64,8 @@ NAN_METHOD(Stringify) {
 NAN_MODULE_INIT(Init) {
   Nan::Set(target
     , Nan::New<v8::String>("stringify").ToLocalChecked()
-    , Nan::New<v8::FunctionTemplate>(Stringify)->GetFunction()
+    , Nan::GetFunction(Nan::New<v8::FunctionTemplate>(Stringify))
+      .ToLocalChecked()
   );
 }
 

--- a/test/cpp/makecallback.cpp
+++ b/test/cpp/makecallback.cpp
@@ -42,8 +42,9 @@ NAN_MODULE_INIT(MyObject::Init) {
 
   SetPrototypeMethod(tpl, "call_emit", CallEmit);
 
-  constructor.Reset(tpl->GetFunction());
-  Set(target, Nan::New("MyObject").ToLocalChecked(), tpl->GetFunction());
+  v8::Local<v8::Function> function = GetFunction(tpl).ToLocalChecked();
+  constructor.Reset(function);
+  Set(target, Nan::New("MyObject").ToLocalChecked(), function);
 }
 
 NAN_METHOD(MyObject::New) {

--- a/test/cpp/morenews.cpp
+++ b/test/cpp/morenews.cpp
@@ -68,36 +68,35 @@ NAN_METHOD(NewExternalAsciiStringResource) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New("newNumber").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewNumber)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewNumber)).ToLocalChecked()
   );
   Set(target
     , New("newNegativeInteger").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewNegativeInteger)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewNegativeInteger)).ToLocalChecked()
   );
   Set(target
     , New("newPositiveInteger").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewPositiveInteger)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewPositiveInteger)).ToLocalChecked()
   );
   Set(target
     , New("newUtf8String").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewUtf8String)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewUtf8String)).ToLocalChecked()
   );
   Set(target
     , New("newLatin1String").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewLatin1String)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewLatin1String)).ToLocalChecked()
   );
   Set(target
     , New("newUcs2String").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewUcs2String)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewUcs2String)).ToLocalChecked()
   );
   Set(target
     , New("newExternalStringResource").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewExternalStringResource)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewExternalStringResource)).ToLocalChecked()
   );
   Set(target
     , New("newExternalAsciiStringResource").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewExternalAsciiStringResource)
-    ->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewExternalAsciiStringResource)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/multifile1.cpp
+++ b/test/cpp/multifile1.cpp
@@ -14,7 +14,7 @@ using namespace Nan;  // NOLINT(build/namespaces)
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("r").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ReturnString)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ReturnString)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/namedinterceptors.cpp
+++ b/test/cpp/namedinterceptors.cpp
@@ -50,7 +50,8 @@ NAN_MODULE_INIT(NamedInterceptor::Init) {
     , NamedInterceptor::PropertyEnumerator);
 
   v8::Local<v8::Function> createnew =
-    Nan::New<v8::FunctionTemplate>(CreateNew)->GetFunction();
+    Nan::GetFunction(Nan::New<v8::FunctionTemplate>(CreateNew))
+    .ToLocalChecked();
   Set(target, Nan::New("create").ToLocalChecked(), createnew);
 }
 
@@ -59,7 +60,8 @@ v8::Local<v8::Value> NamedInterceptor::NewInstance () {
   v8::Local<v8::FunctionTemplate> constructorHandle =
       Nan::New(namedinterceptors_constructor);
   v8::Local<v8::Object> instance =
-    Nan::NewInstance(constructorHandle->GetFunction()).ToLocalChecked();
+    Nan::NewInstance(GetFunction(constructorHandle).ToLocalChecked())
+    .ToLocalChecked();
   return scope.Escape(instance);
 }
 

--- a/test/cpp/nancallback.cpp
+++ b/test/cpp/nancallback.cpp
@@ -37,7 +37,7 @@ NAN_METHOD(CompareCallbacks) {
 
 NAN_METHOD(CallDirect) {
   Callback cb(To<v8::Function>(info[0]).ToLocalChecked());
-  (*cb)->Call(GetCurrentContext()->Global(), 0, NULL);
+  Call(*cb, GetCurrentContext()->Global(), 0, NULL);
 }
 
 NAN_METHOD(CallAsFunction) {
@@ -58,8 +58,10 @@ NAN_METHOD(ResetSet) {
 }
 
 NAN_METHOD(CallRetval) {
+  AsyncResource resource("nan:test.nancallback");
   Callback callback(To<v8::Function>(info[0]).ToLocalChecked());
-  v8::Local<v8::Value> result = callback.Call(0, NULL);
+  v8::Local<v8::Value> result =
+    callback.Call(0, NULL, &resource).ToLocalChecked();
   if (result->IsNumber()) {
     info.GetReturnValue().Set(Nan::True());
   } else {
@@ -70,39 +72,39 @@ NAN_METHOD(CallRetval) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("globalContext").ToLocalChecked()
-    , New<v8::FunctionTemplate>(GlobalContext)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(GlobalContext)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("specificContext").ToLocalChecked()
-    , New<v8::FunctionTemplate>(SpecificContext)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(SpecificContext)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("customReceiver").ToLocalChecked()
-    , New<v8::FunctionTemplate>(CustomReceiver)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(CustomReceiver)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("compareCallbacks").ToLocalChecked()
-    , New<v8::FunctionTemplate>(CompareCallbacks)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(CompareCallbacks)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("callDirect").ToLocalChecked()
-    , New<v8::FunctionTemplate>(CallDirect)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(CallDirect)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("callAsFunction").ToLocalChecked()
-    , New<v8::FunctionTemplate>(CallAsFunction)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(CallAsFunction)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("resetUnset").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ResetUnset)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ResetUnset)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("resetSet").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ResetSet)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ResetSet)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("callRetval").ToLocalChecked()
-    , New<v8::FunctionTemplate>(CallRetval)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(CallRetval)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/news.cpp
+++ b/test/cpp/news.cpp
@@ -165,107 +165,107 @@ NAN_METHOD(NewBoolean2) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("newNumber").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewNumber)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewNumber)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newNegativeInteger").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewNegativeInteger)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewNegativeInteger)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newPositiveInteger").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewPositiveInteger)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewPositiveInteger)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newUnsignedInteger").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewUnsignedInteger)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewUnsignedInteger)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newInt32FromPositive").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewInt32FromPositive)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewInt32FromPositive)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newInt32FromNegative").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewInt32FromNegative)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewInt32FromNegative)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newUint32FromPositive").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewUint32FromPositive)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewUint32FromPositive)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newUint32FromNegative").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewUint32FromNegative)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewUint32FromNegative)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newUtf8String").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewUtf8String)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewUtf8String)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newLatin1String").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewLatin1String)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewLatin1String)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newUcs2String").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewUcs2String)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewUcs2String)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newStdString").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewStdString)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewStdString)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newRegExp").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewRegExp)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewRegExp)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newStringObject").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewStringObject)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewStringObject)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newNumberObject").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewNumberObject)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewNumberObject)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newBooleanObject").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewBooleanObject)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewBooleanObject)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newExternal").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewExternal)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewExternal)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newSignature").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewSignature)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewSignature)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newScript").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewScript)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewScript)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newScript2").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewScript2)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewScript2)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("compileScript").ToLocalChecked()
-    , New<v8::FunctionTemplate>(CompileScript)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(CompileScript)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("compileScript2").ToLocalChecked()
-    , New<v8::FunctionTemplate>(CompileScript2)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(CompileScript2)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newDate").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewDate)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewDate)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newArray").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewArray)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewArray)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newBoolean").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewBoolean)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewBoolean)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("newBoolean2").ToLocalChecked()
-    , New<v8::FunctionTemplate>(NewBoolean2)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(NewBoolean2)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/returnemptystring.cpp
+++ b/test/cpp/returnemptystring.cpp
@@ -17,7 +17,7 @@ NAN_METHOD(ReturnEmptyString) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("r").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ReturnEmptyString)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ReturnEmptyString)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/returnnull.cpp
+++ b/test/cpp/returnnull.cpp
@@ -15,7 +15,8 @@ NAN_METHOD(ReturnNull) {
 NAN_MODULE_INIT(Init) {
   Nan::Set(target
     , Nan::New<v8::String>("r").ToLocalChecked()
-    , Nan::New<v8::FunctionTemplate>(ReturnNull)->GetFunction()
+    , Nan::GetFunction(Nan::New<v8::FunctionTemplate>(ReturnNull))
+      .ToLocalChecked()
   );
 }
 

--- a/test/cpp/returnundefined.cpp
+++ b/test/cpp/returnundefined.cpp
@@ -17,7 +17,7 @@ NAN_METHOD(ReturnUndefined) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("r").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ReturnUndefined)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ReturnUndefined)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/returnvalue.cpp
+++ b/test/cpp/returnvalue.cpp
@@ -39,19 +39,19 @@ NAN_MODULE_INIT(Init) {
 
   Set(target
     , New<v8::String>("r").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ReturnAValue)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ReturnAValue)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("p").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ReturnPrimitive)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ReturnPrimitive)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("q").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ReturnGlobal)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ReturnGlobal)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("u").ToLocalChecked()
-    , New<v8::FunctionTemplate>(ReturnUnsigned)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(ReturnUnsigned)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/setcallhandler.cpp
+++ b/test/cpp/setcallhandler.cpp
@@ -33,11 +33,11 @@ NAN_METHOD(CallAsFunctionHandlerSetter) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New("a").ToLocalChecked()
-    , New<v8::FunctionTemplate>(CallHandlerSetter)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(CallHandlerSetter)).ToLocalChecked()
   );
   Set(target
     , New("b").ToLocalChecked()
-    , New<v8::FunctionTemplate>(CallAsFunctionHandlerSetter)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(CallAsFunctionHandlerSetter)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/settemplate.cpp
+++ b/test/cpp/settemplate.cpp
@@ -72,10 +72,11 @@ NAN_MODULE_INIT(MyObject::Init) {
   , Nan::New<v8::String>("dontDelete").ToLocalChecked()
   , v8::DontDelete);
 
-  constructor.Reset(tpl->GetFunction());
+  v8::Local<v8::Function> function = Nan::GetFunction(tpl).ToLocalChecked();
+  constructor.Reset(function);
   Set(target
   , Nan::New<v8::String>("MyObject").ToLocalChecked()
-  , tpl->GetFunction());
+  , function);
 
 
   //=== SetMethod ==============================================================

--- a/test/cpp/strings.cpp
+++ b/test/cpp/strings.cpp
@@ -40,20 +40,20 @@ NAN_MODULE_INIT(Init) {
 
   returnUtf8String_persistent.Reset(returnUtf8String);
 
-  target->Set(
-      New("returnUtf8String").ToLocalChecked()
-    , returnUtf8String->GetFunction()
-  );
+  Set(target
+    , New("returnUtf8String").ToLocalChecked()
+    , GetFunction(returnUtf8String).ToLocalChecked()
+  ).FromJust();
 
   v8::Local<v8::FunctionTemplate> heapString =
     New<v8::FunctionTemplate>(HeapString);
 
   heapString_persistent.Reset(heapString);
 
-  target->Set(
-      New("heapString").ToLocalChecked()
-    , heapString->GetFunction()
-  );
+  Set(target
+    , New("heapString").ToLocalChecked()
+    , GetFunction(heapString).ToLocalChecked()
+  ).FromJust();
 
   v8::Local<v8::FunctionTemplate> encodeHex =
     New<v8::FunctionTemplate>(EncodeHex);
@@ -62,8 +62,8 @@ NAN_MODULE_INIT(Init) {
 
   Set(target
     , New("encodeHex").ToLocalChecked()
-    , encodeHex->GetFunction()
-  );
+    , GetFunction(encodeHex).ToLocalChecked()
+  ).FromJust();
 
   v8::Local<v8::FunctionTemplate> encodeUCS2 =
     New<v8::FunctionTemplate>(EncodeUCS2);
@@ -72,8 +72,8 @@ NAN_MODULE_INIT(Init) {
 
   Set(target
     , New("encodeUCS2").ToLocalChecked()
-    , encodeUCS2->GetFunction()
-  );
+    , GetFunction(encodeUCS2).ToLocalChecked()
+  ).FromJust();
 }
 
 NODE_MODULE(strings, Init)

--- a/test/cpp/threadlocal.cpp
+++ b/test/cpp/threadlocal.cpp
@@ -63,7 +63,7 @@ NAN_METHOD(thread_local_storage) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("thread_local_storage").ToLocalChecked()
-    , New<v8::FunctionTemplate>(thread_local_storage)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(thread_local_storage)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/trycatch.cpp
+++ b/test/cpp/trycatch.cpp
@@ -24,7 +24,7 @@ NAN_METHOD(TryCatchTest) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("r").ToLocalChecked()
-    , New<v8::FunctionTemplate>(TryCatchTest)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(TryCatchTest)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/weak.cpp
+++ b/test/cpp/weak.cpp
@@ -50,11 +50,11 @@ NAN_METHOD(WeakExternal) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("hustle").ToLocalChecked()
-    , New<v8::FunctionTemplate>(Hustle)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(Hustle)).ToLocalChecked()
   );
   Set(target
     , New<v8::String>("weakExternal").ToLocalChecked()
-    , New<v8::FunctionTemplate>(WeakExternal)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(WeakExternal)).ToLocalChecked()
   );
 }
 

--- a/test/cpp/weak2.cpp
+++ b/test/cpp/weak2.cpp
@@ -27,7 +27,7 @@ v8::Local<v8::String> wrap() {
   v8::Local<v8::String> lstring = New("result").ToLocalChecked();
   v8::Local<v8::ObjectTemplate> otpl = New<v8::ObjectTemplate>();
   otpl->SetInternalFieldCount(1);
-  v8::Local<v8::Object> obj = otpl->NewInstance();
+  v8::Local<v8::Object> obj = NewInstance(otpl).ToLocalChecked();
   SetInternalFieldPointer(obj, 0, new int(42));
   Persistent<v8::Object> persistent(obj);
   persistent.SetWeak(
@@ -47,7 +47,7 @@ NAN_METHOD(Hustle) {
 NAN_MODULE_INIT(Init) {
   Set(target
     , New<v8::String>("hustle").ToLocalChecked()
-    , New<v8::FunctionTemplate>(Hustle)->GetFunction()
+    , GetFunction(New<v8::FunctionTemplate>(Hustle)).ToLocalChecked()
   );
 }
 


### PR DESCRIPTION
v10.12.0 turns on a number of V8 deprecation warnings. This commit fixes
them in NAN.

Fixes: #810
Refs: #811