### PR TITLE
fix: check V8 version directly instead of inferring from NMV

### DIFF
--- a/nan_converters_43_inl.h
+++ b/nan_converters_43_inl.h
@@ -25,7 +25,8 @@ X(Object)
 X(Integer)
 X(Uint32)
 X(Int32)
-#if NODE_MODULE_VERSION <= NODE_11_0_MODULE_VERSION
+// V8 <= 7.0
+#if V8_MAJOR_VERSION < 7 || (V8_MAJOR_VERSION == 7 && V8_MINOR_VERSION == 0)
 X(Boolean)
 #else
 imp::ToFactory<v8::Boolean>::return_t                                          \
@@ -50,7 +51,8 @@ X(double, Number)
 X(int64_t, Integer)
 X(uint32_t, Uint32)
 X(int32_t, Int32)
-#if NODE_MODULE_VERSION <= NODE_11_0_MODULE_VERSION
+// V8 <= 7.0
+#if V8_MAJOR_VERSION < 7 || (V8_MAJOR_VERSION == 7 && V8_MINOR_VERSION == 0)
 X(bool, Boolean)
 #else
 imp::ToFactory<bool>::return_t                                                 \

--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -345,7 +345,8 @@ Factory<v8::String>::New(ExternalOneByteStringResource * value) {
 // TODO(bnoordhuis) Use isolate-based version in Node.js v12.
 Factory<v8::StringObject>::return_t
 Factory<v8::StringObject>::New(v8::Local<v8::String> value) {
-#if NODE_MODULE_VERSION > NODE_11_0_MODULE_VERSION
+// V8 > 7.0
+#if V8_MAJOR_VERSION > 7 || (V8_MAJOR_VERSION == 7 && V8_MINOR_VERSION > 0)
   return v8::StringObject::New(v8::Isolate::GetCurrent(), value).As<v8::StringObject>();
 #else
 #ifdef _MSC_VER


### PR DESCRIPTION
The changes introduced in https://github.com/nodejs/nan/commit/d113c0282072e7ff4f9dfc98b432fd894b798c2c make the (historically correct) assumption that it's impossible for an older version of node (and therefore an older version of V8) to have a higher NODE_MODULE_VERSION.

As of Electron `4.1.0` however this is not the case, it embeds node `10.11` with v8 `v6.9.427.24` but has the NMV of `69` which is higher than node 11's NMV of `68`.  As Electron continuously gets their own NMV numbers (refs https://github.com/nodejs/TSC/issues/651) we can't make this assumption any more.  Currently native modules are failing to build against Electron 4 because of this issue.

This PR updates these checks to check what actually matters here (the V8 version).

cc @kkoopa @Flarna 