### PR TITLE
Use utf-16 string literal to fix alignment in `strings` test

### DIFF
--- a/test/cpp/strings.cpp
+++ b/test/cpp/strings.cpp
@@ -26,7 +26,7 @@ NAN_METHOD(EncodeHex) {
 }
 
 NAN_METHOD(EncodeUCS2) {
-  info.GetReturnValue().Set(Encode("h\0e\0l\0l\0o\0", 10, UCS2));
+  info.GetReturnValue().Set(Encode(u"hello", 10, UCS2));
 }
 
 Persistent<v8::FunctionTemplate> returnUtf8String_persistent;


### PR DESCRIPTION
Currently, the `strings` test in NAN can sometimes cause [a performance DCHECK in v8](https://source.chromium.org/chromium/chromium/src/+/main:v8/src/objects/string.h;l=485;drc=4cf7a03ae38ed1bb17c60536b62d7bd39cdf1495) to fail. This is because the `strings` test passes UTF-16 string data as a normal string literal (i.e. `const char*`), meaning what is eventually interpreted as an unsigned `char16_t` may not have the correct alignment.

To be clear, the DCHECK in question seems to only be there for efficiency/correctness of calling code and there is code in place right after it to handle misaligned string data anyway. However, that doesn't stop the test from failing (when v8 is built with DCHECKs on) if the assembler decides to misalign what it thinks is `const char*` data.

I'm upstreaming this change [from a patch we made in :electron: Electron](https://github.com/electron/electron/issues/29284) recently to fix this since we build with DCHECKs on and started running into this problem when running NAN's test suite. 😊