### PR TITLE
remove usage of deprecated IsNearDeath

### DIFF
--- a/nan_object_wrap.h
+++ b/nan_object_wrap.h
@@ -21,7 +21,6 @@ class ObjectWrap {
       return;
     }
 
-    assert(persistent().IsNearDeath());
     persistent().ClearWeak();
     persistent().Reset();
   }
@@ -124,7 +123,6 @@ class ObjectWrap {
   WeakCallback(v8::WeakCallbackInfo<ObjectWrap> const& info) {
     ObjectWrap* wrap = info.GetParameter();
     assert(wrap->refs_ == 0);
-    assert(wrap->handle_.IsNearDeath());
     wrap->handle_.Reset();
     delete wrap;
   }


### PR DESCRIPTION
Remove use of `PersistentBase::IsNearDeath()` as it has been deprecated in V8 and it would causes compilation warnings in Node.JS 12.

I have not added any `ifdefs` here as it was used only within `asserts`.

Refs: https://github.com/nodejs/node/pull/26630