### PR TITLE
AppVeyor tests fail on Python 3.12 and 3.13

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ install:
   - set PATH=%APPDATA%\npm;%PATH%
   # Typical npm stuff.
   - npm install
-  - IF %nodejs_version% GEQ 22 set NODE_GYP_FORCE_PYTHON=C:\Python38-x64\python.exe
+  - IF %nodejs_version% GEQ 22 set NODE_GYP_FORCE_PYTHON=C:\Python312-x64\python.exe
   - IF %nodejs_version% LSS 8 (npm run rebuild-tests-2015) ELSE (npm run rebuild-tests)
 
 # Post-install test scripts.


### PR DESCRIPTION
Fixed by #985
*  #985
```diff

-  - IF %nodejs_version% GEQ 22 set NODE_GYP_FORCE_PYTHON=C:\Python38-x64\python.exe
+  - IF %nodejs_version% GEQ 22 set NODE_GYP_FORCE_PYTHON=C:\Python312-x64\python.exe
                                                                    ^^
```
Test results: https://ci.appveyor.com/project/RodVagg/nan/builds/51476801 for Node.js v22
```
gyp info it worked if it ends with ok
gyp info using node-gyp@8.4.1
...
gyp info find Python using Python version 3.12.8 found at "C:\Python312-x64\python.exe"
...
gyp info spawn args ]
Traceback (most recent call last):
  File "C:\projects\nan\node_modules\node-gyp\gyp\gyp_main.py", line 42, in <module>
    import gyp  # noqa: E402
    ^^^^^^^^^^
  File "C:\projects\nan\node_modules\node-gyp\gyp\pylib\gyp\__init__.py", line 9, in <module>
    import gyp.input
  File "C:\projects\nan\node_modules\node-gyp\gyp\pylib\gyp\input.py", line 19, in <module>
    from distutils.version import StrictVersion
ModuleNotFoundError: No module named 'distutils'
gyp ERR! configure error 
```

These failing tests will be fixed by
* #985

`node-gyp` issues related to `nan`: https://github.com/nodejs/node-gyp/issues?q=label%3Anodejs%2Fnan