### PR TITLE
add windows test support to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
   - osx
+  - windows
 language: cpp
 addons:
   apt:


### PR DESCRIPTION
This is test PR, adding windows build support to Travis. It's an alternative for #850 to waiting for appveyor support.  IME, Travis windows builds are a fair bit slower than appveyor, but I've also had plenty of false positives on appveyor tests, so it's a mixed bag.

This PR should kick off a Travis build and we can see if it works or not.