### PR TITLE
fix appveyor build tests when x86 binary is not available

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ environment:
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node 0.STABLE.latest
-  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) x64
   - IF %nodejs_version% LSS 4 npm -g install npm@2
   - IF %nodejs_version% EQU 5 npm -g install npm@3
   - set PATH=%APPDATA%\npm;%PATH%


### PR DESCRIPTION
As per Feodor Fitsner (Appveyor Support staff):

> There is no x86 build of Node 18.x anymore, so you should [...] change it to:
>
> Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) x64

See Appveyor ticket: https://help.appveyor.com/discussions/problems/31957-please-install-nodejs-v18-new-builds-are-failing-looks-like-node-18-is-missing

This fixes the following error:
```
Running Install scripts
Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
Updating Node.js v18.0.0 (x86)
Uninstalling Node.js v8.17.0 (x86)...
Installing Node.js v18.0.0 (x86)...
Exception calling "DownloadFile" with "2" argument(s): "The remote server returned an error: (404) Not Found."
At C:\Program Files\AppVeyor\BuildAgent\Modules\nodejs-utils\nodejs-utils.psm1:58 char:5
+     (New-Object Net.WebClient).DownloadFile($packageUrl, $packageFile ...
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException

IF %nodejs_version% LSS 4 npm -g install npm@2
IF %nodejs_version% EQU 5 npm -g install npm@3
set PATH=%APPDATA%\npm;%PATH%
npm install
'npm' is not recognized as an internal or external command,
operable program or batch file.
Command exited with code 1
```