### PR TITLE
fix: Install Node independent from AppVeyor images

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node 0.STABLE.latest
-  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
   - IF %nodejs_version% EQU 0.8 npm config set strict-ssl false
   - IF %nodejs_version% LSS 4 npm -g install npm@2
   - IF %nodejs_version% EQU 5 npm -g install npm@3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node 0.STABLE.latest
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
   - IF %nodejs_version% EQU 0.8 npm config set strict-ssl false
   - IF %nodejs_version% LSS 4 npm -g install npm@2
   - IF %nodejs_version% EQU 5 npm -g install npm@3


### PR DESCRIPTION
Even though Node.js v12 is in the test matrix, it's not being tested. The cause is AppVeyor, which hasn't added v12 to its images just yet.

Luckily, there's a way to have AppVeyor install whatever Node version we want – using `Update-NodeJsInstallation`, which is present in all images.