### PR TITLE
spec: add support for enabling gc at runtime in tests

### DIFF
--- a/test/js/gc-fn.js
+++ b/test/js/gc-fn.js
@@ -1,0 +1,10 @@
+if (global.gc) {
+  module.exports = global.gc
+  return
+}
+
+var v8 = require('v8');
+var vm = require('vm');
+
+v8.setFlagsFromString('--expose_gc');
+module.exports = vm.runInNewContext('gc');

--- a/test/js/gc-fn.js
+++ b/test/js/gc-fn.js
@@ -1,6 +1,6 @@
 if (global.gc) {
-  module.exports = global.gc
-  return
+  module.exports = global.gc;
+  return;
 }
 
 var v8 = require('v8');

--- a/test/js/gc-test.js
+++ b/test/js/gc-test.js
@@ -8,7 +8,8 @@
 
 const test     = require('tap').test
     , testRoot = require('path').resolve(__dirname, '..')
-    , bindings = require('bindings')({ module_root: testRoot, bindings: 'gc' });
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'gc' })
+    , gc = require('./gc-fn');
 
 test('gc', function (t) {
   t.plan(3);
@@ -17,6 +18,6 @@ test('gc', function (t) {
   t.type(bindings.check, 'function');
 
   bindings.hook();
-  require('./gc-fn')();
+  gc();
   t.ok(bindings.check());
 });

--- a/test/js/gc-test.js
+++ b/test/js/gc-test.js
@@ -17,6 +17,6 @@ test('gc', function (t) {
   t.type(bindings.check, 'function');
 
   bindings.hook();
-  gc();
+  require('./gc-fn')();
   t.ok(bindings.check());
 });

--- a/test/js/weak-test.js
+++ b/test/js/weak-test.js
@@ -23,10 +23,10 @@ test('weak', function (t) {
 
   var timeout = setTimeout(function () {
     // run weak callback, should dispose
-    gc();
+    require('./gc-fn')();
 
     // do not run weak callback
-    gc();
+    require('./gc-fn')();
 
     if (count > 0) {
       clearTimeout(timeout);

--- a/test/js/weak-test.js
+++ b/test/js/weak-test.js
@@ -8,7 +8,8 @@
 
 const test     = require('tap').test
     , testRoot = require('path').resolve(__dirname, '..')
-    , bindings = require('bindings')({ module_root: testRoot, bindings: 'weak' });
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'weak' })
+    , gc = require('./gc-fn');
 
 test('weak', function (t) {
   t.plan(3);
@@ -23,10 +24,10 @@ test('weak', function (t) {
 
   var timeout = setTimeout(function () {
     // run weak callback, should dispose
-    require('./gc-fn')();
+    gc();
 
     // do not run weak callback
-    require('./gc-fn')();
+    gc();
 
     if (count > 0) {
       clearTimeout(timeout);

--- a/test/js/weak2-test.js
+++ b/test/js/weak2-test.js
@@ -22,10 +22,10 @@ test('weak2', function (t) {
   });
 
   // run weak callback, should dispose
-  gc();
+  require('./gc-fn')();
 
   // do not run weak callback
-  gc();
+  require('./gc-fn')();
 
   var timeout = setTimeout(function () {
     if (count > 0) {

--- a/test/js/weak2-test.js
+++ b/test/js/weak2-test.js
@@ -8,7 +8,8 @@
 
 const test     = require('tap').test
     , testRoot = require('path').resolve(__dirname, '..')
-    , bindings = require('bindings')({ module_root: testRoot, bindings: 'weak2' });
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'weak2' })
+    , gc = require('./gc-fn');
 
 test('weak2', function (t) {
   t.plan(3);
@@ -22,10 +23,10 @@ test('weak2', function (t) {
   });
 
   // run weak callback, should dispose
-  require('./gc-fn')();
+  gc();
 
   // do not run weak callback
-  require('./gc-fn')();
+  gc();
 
   var timeout = setTimeout(function () {
     if (count > 0) {


### PR DESCRIPTION
This allows folks running the `nan` tests in their own CI to run it without `--expose_gc` being supported as an incoming CLI flag.

The backstory here is I'm setting up some infra to run nan's test suite on Electron CI so that we know when things are gonna break as typically nowadays we are on the fringe of V8 👍 