### PR TITLE
Add variant of Nan::New<v8::String> which takes a C++17 string_view

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -53,6 +53,10 @@
 
 #define NAN_HAS_CPLUSPLUS_17 (__cplusplus >= 201703L)
 
+#ifndef NAN_ENABLE_STRING_VIEW
+# define NAN_ENABLE_STRING_VIEW NAN_HAS_CPLUSPLUS_17
+#endif
+
 #include <uv.h>
 #include <node.h>
 #include <node_buffer.h>
@@ -73,6 +77,9 @@
 # include <queue>
 # include <string>
 # include <vector>
+#endif
+#if NAN_ENABLE_STRING_VIEW
+# include <string_view>
 #endif
 
 // uv helpers

--- a/nan.h
+++ b/nan.h
@@ -51,6 +51,8 @@
 # error This version of node/NAN/v8 requires a C++11 compiler
 #endif
 
+#define NAN_HAS_CPLUSPLUS_17 (__cplusplus >= 201703L)
+
 #include <uv.h>
 #include <node.h>
 #include <node_buffer.h>

--- a/nan_new.h
+++ b/nan_new.h
@@ -161,6 +161,9 @@ struct Factory<v8::String> : MaybeFactoryBase<v8::String> {
   static inline return_t New(const char *value, int length = -1);
   static inline return_t New(const uint16_t *value, int length = -1);
   static inline return_t New(std::string const& value);
+  #if NAN_ENABLE_STRING_VIEW
+  static inline return_t New(std::string_view value);
+  #endif
 
   static inline return_t New(v8::String::ExternalStringResource * value);
   static inline return_t New(ExternalOneByteStringResource * value);
@@ -288,6 +291,14 @@ imp::Factory<v8::Number>::return_t
 New(double value) {
   return New<v8::Number>(value);
 }
+
+#if NAN_ENABLE_STRING_VIEW
+inline
+imp::Factory<v8::String>::return_t
+New(std::string_view value) {
+  return New<v8::String>(value.data(), value.length());
+}
+#endif
 
 inline
 imp::Factory<v8::String>::return_t


### PR DESCRIPTION
This PR adds `Nan::New<v8::String>(std::string_view)`, which makes it easier to handle compile time known strings.

In order to maintan backwards compatibility to C++11, a `NAN_HAS_CPLUSPLUS_17` macro is added (which will also be needed for my next PRs), the code is wrapped into `NAN_ENABLE_STRING_VIEW` guards. If the user wishes to disable the usage of string_view, it can be disabled via adding a define `-DNAN_ENABLE_STRING_VIEW=false`, otherwise it is automatically enabled if it's supported by the C++ runtime (C++17 and up)