### PR TITLE
chore: remove deprecated AccessorSignatures

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -2516,8 +2516,7 @@ inline void SetAccessor(
   , SetterCallback setter = 0
   , v8::Local<v8::Value> data = v8::Local<v8::Value>()
   , v8::AccessControl settings = v8::DEFAULT
-  , v8::PropertyAttribute attribute = v8::None
-  , imp::Sig signature = imp::Sig()) {
+  , v8::PropertyAttribute attribute = v8::None) {
   HandleScope scope;
 
   imp::NativeGetter getter_ =
@@ -2550,9 +2549,6 @@ inline void SetAccessor(
     , obj
     , settings
     , attribute
-#if (NODE_MODULE_VERSION < NODE_18_0_MODULE_VERSION)
-    , signature
-#endif
   );
 }
 

--- a/nan_callbacks.h
+++ b/nan_callbacks.h
@@ -52,8 +52,6 @@ typedef void(*IndexQueryCallback)(
     const PropertyCallbackInfo<v8::Integer>&);
 
 namespace imp {
-typedef v8::Local<v8::AccessorSignature> Sig;
-
 static const int kDataIndex =                    0;
 
 static const int kFunctionIndex =                1;


### PR DESCRIPTION
This was removed in https://chromium-review.googlesource.com/c/v8/v8/+/3654096

Co-Authored-By: Shelley Vohr <shelley.vohr@gmail.com>

Fixes: https://github.com/nodejs/nan/issues/942