### PR TITLE
AppVeyor: Test and support versions 8, 10, 12, 14, 16, 17, 18, 19, 20, 21, and 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,6 @@ jobs:
             os: windows-2025
           - node-version: 14.x
             os: windows-2019
-          - node-version: 13.x
-            os: windows-2019
           - node-version: 12.x
             os: windows-2019
           - node-version: 10.x

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Native Abstractions for Node.js
 ===============================
 
-**A header file filled with macro and utility goodness for making add-on development for Node.js easier across versions 0.8, 0.10, 0.12, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22 and 23.**
+**A header file filled with macro and utility goodness for making add-on development for Node.js easier across versions 8, 10, 12, 14, 16, 17, 18, 19, 20, 21, and 22.**
 
 ***Current version: 2.22.0***
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,25 +17,14 @@ environment:
     # - nodejs_version: "23"  # Enable after nodejs/nan#979 or similar.
     - nodejs_version: "22"
     - nodejs_version: "22"
-      NODE_GYP_FORCE_PYTHON: C:\Python310-x64\python.exe
-    - nodejs_version: "22"
-      NODE_GYP_FORCE_PYTHON: C:\Python311-x64\python.exe
-    # node-gyp >= v3.10 is required for Python >= 3.12
-    #- nodejs_version: "22"  # These fail because of nodejs/node-gyp#2869
-    #  NODE_GYP_FORCE_PYTHON: C:\Python312-x64\python.exe
-    #- nodejs_version: "22"
-    #  NODE_GYP_FORCE_PYTHON: C:\Python313-x64\python.exe
+      NODE_GYP_FORCE_PYTHON: C:\Python312-x64\python.exe
     - nodejs_version: "21"
     - nodejs_version: "20"
-    #- nodejs_version: "20"
-    #  NODE_GYP_FORCE_PYTHON: C:\Python313-x64\python.exe
     - nodejs_version: "19"
     - nodejs_version: "18"
-    #- nodejs_version: "18"
-    #  NODE_GYP_FORCE_PYTHON: C:\Python313-x64\python.exe
     - nodejs_version: "17"
     - nodejs_version: "16"
-    - nodejs_version: "15"
+    # - nodejs_version: "15"
     - nodejs_version: "14"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     - nodejs_version: "13"
@@ -47,17 +36,18 @@ environment:
     - nodejs_version: "10"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     - nodejs_version: "9"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - nodejs_version: "8"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    - nodejs_version: "7"
-    - nodejs_version: "6"
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - nodejs_version: "5"
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - nodejs_version: "4"
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    - nodejs_version: "0.12"
-    - nodejs_version: "0.10"
+    # - nodejs_version: "7"
+    # - nodejs_version: "6"
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    # - nodejs_version: "5"
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    # - nodejs_version: "4"
+    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    # - nodejs_version: "0.12"
+    # - nodejs_version: "0.10"
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,30 +24,14 @@ environment:
     - nodejs_version: "18"
     - nodejs_version: "17"
     - nodejs_version: "16"
-    # - nodejs_version: "15"
     - nodejs_version: "14"
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    - nodejs_version: "13"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
     - nodejs_version: "12"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    - nodejs_version: "11"
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - nodejs_version: "10"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    - nodejs_version: "9"
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
     - nodejs_version: "8"
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-    # - nodejs_version: "7"
-    # - nodejs_version: "6"
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    # - nodejs_version: "5"
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    # - nodejs_version: "4"
-    #   APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-    # - nodejs_version: "0.12"
-    # - nodejs_version: "0.10"
 
 matrix:
   fast_finish: true
@@ -63,14 +47,10 @@ install:
   # Get the latest stable version of Node 0.STABLE.latest
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) x64
   - node --version
-  - IF %nodejs_version% LSS 4 npm -g install npm@2
-  - IF %nodejs_version% EQU 5 npm -g install npm@3
   - set PATH=%APPDATA%\npm;%PATH%
   # Typical npm stuff.
   - npm install
-  - IF %nodejs_version% LSS 8 (npm run rebuild-tests-2015) ELSE (npm run rebuild-tests)
-  # If Python >= v3.12 then node-gyp < v10 will need setuptools installed.
-  - IF "%NODE_GYP_FORCE_PYTHON%" NEQ "C:\Python39-x64\python.exe" (py -m pip install setuptools)
+  - npm run rebuild-tests
 
 # Post-install test scripts.
 test_script:
@@ -81,7 +61,7 @@ test_script:
   - py -VV          # py is 64-bit AMD64 Python 3 on Visual Studio images
   - python -VV  # python is 32-bit Intel Python 3 on Visual Studio images
   # run tests
