### PR TITLE
package.json: Upgrade node-gyp to support Python >= v3.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "commander": "^2.8.1",
     "glob": "^5.0.14",
     "request": "=2.81.0",
-    "node-gyp": "~8.4.1",
+    "node-gyp": "~v10.3.1",
     "readable-stream": "^2.1.4",
     "tap": "~0.7.1",
     "xtend": "~4.0.0"


### PR DESCRIPTION
https://github.com/nodejs/node-gyp?tab=readme-ov-file#installation says
> [!Important]
> Python >= v3.12 requires `node-gyp` >= v10

Fixes: #986
* #986

`package.json`:
```diff
-    "node-gyp": "~8.4.1",
+    "node-gyp": "~v10.3.1",
```
Provides compatibility with Python 3.12, 3.13, and later.

https://github.com/nodejs/node-gyp/releases
* nodejs/node-gyp#2869
* https://devguide.python.org/versions

Related to:
* #932

@mkrufky Your review, please.