### PR TITLE
Added power support for the travis.yml file with ppc64le and dropped node 0.10,0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ addons:
     - g++-4.8
 env:
   matrix:
-  - TRAVIS_NODE_VERSION="0.10"
-  - TRAVIS_NODE_VERSION="0.12"
   - TRAVIS_NODE_VERSION="4"
   - TRAVIS_NODE_VERSION="5"
   - TRAVIS_NODE_VERSION="6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ os:
   - linux
   - osx
 language: cpp
+arch:
+  - amd64
+  - ppc64le
 addons:
   apt:
     sources:


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing

Dropped  ppc64 unsupported node versions 0.10, 0.12 