### PR TITLE
readme: remove `--save` since that's the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ This project also contains some helper utilities that make addon development a b
 
 ## Usage
 
-Simply add **NAN** as a dependency in the *package.json* of your Node addon:
+Simply add **NAN** as a dependency using a package manager like npm, yarn, or bun:
 
 ``` bash
-$ npm install --save nan
+$ npm install nan
 ```
 
 Pull in the path to **NAN** in your *binding.gyp* so that you can use `#include <nan.h>` in your *.cpp* files:


### PR DESCRIPTION
`npm i --save` has been the default for a long time. This removes it from the readme, also mentions you can use other package managers like yarn and bun.