### PR TITLE
Add GitHub Actions workflow and delete old CI configurations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [0.10, 0.12, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+        node-version: ['0.10', 0.12, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
       fail-fast: false
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Build
         run: node_modules/.bin/node-gyp rebuild --directory test
       - name: Test
-        run: node_modules/.bin/tap --gc test/js/*-test.js; fi
+        run: node_modules/.bin/tap --gc test/js/*-test.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [0.10, 0.12, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Node.js ${{matrix.node-version}}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{matrix.node-version}}
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: node_modules/.bin/node-gyp rebuild --directory test
+      - name: Test
+        run: node_modules/.bin/tap --gc test/js/*-test.js; fi


### PR DESCRIPTION
Not ready, but let's see what happens.

- [ ] Fix build for Node.js 9 and below
- [ ] Copy other version-dependent logic from `.travis.yml` and `appveyor.yml` as necessary
- [ ] Build and test against Electron versions (see `ELECTRON_VERSION` in `.travis.yml`)
- [ ] Delete `.travis.yml` and `appveyor.yml`

Fixes: https://github.com/nodejs/nan/issues/958