### PR TITLE
chore: use new constructor for ScriptOrigin when >= 17.x

### DIFF
--- a/test/cpp/news.cpp
+++ b/test/cpp/news.cpp
@@ -115,7 +115,7 @@ NAN_METHOD(NewScript) {
 
 NAN_METHOD(NewScript2) {
   v8::ScriptOrigin origin(
-#if NODE_MODULE_VERSION >= NODE_18_0_MODULE_VERSION
+#if NODE_MODULE_VERSION >= NODE_17_0_MODULE_VERSION
     info.GetIsolate(),
 #endif
     New<v8::String>("x").ToLocalChecked());
@@ -136,7 +136,7 @@ NAN_METHOD(CompileScript) {
 
 NAN_METHOD(CompileScript2) {
   v8::ScriptOrigin origin(
-#if NODE_MODULE_VERSION >= NODE_18_0_MODULE_VERSION
+#if NODE_MODULE_VERSION >= NODE_17_0_MODULE_VERSION
     info.GetIsolate(),
 #endif
     New<v8::String>("x").ToLocalChecked());


### PR DESCRIPTION
Refs https://chromium-review.googlesource.com/c/v8/v8/+/3395880.

Chromium did an advance deprecation removal of the `ScriptOrigin` ctor without an Isolate.

This allows Electron to remove a [patch](https://github.com/electron/electron/blob/61374019c03ab1af8584550277318ba7c2adb0ca/patches/nan/use_new_constructor_for_scriptorigin_when_17_x.patch#L1-L29)