-  - IF %nodejs_version% LSS 1 (npm test) ELSE (IF %nodejs_version% LSS 4 (iojs node_modules\tap\bin\tap.js --gc test/js/*-test.js) ELSE (node node_modules\tap\bin\tap.js --gc test/js/*-test.js))
+  - node node_modules\tap\bin\tap.js --gc test/js/*-test.js
 
 # Don't actually build.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,54 +1,95 @@
 # http://www.appveyor.com/docs/appveyor-yml
+# https://www.appveyor.com/docs/windows-images-software
+# https://nodejs.org/en/about/previous-releases
+# https://devguide.python.org/versions
+
+# Test supported Node.js versions before unsupported versions.
+# Run on the most current Visual Studio possible for each nodejs_version.
+# Run on the earliest supported Python version when possible (currently py39).
+# For all supported Node.js versions test also on the latest Python (currently py313).
 
 image:
-  - Visual Studio 2017
+  - Visual Studio 2022
 
-# Test against these versions of Io.js and Node.js.
 environment:
-  matrix:
-  # node.js
-    - nodejs_version: "0.10"
-    - nodejs_version: "0.12"
-    - nodejs_version: "4"
-    - nodejs_version: "5"
-    - nodejs_version: "6"
-    - nodejs_version: "7"
-    - nodejs_version: "8"
-    - nodejs_version: "9"
-    - nodejs_version: "10"
-    - nodejs_version: "11"
-    - nodejs_version: "12"
-    - nodejs_version: "13"
-    - nodejs_version: "14"
-    - nodejs_version: "15"
-    - nodejs_version: "16"
-    - nodejs_version: "17"
-    - nodejs_version: "18"
-    - nodejs_version: "19"
-    - nodejs_version: "20"
+  NODE_GYP_FORCE_PYTHON: C:\Python39-x64\python.exe
+  matrix:  # Test against these versions of Io.js and Node.js.
+    # - nodejs_version: "23"  # Enable after nodejs/nan#979 or similar.
+    - nodejs_version: "22"
+    - nodejs_version: "22"
+      NODE_GYP_FORCE_PYTHON: C:\Python310-x64\python.exe
+    - nodejs_version: "22"
+      NODE_GYP_FORCE_PYTHON: C:\Python311-x64\python.exe
+    # node-gyp >= v3.10 is required for Python >= 3.12
+    #- nodejs_version: "22"  # These fail because of nodejs/node-gyp#2869
+    #  NODE_GYP_FORCE_PYTHON: C:\Python312-x64\python.exe
+    #- nodejs_version: "22"
+    #  NODE_GYP_FORCE_PYTHON: C:\Python313-x64\python.exe
     - nodejs_version: "21"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      nodejs_version: "22"
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      nodejs_version: "23"
+    - nodejs_version: "20"
+    #- nodejs_version: "20"
+    #  NODE_GYP_FORCE_PYTHON: C:\Python313-x64\python.exe
+    - nodejs_version: "19"
+    - nodejs_version: "18"
+    #- nodejs_version: "18"
+    #  NODE_GYP_FORCE_PYTHON: C:\Python313-x64\python.exe
+    - nodejs_version: "17"
+    - nodejs_version: "16"
+    - nodejs_version: "15"
+    - nodejs_version: "14"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - nodejs_version: "13"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - nodejs_version: "12"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - nodejs_version: "11"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - nodejs_version: "10"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - nodejs_version: "9"
+    - nodejs_version: "8"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - nodejs_version: "7"
+    - nodejs_version: "6"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - nodejs_version: "5"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - nodejs_version: "4"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    - nodejs_version: "0.12"
+    - nodejs_version: "0.10"
+
+matrix:
+  fast_finish: true
 
 # Install scripts. (runs after repo cloning)
 install:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  - py --list
+  - py -VV          # py is 64-bit AMD64 Python 3 on Visual Studio images
+  - python -VV  # python is 32-bit Intel Python 3 on Visual Studio images
   # Get the latest stable version of Node 0.STABLE.latest
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) x64
+  - node --version
   - IF %nodejs_version% LSS 4 npm -g install npm@2
   - IF %nodejs_version% EQU 5 npm -g install npm@3
   - set PATH=%APPDATA%\npm;%PATH%
   # Typical npm stuff.
   - npm install
-  - IF %nodejs_version% GEQ 22 set NODE_GYP_FORCE_PYTHON=C:\Python38-x64\python.exe
   - IF %nodejs_version% LSS 8 (npm run rebuild-tests-2015) ELSE (npm run rebuild-tests)
+  # If Python >= v3.12 then node-gyp < v10 will need setuptools installed.
+  - IF "%NODE_GYP_FORCE_PYTHON%" NEQ "C:\Python39-x64\python.exe" (py -m pip install setuptools)
 
 # Post-install test scripts.
 test_script:
   # Output useful info for debugging.
   - node --version
   - npm --version
+  - py --list
+  - py -VV          # py is 64-bit AMD64 Python 3 on Visual Studio images
+  - python -VV  # python is 32-bit Intel Python 3 on Visual Studio images
   # run tests
   - IF %nodejs_version% LSS 1 (npm test) ELSE (IF %nodejs_version% LSS 4 (iojs node_modules\tap\bin\tap.js --gc test/js/*-test.js) ELSE (node node_modules\tap\bin\tap.js --gc test/js/*-test.js))
 


### PR DESCRIPTION
# Tested versions 8, 10, 12, 14, 16, 17, 18, 19, 20, 21, and 22.

Test supported Node.js versions before unsupported versions because each test takes ~5 minutes.
Test on the most current Visual Studio possible for each nodejs_version.
Test on the oldest ___supported___ Python version when possible (currently py39).
For all supported Node.js versions also test on the newest Python (currently py313).
* https://devguide.python.org/versions
# Test results: https://ci.appveyor.com/project/RodVagg/nan

Visual Studio 2017 image tops out at Python 3.8 which is end-of-life.
Visual Studio 2019 and 2022 images top out at Python 3.13.

`node-gyp` issues related to `nan`: https://github.com/nodejs/node-gyp/issues?q=label%3Anodejs%2Fnan

The Node.js v23 tests are commented out waiting for:
* #979 or similar.

~The Python 3.12 and 3.13 tests are commented out waiting for:~
*  ~#985 because of:~
    * ~nodejs/node-gyp#2869~

@kkoopa Your review, please.  These changes enable us to focus on the two issues above.

