### PR TITLE
docs: license format and contributors

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,10 +1,6 @@
 The MIT License (MIT)
-=====================
 
-Copyright (c) 2018 NAN contributors
------------------------------------
-
-*NAN contributors listed at <https://github.com/nodejs/nan#contributors>*
+Copyright (c) 2018 [NAN contributors](<https://github.com/nodejs/nan#wg-members--collaborators>)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
The license file differed enough that licensed did not recognize it.

The link to the contributors was also outdated.