### PR TITLE
Fix version guard for `ScriptOrigin` constructors

### DIFF
--- a/nan_scriptorigin.h
+++ b/nan_scriptorigin.h
@@ -12,8 +12,8 @@
 class ScriptOrigin : public v8::ScriptOrigin {
  public:
 
-#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 11 \
-    && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION > 7)
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 11 || \
+  (V8_MAJOR_VERSION == 11 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION > 7))
   explicit ScriptOrigin(v8::Local<v8::Value> name) :
       v8::ScriptOrigin(name) {}
 

--- a/nan_scriptorigin.h
+++ b/nan_scriptorigin.h
@@ -12,8 +12,10 @@
 class ScriptOrigin : public v8::ScriptOrigin {
  public:
 
-#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 11 || \
-  (V8_MAJOR_VERSION == 11 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION > 7))
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 12 ||                      \
+  (V8_MAJOR_VERSION == 12 && (defined(V8_MINOR_VERSION) && (V8_MINOR_VERSION > 6\
+      || (V8_MINOR_VERSION == 6 && defined(V8_BUILD_NUMBER)                     \
+          && V8_BUILD_NUMBER >= 175)))))
   explicit ScriptOrigin(v8::Local<v8::Value> name) :
       v8::ScriptOrigin(name) {}
 


### PR DESCRIPTION
The current version guard for `Isolate`-less ScriptOrigin constructors checks both `V8_MAJOR_VERSION > 11` and `V8_MINOR_VERSION > 7`. Newer V8s with a minor version not greater than 7, such as V8 v13.2.152.36 of Electron v34.2.0, still fall back to deprecated constructors removed since V8 v12.7.23 and fail to compile.

Fix the preprocessor logic to properly detect V8 v11.7+.