### PR TITLE
Fix warnings

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -163,7 +163,7 @@ namespace Nan {
 #undef NODE_MODULE_X
 #define NODE_MODULE_X(modname, regfunc, priv, flags)                  \
   extern "C" {                                                        \
-    static void trampoline(v8::Local<v8::Object> target,              \
+    void nan_mod_init(v8::Local<v8::Object> target,                   \
       v8::Local<v8::Value>,                                           \
       void *) {                                                       \
       regfunc(target);                                                \
@@ -174,7 +174,7 @@ namespace Nan {
       flags,                                                          \
       NULL,  /* NOLINT (readability/null_usage) */                    \
       __FILE__,                                                       \
-      (node::addon_register_func) (trampoline),                       \
+      (node::addon_register_func) (nan_mod_init),                     \
       NULL,  /* NOLINT (readability/null_usage) */                    \
       NODE_STRINGIFY(modname),                                        \
       priv,                                                           \

--- a/nan_weak.h
+++ b/nan_weak.h
@@ -55,7 +55,7 @@ class WeakCallbackInfo {
     , void *field1 = 0
     , void *field2 = 0) :
         callback_(callback), isolate_(0), parameter_(parameter) {
-    std::memcpy(&persistent_, persistent, sizeof (v8::Persistent<v8::Value>));
+    std::memcpy((void*)&persistent_, (void*)persistent, sizeof (v8::Persistent<v8::Value>));
     internal_fields_[0] = field1;
     internal_fields_[1] = field2;
   }

--- a/test/cpp/accessors.cpp
+++ b/test/cpp/accessors.cpp
@@ -97,8 +97,8 @@ NAN_GETTER(SetterGetter::GetProp1) {
     , "Prop1:GETTER("
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
-  strncat(
-      settergetter->log
+  strncpy(
+      settergetter->log + strlen(settergetter->log)
     , settergetter->prop1
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
@@ -119,8 +119,8 @@ NAN_GETTER(SetterGetter::GetProp2) {
     , "Prop2:GETTER("
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
-  strncat(
-      settergetter->log
+  strncpy(
+      settergetter->log + strlen(settergetter->log)
     , settergetter->prop2
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
@@ -146,8 +146,8 @@ NAN_SETTER(SetterGetter::SetProp2) {
     , "Prop2:SETTER("
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
-  strncat(
-      settergetter->log
+  strncpy(
+      settergetter->log + strlen(settergetter->log)
     , settergetter->prop2
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));

--- a/test/cpp/accessors2.cpp
+++ b/test/cpp/accessors2.cpp
@@ -95,8 +95,8 @@ NAN_GETTER(SetterGetter::GetProp1) {
     , "Prop1:GETTER("
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
-  strncat(
-      settergetter->log
+  strncpy(
+      settergetter->log + strlen(settergetter->log)
     , settergetter->prop1
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
@@ -117,8 +117,8 @@ NAN_GETTER(SetterGetter::GetProp2) {
     , "Prop2:GETTER("
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
-  strncat(
-      settergetter->log
+  strncpy(
+      settergetter->log + strlen(settergetter->log)
     , settergetter->prop2
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
@@ -144,8 +144,8 @@ NAN_SETTER(SetterGetter::SetProp2) {
     , "Prop2:SETTER("
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
-  strncat(
-      settergetter->log
+  strncpy(
+      settergetter->log + strlen(settergetter->log)
     , settergetter->prop2
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));

--- a/test/cpp/methodswithdata.cpp
+++ b/test/cpp/methodswithdata.cpp
@@ -81,8 +81,8 @@ NAN_GETTER(SetterGetter::GetProp1) {
     , "Prop1:GETTER("
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
-  strncat(
-      settergetter->log
+  strncpy(
+      settergetter->log + strlen(settergetter->log)
     , settergetter->prop1
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
@@ -106,8 +106,8 @@ NAN_GETTER(SetterGetter::GetProp2) {
     , "Prop2:GETTER("
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
-  strncat(
-      settergetter->log
+  strncpy(
+      settergetter->log + strlen(settergetter->log)
     , settergetter->prop2
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
@@ -136,8 +136,8 @@ NAN_SETTER(SetterGetter::SetProp2) {
     , "Prop2:SETTER("
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
-  strncat(
-      settergetter->log
+  strncpy(
+      settergetter->log + strlen(settergetter->log)
     , settergetter->prop2
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
   assert(strlen(settergetter->log) < sizeof (settergetter->log));

--- a/test/cpp/persistent.cpp
+++ b/test/cpp/persistent.cpp
@@ -29,7 +29,7 @@ NAN_METHOD(ToPersistentAndBackAgain) {
   Persistent<v8::Object> persistent(To<v8::Object>(info[0]).ToLocalChecked());
   v8::Local<v8::Object> object = New(persistent);
   persistent.Reset();
-  memset(&persistent, -1, sizeof(persistent));  // Clobber it good.
+  memset((void*)&persistent, -1, sizeof(persistent));  // Clobber it good.
   info.GetReturnValue().Set(object);
 }
 


### PR DESCRIPTION
Fix all recent gcc warnings - class memaccess, incompatible function pointer cast and `strncat` restrict warnings