### PR TITLE
use ArrayBuffer->Data() when available

### DIFF
--- a/nan_typedarray_contents.h
+++ b/nan_typedarray_contents.h
@@ -31,9 +31,13 @@ class TypedArrayContents {
       v8::Local<v8::ArrayBuffer> buffer = array->Buffer();
 
       length = byte_length / sizeof(T);
+#if (V8_MAJOR_VERSION >= 10 ||                                                 \
+     (V8_MAJOR_VERSION == 10 &&                                                \
+      (defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 5)))
+      data = static_cast<char*>(buffer->Data()) + byte_offset;
 // Actually it's 7.9 here but this would lead to ABI issues with Node.js 13
 // using 7.8 till 13.2.0.
-#if (V8_MAJOR_VERSION >= 8)
+#elif (V8_MAJOR_VERSION >= 8)
       data = static_cast<char*>(buffer->GetBackingStore()->Data()) + byte_offset;
 #else
       data = static_cast<char*>(buffer->GetContents().Data()) + byte_offset;


### PR DESCRIPTION
This is faster than accessing the BackingStore. API is available in V8 10.5+ per https://github.com/nodejs/node/issues/32226#issuecomment-1185423020.

Manually tested in Node.js v18.20 and v20.