### PR TITLE
Drop Node.js v0.8.x from Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
     - g++-4.8
 env:
   matrix:
-  - TRAVIS_NODE_VERSION="0.8"
   - TRAVIS_NODE_VERSION="0.10"
   - TRAVIS_NODE_VERSION="0.12"
   - TRAVIS_NODE_VERSION="4"


### PR DESCRIPTION
node-gyp v3.6.3 doesn't work with node.js v0.8.28 any longer and
therefore the test suite doesn't build. As that is outside our
control, drop it.

In fact, it's a dependency of node-gyp that stopped working but
that is immaterial, the net result is the same.