### PR TITLE
Fix builds for Electron 29

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -2550,7 +2550,9 @@ NAN_DEPRECATED inline void SetAccessor(
     , getter_
     , setter_
     , obj
+#if !defined(V8_MAJOR_VERSION) || V8_MAJOR_VERSION < 12
     , settings
+#endif
     , attribute
 #if (NODE_MODULE_VERSION < NODE_16_0_MODULE_VERSION)
     , signature
@@ -2596,7 +2598,9 @@ inline void SetAccessor(
     , getter_
     , setter_
     , obj
+#if !defined(V8_MAJOR_VERSION) || V8_MAJOR_VERSION < 12
     , settings
+#endif
     , attribute
   );
 }


### PR DESCRIPTION
`ObjectTemplate::SetAccessor` signature has changed in the V8 >= 12, and no longer accepts `v8::AccessControl` parameter. The `v8::AccessControl` enum is in fact a single value now so no public users of nan would be broken if we just stop passing it down to V8.