### PR TITLE
package.json: fix supported Node.js versions in package description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nan",
   "version": "2.16.0",
-  "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 14 compatibility",
+  "description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 18 compatibility",
   "main": "include_dirs.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Oops!  It looks like we may have forgotten to update this field for a while...

from:
```
"description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 14 compatibility"
```

to:
```
"description": "Native Abstractions for Node.js: C++ header for Node 0.8 -> 18 compatibility"
```