### PR TITLE
Fix outdated links to V8 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Due to the evolution of the V8 API, it is necessary for NAN to provide a wrapper
  - <a href="doc/persistent.md#api_nan_weak_callback_info"><b><code>Nan::WeakCallbackInfo</code></b></a>
  - <a href="doc/persistent.md#api_nan_weak_callback_type"><b><code>Nan::WeakCallbackType</code></b></a>
 
-Also see the V8 Embedders Guide section on [Handles and Garbage Collection](https://developers.google.com/v8/embed#handles).
+Also see the V8 Embedders Guide section on [Handles and Garbage Collection](https://v8.dev/docs/embed#handles-and-garbage-collection).
 
 ### New
 
@@ -227,7 +227,7 @@ NAN includes helpers for creating, throwing and catching Errors as much of this 
 
 Note that an Error object is simply a specialized form of `v8::Value`.
 
-Also consult the V8 Embedders Guide section on [Exceptions](https://developers.google.com/v8/embed#exceptions) for more information.
+Also consult the V8 Embedders Guide section on [Exceptions](https://v8.dev/docs/embed#exceptions) for more information.
 
  - <a href="doc/errors.md#api_nan_error"><b><code>Nan::Error()</code></b></a>
  - <a href="doc/errors.md#api_nan_range_error"><b><code>Nan::RangeError()</code></b></a>

--- a/doc/errors.md
+++ b/doc/errors.md
@@ -4,7 +4,7 @@ NAN includes helpers for creating, throwing and catching Errors as much of this 
 
 Note that an Error object is simply a specialized form of `v8::Value`.
 
-Also consult the V8 Embedders Guide section on [Exceptions](https://developers.google.com/v8/embed#exceptions) for more information.
+Also consult the V8 Embedders Guide section on [Exceptions](https://v8.dev/docs/embed#exceptions) for more information.
 
  - <a href="#api_nan_error"><b><code>Nan::Error()</code></b></a>
  - <a href="#api_nan_range_error"><b><code>Nan::RangeError()</code></b></a>

--- a/doc/methods.md
+++ b/doc/methods.md
@@ -210,7 +210,7 @@ You do not need to declare a new `HandleScope` within a getter as one is implici
 
 A helper macro `NAN_GETTER(methodname)` exists, compatible with NAN v1 method declarations.
 
-Also see the V8 Embedders Guide documentation on [Accessors](https://developers.google.com/v8/embed#accesssors).
+Also see the V8 Embedders Guide documentation on [Accessors](https://v8.dev/docs/embed#accessors).
 
 <a name="api_nan_setter"></a>
 ### Setter declaration
@@ -237,7 +237,7 @@ You do not need to declare a new `HandleScope` within a setter as one is implici
 
 A helper macro `NAN_SETTER(methodname)` exists, compatible with NAN v1 method declarations.
 
-Also see the V8 Embedders Guide documentation on [Accessors](https://developers.google.com/v8/embed#accesssors).
+Also see the V8 Embedders Guide documentation on [Accessors](https://v8.dev/docs/embed#accessors).
 
 <a name="api_nan_property_getter"></a>
 ### Property getter declaration
@@ -262,7 +262,7 @@ You do not need to declare a new `HandleScope` within a property getter as one i
 
 A helper macro `NAN_PROPERTY_GETTER(methodname)` exists, compatible with NAN v1 method declarations.
 
-Also see the V8 Embedders Guide documentation on named property [Interceptors](https://developers.google.com/v8/embed#interceptors).
+Also see the V8 Embedders Guide documentation on named property [Interceptors](https://v8.dev/docs/embed#interceptors).
 
 <a name="api_nan_property_setter"></a>
 ### Property setter declaration
@@ -287,7 +287,7 @@ You do not need to declare a new `HandleScope` within a property setter as one i
 
 A helper macro `NAN_PROPERTY_SETTER(methodname)` exists, compatible with NAN v1 method declarations.
 
-Also see the V8 Embedders Guide documentation on named property [Interceptors](https://developers.google.com/v8/embed#interceptors).
+Also see the V8 Embedders Guide documentation on named property [Interceptors](https://v8.dev/docs/embed#interceptors).
 
 <a name="api_nan_property_enumerator"></a>
 ### Property enumerator declaration
@@ -308,7 +308,7 @@ You do not need to declare a new `HandleScope` within a property enumerator as o
 
 A helper macro `NAN_PROPERTY_ENUMERATOR(methodname)` exists, compatible with NAN v1 method declarations.
 
-Also see the V8 Embedders Guide documentation on named property [Interceptors](https://developers.google.com/v8/embed#interceptors).
+Also see the V8 Embedders Guide documentation on named property [Interceptors](https://v8.dev/docs/embed#interceptors).
 
 <a name="api_nan_property_deleter"></a>
 ### Property deleter declaration
@@ -331,7 +331,7 @@ You do not need to declare a new `HandleScope` within a property deleter as one 
 
 A helper macro `NAN_PROPERTY_DELETER(methodname)` exists, compatible with NAN v1 method declarations.
 
-Also see the V8 Embedders Guide documentation on named property [Interceptors](https://developers.google.com/v8/embed#interceptors).
+Also see the V8 Embedders Guide documentation on named property [Interceptors](https://v8.dev/docs/embed#interceptors).
 
 <a name="api_nan_property_query"></a>
 ### Property query declaration
@@ -354,7 +354,7 @@ You do not need to declare a new `HandleScope` within a property query method as
 
 A helper macro `NAN_PROPERTY_QUERY(methodname)` exists, compatible with NAN v1 method declarations.
 
-Also see the V8 Embedders Guide documentation on named property [Interceptors](https://developers.google.com/v8/embed#interceptors).
+Also see the V8 Embedders Guide documentation on named property [Interceptors](https://v8.dev/docs/embed#interceptors).
 
 <a name="api_nan_index_getter"></a>
 ### Index getter declaration
@@ -376,7 +376,7 @@ You do not need to declare a new `HandleScope` within a index getter as one is i
 
 A helper macro `NAN_INDEX_GETTER(methodname)` exists, compatible with NAN v1 method declarations.
 
-Also see the V8 Embedders Guide documentation on indexed property [Interceptors](https://developers.google.com/v8/embed#interceptors).
+Also see the V8 Embedders Guide documentation on indexed property [Interceptors](https://v8.dev/docs/embed#interceptors).
 
 <a name="api_nan_index_setter"></a>
 ### Index setter declaration
@@ -401,7 +401,7 @@ You do not need to declare a new `HandleScope` within a index setter as one is i
 
 A helper macro `NAN_INDEX_SETTER(methodname)` exists, compatible with NAN v1 method declarations.
 
-Also see the V8 Embedders Guide documentation on indexed property [Interceptors](https://developers.google.com/v8/embed#interceptors).
+Also see the V8 Embedders Guide documentation on indexed property [Interceptors](https://v8.dev/docs/embed#interceptors).
 
 <a name="api_nan_index_enumerator"></a>
 ### Index enumerator declaration
@@ -422,7 +422,7 @@ You do not need to declare a new `HandleScope` within a index enumerator as one 
 
 A helper macro `NAN_INDEX_ENUMERATOR(methodname)` exists, compatible with NAN v1 method declarations.
 
-Also see the V8 Embedders Guide documentation on indexed property [Interceptors](https://developers.google.com/v8/embed#interceptors).
+Also see the V8 Embedders Guide documentation on indexed property [Interceptors](https://v8.dev/docs/embed#interceptors).
 
 <a name="api_nan_index_deleter"></a>
 ### Index deleter declaration
@@ -444,7 +444,7 @@ You do not need to declare a new `HandleScope` within a index deleter as one is 
 
 A helper macro `NAN_INDEX_DELETER(methodname)` exists, compatible with NAN v1 method declarations.
 
-Also see the V8 Embedders Guide documentation on indexed property [Interceptors](https://developers.google.com/v8/embed#interceptors).
+Also see the V8 Embedders Guide documentation on indexed property [Interceptors](https://v8.dev/docs/embed#interceptors).
 
 <a name="api_nan_index_query"></a>
 ### Index query declaration
@@ -466,7 +466,7 @@ You do not need to declare a new `HandleScope` within a index query method as on
 
 A helper macro `NAN_INDEX_QUERY(methodname)` exists, compatible with NAN v1 method declarations.
 
-Also see the V8 Embedders Guide documentation on indexed property [Interceptors](https://developers.google.com/v8/embed#interceptors).
+Also see the V8 Embedders Guide documentation on indexed property [Interceptors](https://v8.dev/docs/embed#interceptors).
 
 <a name="api_nan_set_method"></a>
 ### Nan::SetMethod()

--- a/doc/persistent.md
+++ b/doc/persistent.md
@@ -12,7 +12,7 @@ Due to the evolution of the V8 API, it is necessary for NAN to provide a wrapper
  - <a href="#api_nan_weak_callback_info"><b><code>Nan::WeakCallbackInfo</code></b></a>
  - <a href="#api_nan_weak_callback_type"><b><code>Nan::WeakCallbackType</code></b></a>
 
-Also see the V8 Embedders Guide section on [Handles and Garbage Collection](https://developers.google.com/v8/embed#handles).
+Also see the V8 Embedders Guide section on [Handles and Garbage Collection](https://v8.dev/docs/embed#handles-and-garbage-collection).
 
 <a name="api_nan_persistent_base"></a>
 ### Nan::PersistentBase & v8::PersistentBase


### PR DESCRIPTION
This pull request fixes links to the V8 Embedder's Guide in the documentation.