### PR TITLE
Fix nan_weak.h for V8 >= 14.2.194 (missing EmbedderDataTypeTag)

### DIFF
--- a/nan_weak.h
+++ b/nan_weak.h
@@ -276,7 +276,15 @@ inline void Persistent<T, M>::SetWeak(
     int count = self->InternalFieldCount();
     void *internal_fields[kInternalFieldsInWeakCallback] = {0, 0};
     for (int i = 0; i < count && i < kInternalFieldsInWeakCallback; i++) {
+#if (V8_MAJOR_VERSION > 14) || \
+    (V8_MAJOR_VERSION == 14 && V8_MINOR_VERSION > 2) || \
+    (V8_MAJOR_VERSION == 14 && V8_MINOR_VERSION == 2 && V8_BUILD_NUMBER >= 194)
+      internal_fields[i] = self->GetAlignedPointerFromInternalField(
+          i, v8::kEmbedderDataTypeTagDefault
+      );
+# else
       internal_fields[i] = self->GetAlignedPointerFromInternalField(i);
+# endif
     }
     wcbd = new WeakCallbackInfo<P>(
         reinterpret_cast<Persistent<v8::Value>*>(this)
@@ -284,7 +292,15 @@ inline void Persistent<T, M>::SetWeak(
       , 0
       , internal_fields[0]
       , internal_fields[1]);
+#if (V8_MAJOR_VERSION > 14) || \
+    (V8_MAJOR_VERSION == 14 && V8_MINOR_VERSION > 2) || \
+    (V8_MAJOR_VERSION == 14 && V8_MINOR_VERSION == 2 && V8_BUILD_NUMBER >= 194)
+    self->SetAlignedPointerInInternalField(
+        0, wcbd, v8::kEmbedderDataTypeTagDefault
+    );
+# else
     self->SetAlignedPointerInInternalField(0, wcbd);
+# endif
     v8::PersistentBase<T>::SetWeak(
         static_cast<WeakCallbackInfo<P>*>(0)
       , WeakCallbackInfo<P>::template invoketwofield<true>


### PR DESCRIPTION
## Summary

- Commit fcc7b7d added V8 >= 14.2.194 compatibility guards to `nan.h` for `GetAlignedPointerFromInternalField` and `SetAlignedPointerInInternalField` (which now require an additional `v8::kEmbedderDataTypeTagDefault` tag parameter), but missed the same unguarded calls in `nan_weak.h`
- This causes build failures with Electron 41+ / V8 >= 14.2.194:
  ```
  error C2661: 'v8::Object::GetAlignedPointerFromInternalField': no overloaded function takes 1 arguments
  error C2660: 'v8::Object::SetAlignedPointerInInternalField': function does not take 2 arguments
  ```
- Applies the exact same preprocessor guard pattern from `nan.h` to the two call sites in `nan_weak.h` (inside the `V8 >= 4.3` block, which is the only block compiled with V8 14.2+)

## Test plan
- [ ] Build a native addon using NAN against Electron 41+ (V8 >= 14.2.194) and verify no compilation errors
- [ ] Verify existing builds against older V8 versions are unaffected (the `# else` branches preserve the original calls)