### PR TITLE
tests: adapt for v8 8.9

### DIFF
--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -246,7 +246,12 @@ NAN_METHOD(testScript) {
 
   t.plan(6);
 
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 8 ||                      \
+  (V8_MAJOR_VERSION == 8 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 9))
+  ScriptOrigin origin(New("foo").ToLocalChecked(), 5);
+#else
   ScriptOrigin origin(New("foo").ToLocalChecked(), New(5));
+#endif
 
   t.ok(_( assertType<Script>(New<Script>(
       New("2 + 3").ToLocalChecked()).ToLocalChecked())));


### PR DESCRIPTION
V8 API for `ScriptOrigin` constructor has changed. Adapt test to compile with v8 8.9.

Currently only `ScriptOrigin` instances are consumed by NAN therefore no adaptions in the NAN API are needed to keep build/tests working.

fixes: #909