### PR TITLE
Remove sudo: false from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 os:
   - linux
   - osx
-sudo: false
 language: cpp
 addons:
   apt:


### PR DESCRIPTION
According to the blog post it's deprecated and should be removed.
I don't think it matters one way or the other to us so away it goes.

Fixes: https://github.com/nodejs/nan/issues/846
Refs: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration